### PR TITLE
Move `"core/validators"` into `"core/utils/validators"`

### DIFF
--- a/src/app/core/utils/validators.js
+++ b/src/app/core/utils/validators.js
@@ -1,0 +1,75 @@
+const { truefnc } = require('core/utils/utils');
+
+const InputValidators = {
+  validators: {
+
+    float(options = {}) {
+      this.options = options;
+      this.validate = function(value) {
+        const float = Number(1 * value);
+        return !Number.isNaN(float) && float <= 2147483647;
+      }
+    },
+
+    integer(options = {}) {
+      this.options = options;
+      this.validate = function(value) {
+        const integer = 1 * value;
+        return !_.isNaN(integer) ? Number.isSafeInteger(integer) && (integer <= 2147483647) : false;
+      }
+    },
+
+    checkbox(options = {}) {
+      this.options = options;
+      this.validate = function(value) {
+        const values = this.options.values || [];
+        return values.indexOf(value) !== -1;
+      }
+    },
+
+    datetimepicker(options = {}) {
+      this.options = options;
+      this.validate = function(value, options) {
+        const fielddatetimeformat = options.fielddatetimeformat;
+        return moment(value, fielddatetimeformat, true).isValid();
+      }
+    },
+
+    text(options = {}) {
+      this.options = options;
+      this.validate = truefnc;
+    },
+
+    string(options = {}) {
+      this.options = options;
+      this.validate = truefnc;
+    },
+
+    radio(options = {}) {
+      this.options = options;
+      this.validate = truefnc;
+    },
+
+    default(options = {}) {
+      this.options = options;
+      this.validate = truefnc;
+    },
+
+    range(options = {}) {
+      const { min, max } = options;
+      this.validate = function(value) {
+        value = 1 * value;
+        return value >= min && value <= max;
+      }
+    },
+
+  },
+
+  get(type, options={}) {
+    const Validator = this.validators[type] || this.validators.default;
+    return new Validator(options);
+  }
+
+};
+
+module.exports = InputValidators;

--- a/src/app/core/validators/inputs/checkbox.js
+++ b/src/app/core/validators/inputs/checkbox.js
@@ -1,14 +1,6 @@
-const {base, inherit}= require('core/utils/utils');
-const Validator = require('./validator');
+const { validators } = require('core/utils/validators');
 
-function CheckBoxValidator(options) {
-  base(this, options);
-  this.validate = function(value) {
-    const values = this.options.values || [];
-    return values.indexOf(value) !== -1;
-  }
-}
-
-inherit(CheckBoxValidator, Validator);
-
-module.exports =  CheckBoxValidator;
+/**
+ * DEPRECATED: this folder will be removed after v3.4 (use "core/utils/validators" instead)
+ */
+module.exports = validators.checkbox;

--- a/src/app/core/validators/inputs/datetimepicker.js
+++ b/src/app/core/validators/inputs/datetimepicker.js
@@ -1,13 +1,6 @@
-const {base, inherit}= require('core/utils/utils');
-const Validator = require('./validator');
+const { validators } = require('core/utils/validators');
 
-function DateTimePickerValidator(options) {
-  base(this, options);
-  this.validate = function(value, options) {
-    const fielddatetimeformat = options.fielddatetimeformat;
-    return moment(value, fielddatetimeformat, true).isValid();
-  }
-}
-inherit(DateTimePickerValidator, Validator);
-
-module.exports =  DateTimePickerValidator;
+/**
+ * DEPRECATED: this folder will be removed after v3.4 (use "core/utils/validators" instead)
+ */
+module.exports = validators.datetimepicker;

--- a/src/app/core/validators/inputs/float.js
+++ b/src/app/core/validators/inputs/float.js
@@ -1,14 +1,6 @@
-const {base, inherit}= require('core/utils/utils');
-const Validator = require('./validator');
+const { validators } = require('core/utils/validators');
 
-function FloatValidator(options) {
-  base(this, options);
-  this.validate = function(value) {
-    const float = Number(1*value);
-    return !Number.isNaN(float) && float <= 2147483647;
-  }
-}
-
-inherit(FloatValidator, Validator);
-
-module.exports =  FloatValidator;
+/**
+ * DEPRECATED: this folder will be removed after v3.4 (use "core/utils/validators" instead)
+ */
+module.exports = validators.float;

--- a/src/app/core/validators/inputs/integer.js
+++ b/src/app/core/validators/inputs/integer.js
@@ -1,14 +1,6 @@
-const {base, inherit}= require('core/utils/utils');
-const Validator = require('./validator');
+const { validators } = require('core/utils/validators');
 
-function IntegerValidator(options) {
-  base(this, options);
-  this.validate = function(value) {
-    const integer = 1*value;
-    return !_.isNaN(integer) ? Number.isSafeInteger(integer) && (integer <= 2147483647) : false;
-  }
-}
-
-inherit(IntegerValidator, Validator);
-
-module.exports =  IntegerValidator;
+/**
+ * DEPRECATED: this folder will be removed after v3.4 (use "core/utils/validators" instead)
+ */
+module.exports = validators.integer;

--- a/src/app/core/validators/inputs/radio.js
+++ b/src/app/core/validators/inputs/radio.js
@@ -1,10 +1,6 @@
-const {base, inherit}= require('core/utils/utils');
-const Validator = require('./validator');
+const { validators } = require('core/utils/validators');
 
-function RadioValidator(options) {
-  base(this, options);
-}
-
-inherit(RadioValidator, Validator);
-
-module.exports = RadioValidator;
+/**
+ * DEPRECATED: this folder will be removed after v3.4 (use "core/utils/validators" instead)
+ */
+module.exports = validators.radio;

--- a/src/app/core/validators/inputs/range.js
+++ b/src/app/core/validators/inputs/range.js
@@ -1,15 +1,6 @@
-const {base, inherit}= require('core/utils/utils');
-const Validator = require('./validator');
+const { validators } = require('core/utils/validators');
 
-function RangeValidator(options={}) {
-  base(this, options);
-  const {min, max} = options;
-  this.validate = function(value) {
-    value = 1*value;
-    return value >= min && value <= max;
-  }
-}
-
-inherit(RangeValidator, Validator);
-
-module.exports =  RangeValidator;
+/**
+ * DEPRECATED: this folder will be removed after v3.4 (use "core/utils/validators" instead)
+ */
+module.exports = validators.range;

--- a/src/app/core/validators/inputs/validator.js
+++ b/src/app/core/validators/inputs/validator.js
@@ -1,8 +1,6 @@
-function InputValidator(options={}) {
-  this.options = options;
-  this.validate = function() {
-    return true; // always true. Generic validator
-  }
-}
+const { validators } = require('core/utils/validators');
 
-module.exports = InputValidator;
+/**
+ * DEPRECATED: this folder will be removed after v3.4 (use "core/utils/validators" instead)
+ */
+module.exports = validators.default;

--- a/src/app/core/validators/inputs/validators.js
+++ b/src/app/core/validators/inputs/validators.js
@@ -1,21 +1,6 @@
-const Validators = {
-  validators: {
-    float: require('./float'),
-    integer: require('./integer'),
-    checkbox: require('./checkbox'),
-    datetimepicker: require('./datetimepicker'),
-    text: require('./validator'),
-    string: require('./validator'),
-    radio: require('./radio'),
-    default: require('./validator'),
-    range: require('./range')
-  },
+const Validators = require('core/utils/validators');
 
-  get(type, options={}) {
-    const Validator = this.validators[type] || this.validators.default;
-    return new Validator(options);
-  }
-
-};
-
+/**
+ * DEPRECATED: this folder will be removed after v3.4 (use "core/utils/validators" instead)
+ */
 module.exports = Validators;

--- a/src/app/core/validators/layers/validator.js
+++ b/src/app/core/validators/layers/validator.js
@@ -1,0 +1,3 @@
+/**
+ * DEPRECATED: this folder will be removed after v3.4 (use "core/utils/validators" instead)
+ */

--- a/src/app/gui/inputs/range/vue/range.html
+++ b/src/app/gui/inputs/range/vue/range.html
@@ -4,6 +4,7 @@
       @keydown.69.prevent=""
       @keydown.13.stop=""
       @change="checkValue"
+      @input="checkValue"
       @blur="checkValue"
       style="width:100%; padding-right: 5px;"
       class="form-control"

--- a/src/app/gui/inputs/sliderrange/service.js
+++ b/src/app/gui/inputs/sliderrange/service.js
@@ -1,12 +1,12 @@
 const {base, inherit} = require('core/utils/utils');
 const Service = require('gui/inputs/service');
-const ValidatorClass = require('core/validators/inputs/range');
+const Validators = require('core/validators/inputs/validators');
 
 function SliderRangeService(options={}) {
   const {state} = options;
   options.state.info = `[MIN: ${state.input.options.min} - MAX: ${state.input.options.max}]`;
   base(this, options);
-  const validator = new ValidatorClass({
+  const validator = Validators.get('range', {
     min: 1*state.input.options.min,
     max: 1*state.input.options.max
   });


### PR DESCRIPTION
- replace `ValidatorClass` in favour of a single `InputValidators` object
- deprecate notice for `"core/validators"` folder (will be removed after v3.4)
- move entire input validation logic within `"core/utils/validators"`

Close: https://github.com/g3w-suite/g3w-client/issues/60