### PR TITLE
add 1:200 and 1:100 print scale

### DIFF
--- a/src/app/gui/print/printconfig.js
+++ b/src/app/gui/print/printconfig.js
@@ -1,5 +1,13 @@
 const scale = [
   {
+    value:100,
+    label:'1:100'
+  },
+  {
+    value:200,
+    label:'1:200'
+  },
+  {
     value:500,
     label:'1:500'
   },


### PR DESCRIPTION
I think these should be included in the default print scales as in the cities (public utilities, cadastre etc) they're normally used for detail maps.