### PR TITLE
Remove sdk and template reference within `readme.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ sudo apt-get install -y nodejs-legacy npm
 Note: You have to install Node version => v10.x.x
 
 
-## Clone sdk and template repository
-
-To use G3W-CLIENT
-
 ## Install G3W-CLIENT development dependencies
 
 The following instruction will install all node modules mandatory to use development enviromental


### PR DESCRIPTION
If I'm not mistaken the following libraries are no longer needed:

- [g3w-suite/g3w-client-sdk](https://github.com/g3w-suite/g3w-client-sdk)
- [g3w-suite/g3w-client-template-lte](https://github.com/g3w-suite/g3w-client-template-lte)

if so, also consider [archiving](https://docs.github.com/en/repositories/archiving-a-github-repository/archiving-repositories) them for the sake of clarity (assuming we don't need to manually import them yet).

_Have a nice day,
Raruto_