### PR TITLE
Add a simple hint about plugin development within `config/dev/index.template.js`

### DIFF
--- a/src/config/dev/index.template.js
+++ b/src/config/dev/index.template.js
@@ -17,5 +17,11 @@ export default {
       //code here
     }
   },
-  plugins: {} // plugin configuration dev
+  // override here "initConfig" plugins attribute for custom plugin development
+  plugins: {
+    // "your-plugin-folder-name": {
+    //    baseurl: '../dist',
+    //    gid: 'qdjango:1'    // 1 = current project id
+    // }
+  }
 }


### PR DESCRIPTION
related to: https://github.com/g3w-suite/g3w-client/issues/46 and [g3w-client-plugin-base-template](https://github.com/g3w-suite/g3w-client-plugin-base-template)