### PR TITLE
Align some `dev` configuration with next release (v4)

### DIFF
--- a/config.template.js
+++ b/config.template.js
@@ -1,33 +1,54 @@
-const PROTOCOL = 'http';
-const HOST = '127.0.0.1';
-const PROXY_PORT = '8001';
-const LOCAL_PORT = '3000';
-const G3W_ADMIN_MEDIA_PUBLIC_FOLDER = '/media'; // change g3w-admin media public folder (default is /media)
+const { version }     = require('./package.json');
 
-const conf = {
-  assetsFolder: './assets', //template folder of template repository
-  pluginsFolder: './src/plugins', // plugins folder of app plugins
-  distFolder: './dist', // G3W-CLIENT main dist folder
-  clientFolder: './dist/client', // G3W-CLIENT client dist folder where are compiled
-  localServerPort: LOCAL_PORT, // port for local server. If not set local server run on port 3000
-  g3w_admin_paths: {
-    dev: {
-      g3w_admin_plugins_basepath: '<RELATIVE PATH OF G3W-ADMIN-INSTALLATION>/g3w-admin/g3w-admin/', // local G3W-ADMIN main path code
-      g3w_admin_client_dest_static: '<RELATIVE PATH OF G3W-ADMIN-INSTALLATION>/g3w-admin/g3w-admin/client/static', // local G3W-ADMIN client static path
-      g3w_admin_client_dest_template: '<RELATIVE PATH OF G3W-ADMIN-INSTALLATION>/g3w-admin/g3w-admin/client/templates', // local G3W-ADMIN client template folder
+const G3W_HOST_SCHEMA = 'http';
+const G3W_HOST        = '127.0.0.1'; // local development server
+const G3W_ADMIN_PORT  = '8000';      // G3W-ADMIN development server
+const G3W_CLIENT_PORT = '3000';      // G3W-CLIENT development server
+
+if (version < "4") {
+  module.exports = {
+    assetsFolder:  './assets',        //template folder of template repository
+    pluginsFolder: './src/plugins',   // plugins folder of app plugins
+    distFolder:    './dist',          // G3W-CLIENT main dist folder
+    clientFolder:  './dist/client',   // G3W-CLIENT client dist folder where are compiled
+    localServerPort: G3W_CLIENT_PORT, // port for local server. If not set local server run on port 3000
+    g3w_admin_paths: {
+      dev: {
+        g3w_admin_plugins_basepath:     '../g3w-admin/g3w-admin/',                 // local G3W-ADMIN main path code
+        g3w_admin_client_dest_static:   '../g3w-admin/g3w-admin/client/static',    // local G3W-ADMIN client static path
+        g3w_admin_client_dest_template: '../g3w-admin/g3w-admin/client/templates', // local G3W-ADMIN client template folder
+      }
+    },
+    host: G3W_HOST,
+    localServerPort: G3W_CLIENT_PORT, // port for local server. If not set local server run on port 3000
+    proxy: {                          // proxy configuration for local server
+      host: G3W_HOST,
+      url: `${G3W_HOST_SCHEMA}://${G3W_HOST}:${G3W_ADMIN_PORT}/`,            // local G3W_ADMIN server and port (where G3W-ADIMN is running)
+      urls: ['/media', '/api','/ows', '/static', '/en/', '/it/', '/upload/'] // urls to proxy referred to G3W-ADMIN
+    },
+    test: {
+      path: '/test/config/groups/'
     }
-  },
-  host: HOST,
-  localServerPort: LOCAL_PORT, // port for local server. If not set local server run on port 3000
-  // proxy configurazion for local server
-  proxy: {
-    host: HOST,
-    url: `${PROTOCOL}://${HOST}:${PROXY_PORT}/`, // local G3W_ADMIN server and port (where G3W-ADIMN is running)
-    urls: [G3W_ADMIN_MEDIA_PUBLIC_FOLDER , '/api','/ows', '/static', '/en/', '/it/', '/upload/'] // urls to proxy referred to G3W-ADMIN
-  },
-  test: {
-    path: '/test/config/groups/'
-  }
-};
-
-module.exports = conf;
+  };
+} else {
+  module.exports = {
+    assetsFolder:  './assets',      // path to G3W-CLIENT assets folder
+    pluginsFolder: './src/plugins', // path to G3W-CLIENT plugins folder
+    distFolder:    './dist',        // path to G3W-CLIENT dist folder
+    clientFolder:  './dist/client', // path to G3W-CLIENT client folder
+    admin_plugins_folder:   '../g3w-admin/g3w-admin',                  // path to G3W-ADMIN main code
+    admin_static_folder:    '../g3w-admin/g3w-admin/client/static',    // path to G3W-ADMIN client/static
+    admin_templates_folder: '../g3w-admin/g3w-admin/client/templates', // path to G3W-ADMIN client/templates
+    host: G3W_HOST,
+    port: G3W_CLIENT_PORT,
+    // proxy configuration for local G3W_ADMIN server (where G3W-ADMIN is running)
+    proxy: {
+      host: G3W_HOST,
+      url: `${G3W_HOST_SCHEMA}://${G3W_HOST}:${G3W_ADMIN_PORT}/`,
+      routes: ['/api','/ows','/media','/static', '/en/', '/it/', '/upload/']
+    },
+    test: {
+      path: '/test/config/groups/'
+    }
+  };
+}

--- a/package.json
+++ b/package.json
@@ -9,11 +9,12 @@
     "admin:client": "gulp g3w-admin:client_only --max-old-space-size=2048",
     "plugins": "gulp g3w-admin-plugins-select",
     "default": "gulp default --max-old-space-size=2048",
+    "dev": "npm run dev",
     "test": "gulp test",
     "cy:open": "cypress open",
     "preversion": "npm run test",
     "version": "npm run admin && git add -A dist",
-    "postversion": "git push && git push --tags"
+    "postversion": "git push && git push --tags",
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "admin:client": "gulp g3w-admin:client_only --max-old-space-size=2048",
     "plugins": "gulp g3w-admin-plugins-select",
     "default": "gulp default --max-old-space-size=2048",
-    "dev": "npm run dev",
+    "dev": "npm run default",
     "test": "gulp test",
     "cy:open": "cypress open",
     "preversion": "npm run test",


### PR DESCRIPTION
Update the `config.template.js` file and adds the `npm run dev` alias in order to share same development experience between major releases