### PR TITLE
Add `npm-version` support

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "plugins": "gulp g3w-admin-plugins-select",
     "default": "gulp default --max-old-space-size=2048",
     "test": "gulp test",
-    "cy:open": "cypress open"
+    "cy:open": "cypress open",
+    "version": "npm admin && git add -A dist"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "default": "gulp default --max-old-space-size=2048",
     "test": "gulp test",
     "cy:open": "cypress open",
-    "version": "npm admin && git add -A dist"
+    "preversion": "npm run test",
+    "version": "npm run admin && git add -A dist",
+    "postversion": "git push && git push --tags"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Usage examples:

```js
npm version [<newversion> | major | minor | patch | premajor | preminor | prepatch | prerelease | from-git]
```

Reference: https://docs.npmjs.com/cli/v8/commands/npm-version

closes: https://github.com/g3w-suite/g3w-client/issues/27