### PR TITLE
Move `src/config` into `src/app/config`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ package-lock.json
 /src/app/__dev__/
 /src/app/core/iframe/test/
 /src/app/dev/
-/src/config/keys/index.js
 /src/libs/sdk/config/dev/
 /src/libs/sdk/g3w-ol3/config/config.js
 /src/index.html

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ npm run docker pull # docker dependencies (admin)
 Create these configuration files from the available templates:
 
 - `/g3w-client/config.js` ← [config.template.js](https://github.com/g3w-suite/g3w-client/blob/dev/config.template.js)
-- `/g3w-client/src/config/keys/index.js` ← [index.template.js](https://github.com/g3w-suite/g3w-client/blob/dev/src/config/keys/index.template.js)
 - `/g3w-suite-docker/.env` ← [.env.example](https://github.com/g3w-suite/g3w-suite-docker/blob/dev/.env.example)
 - `/g3w-suite-docker/config/g3w-suite/settings_docker.py` ← [settings_docker.py](https://github.com/g3w-suite/g3w-suite-docker/blob/dev/config/g3w-suite/settings_docker.py)
 - `/g3w-suite-docker/shared-volume/` ← add this folder if it doesn't exist
@@ -59,10 +58,6 @@ Now your folder structure should matches this one:
 │
 ├── g3w-client/
 │   ├── node_modules/
-│   ├── src/
-│   │   └── config/
-│   │       └── keys/
-│   │           └── index.js
 │   ├── package.json
 │   ├── package-lock.json
 │   └── config.js

--- a/config.template.js
+++ b/config.template.js
@@ -21,6 +21,11 @@ const G3W_PLUGINS = {                // override "initConfig->group->plugins" at
   // }
 };
 
+const G3W_KEYS = {
+  // GOOGLE_API_KEY: '<INSERT HERE YOUR GOOGLE API KEY>',
+  // BING_API_KEY: '<INSERT HERE YOUR BING API KEY>'
+};
+
 if (version < "4") {
   module.exports = {
     assetsFolder:  './assets',        //template folder of template repository
@@ -54,6 +59,7 @@ if (version < "4") {
       after(project) { /* code here */ },
     },
     plugins: G3W_PLUGINS,
+    keys: G3W_KEYS
   };
 } else {
   module.exports = {
@@ -84,5 +90,6 @@ if (version < "4") {
       after(project) { /* code here */ },
     },
     plugins: G3W_PLUGINS,
+    keys: G3W_KEYS
   };
 }

--- a/src/app/config.js
+++ b/src/app/config.js
@@ -1,0 +1,54 @@
+/**
+ * TODO: consolidate configuration parameters in a single location
+ * (eg. appConfig, ApplicationState, Constants, ...)
+ */
+
+import translations from '../locales';
+const apptitle = "G3W Client";
+const supportedLng = ['en', 'it'];
+
+export const plugins = {};
+
+export const tools = {
+  tools:  []
+};
+
+// get message from internationalization
+export const _i18n = {
+  resources: translations
+};
+
+export const client = {
+  debug:  true,
+  local:  false
+};
+
+export const server = {
+  urls:  {
+    baseurl: '/',
+    ows:  'ows',
+    api:  'api',
+    initconfig:  'api/initconfig',
+    config:  'api/config'
+  }
+};
+
+export const utils = {
+  merge(type) {
+    if (type) {
+      console.log(CONFIG)
+    }
+  }
+};
+
+export default {
+  apptitle,
+  client,
+  server,
+  plugins,
+  supportedLng,
+  tools,
+  _i18n,
+  utils
+};
+

--- a/src/app/core/applicationservice.js
+++ b/src/app/core/applicationservice.js
@@ -1,4 +1,4 @@
-import appConfig from 'config';
+import appConfig from 'app/config';
 import {TIMEOUT} from "../constant";
 import ApplicationState from './applicationstate';
 const {init:i18ninit, changeLanguage} = require('core/i18n/i18n.service');

--- a/src/app/core/layers/baselayers/binglayer.js
+++ b/src/app/core/layers/baselayers/binglayer.js
@@ -1,4 +1,3 @@
-import { BING_API_KEY } from 'config/keys';
 import ApplicationState from 'core/applicationstate'
 const {base, inherit} = require('core/utils/utils');
 const BaseLayer = require('core/layers/baselayers/baselayer');
@@ -14,7 +13,7 @@ const proto = BingLayer.prototype;
 
 proto._makeOlLayer = function(){
   let olLayer;
-  const key = ApplicationState.keys.vendorkeys.bing || BING_API_KEY;
+  const key = ApplicationState.keys.vendorkeys.bing;
   const subtype = this.config.source ? this.config.source.subtype : null;
   switch(subtype) {
     case 'streets':

--- a/src/app/dev/index.js
+++ b/src/app/dev/index.js
@@ -2,6 +2,7 @@ const {
   createProject = {},
     setCurrentProject = {},
     plugins = {},
+    keys = {}
 } = require('../../../config');
 const ProjectsRegistry = require('core/project/projectsregistry');
 const ApplicationService = require('core/applicationservice');
@@ -11,13 +12,19 @@ const ApplicationService = require('core/applicationservice');
 // ApplicationService.once('ready', () => {});
 
 ApplicationService.once('initconfig', () => {
-  // TODO: make use of a recursive merge utility function for: "initConfig->group->plugins"
+  // sets "initConfig->group->plugins"
   Object.keys(plugins).forEach((plugin) => {
+    // TODO: make use of a recursive merge utility function ?
     window.initConfig.group.plugins[plugin] = window.initConfig.group.plugins[plugin] ? {
       ...window.initConfig.group.plugins[plugin],
       ...plugins[plugin],
     } : plugins[plugin];
   });
+  // sets "initConfig->group->vendorkeys"
+  if (Object.keys(keys).length > 0) {
+    window.initConfig.group.vendorkeys = window.initConfig.group.vendorkeys || {};
+    Object.keys(keys).forEach((key) => { window.initConfig.group.vendorkeys[key] = keys[key]; });
+  }
 });
 
 if (createProject.before) {

--- a/src/config/README.md
+++ b/src/config/README.md
@@ -1,0 +1,1 @@
+# 🚨 `src/config` folder will be removed in the next major release!

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -1,55 +1,6 @@
-import keys from 'config/keys';
-import translations from '../locales';
-const apptitle = "G3W Client";
-const supportedLng = ['en', 'it'];
+import appConfig from 'app/config';
 
-export const plugins = {};
-
-export const tools = {
-  tools:  []
-};
-
-// get message from internationalization
-export const _i18n = {
-  resources: translations
-};
-
-export const client = {
-  debug:  true,
-  local:  false
-};
-
-export const server = {
-  urls:  {
-    baseurl: '/',
-    ows:  'ows',
-    api:  'api',
-    initconfig:  'api/initconfig',
-    config:  'api/config'
-  }
-};
-
-export const utils = {
-  merge(type) {
-    if (type) {
-      console.log(CONFIG)
-    }
-  }
-};
-
-export const secrets = {
-  keys
-};
-
-export default {
-  apptitle,
-  secrets,
-  client,
-  server,
-  plugins,
-  supportedLng,
-  tools,
-  _i18n,
-  utils
-};
-
+/**
+ * DEPRECATED: this folder will be removed after v3.4 (use "app/config" instead)
+ */
+export default appConfig;

--- a/src/config/keys/index.js
+++ b/src/config/keys/index.js
@@ -1,0 +1,11 @@
+const devConfig = require('../../../config');
+
+/**
+ * DEPRECATED: this folder will be removed after v3.4 (use "/config.template.js" instead)
+ */
+export const GOOGLE_API_KEY = devConfig.GOOGLE_API_KEY;
+export const BING_API_KEY = devConfig.BING_API_KEY;
+export default {
+  GOOGLE_API_KEY,
+  BING_API_KEY
+}

--- a/src/config/keys/index.template.js
+++ b/src/config/keys/index.template.js
@@ -1,9 +1,0 @@
-/*
-* You need to copy this file in the same folder named index.js and add your personal keys
-* */
-export const GOOGLE_API_KEY = '<INSERT HERE YOUR GOOGLE API KEY>';
-export const BING_API_KEY = '<INSERT HERE YOUR BING API KEY>';
-export default {
-  GOOGLE_API_KEY,
-  BING_API_KEY
-}

--- a/test/specs/application/service.js
+++ b/test/specs/application/service.js
@@ -1,4 +1,4 @@
-import { server as serverConfig } from '../../../src/config';
+import { server as serverConfig } from '../../../src/app/config';
 import { LOGIN as LoginConfig} from '../../config/config';
 window.g3wsdk = require('api'); //usefull for plugiin
 const GUI = require('gui/gui');


### PR DESCRIPTION
Remove the need of the `src/config/keys/index.template.js` while deprecating the `src/config` folder:

```diff
.
└── g3w-client/
    ├── node_modules/
-   ├── src/
-   │   └── config/
-   │       └── keys/
-   │           └── index.js
    ├── package.json
    ├── package-lock.json
    └── config.js
```

**List of changes:**

- move `src/config/keys/index.js` into `/config.template.js`
- move `src/config/index.js` into `src/app/config.js`
- remove exported variabile `config::secrets` (use initiConfig->group->vendorkeys instead)
- merge `initiConfig->group->vendorkeys` within `src/app/dev/index.js`
- remove `src/config/keys/index.template.js`
- deprecate notice for `src/config/keys` folder
- deprecate notice for `src/config` folder

Close: https://github.com/g3w-suite/g3w-client/issues/87