### PR TITLE
Add `.github/release.yml` (github release notes automation)

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,38 +7,28 @@ changelog:
   categories:
     - title: New Features
       labels:
-        - Semver-Minor
-        - enhancement
-        - add-feature
-        - new-feature
+        - feature
     - title: Bug fixed
       labels:
-        - Semver-Patch
-        - bug-fix
-        - fix
-        - patch
+        - bug
     - title: Improvements
       labels:
-        - behaviour-change
+        - behaviour
     - title: Documentation
       labels:
         - docs
     - title: Translations
       labels:
         - i18n
-        - add-language
-        - update-translation
     - title: Config
       labels:
-        - update-config
+        - config
     - title: API changes
       labels:
         - refactoring
-        
     - title: Breaking changes
       labels:
-        - Semver-Major
-        - breaking-change
+        - breaking
     - title: Other changes
       labels:
         - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -13,7 +13,7 @@ changelog:
         - bug
     - title: Improvements
       labels:
-        - behaviour
+        - ux
     - title: Documentation
       labels:
         - docs

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,44 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - octocat
+  categories:
+    - title: New Features
+      labels:
+        - Semver-Minor
+        - enhancement
+        - add-feature
+        - new-feature
+    - title: Bug fixed
+      labels:
+        - Semver-Patch
+        - bug-fix
+        - fix
+        - patch
+    - title: Improvements
+      labels:
+        - behaviour-change
+    - title: Documentation
+      labels:
+        - docs
+    - title: Translations
+      labels:
+        - i18n
+        - add-language
+        - update-translation
+    - title: Config
+      labels:
+        - update-config
+    - title: API changes
+      labels:
+        - refactoring
+        
+    - title: Breaking changes
+      labels:
+        - Semver-Major
+        - breaking-change
+    - title: Other changes
+      labels:
+        - "*"


### PR DESCRIPTION
Add `release.yml` as reported within the official guide: [automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes)

Here you can already get an idea of how it should look (v3.5): https://github.com/g3w-suite/g3w-client/releases

Close: https://github.com/g3w-suite/g3w-client/issues/102