### PR TITLE
fix wrong default vendor keys names within `config.template.js`

### DIFF
--- a/config.template.js
+++ b/config.template.js
@@ -22,8 +22,8 @@ const G3W_PLUGINS = {                // override "initConfig->group->plugins" at
 };
 
 const G3W_KEYS = {
-  // GOOGLE_API_KEY: '<INSERT HERE YOUR GOOGLE API KEY>',
-  // BING_API_KEY: '<INSERT HERE YOUR BING API KEY>'
+  // google: '<INSERT HERE YOUR GOOGLE API KEY>',
+  // bing: '<INSERT HERE YOUR BING API KEY>'
 };
 
 let conf = {

--- a/src/config/keys/index.js
+++ b/src/config/keys/index.js
@@ -3,8 +3,8 @@ const devConfig = require('../../../config');
 /**
  * DEPRECATED: this folder will be removed after v3.4 (use "/config.template.js" instead)
  */
-export const GOOGLE_API_KEY = devConfig.GOOGLE_API_KEY;
-export const BING_API_KEY = devConfig.BING_API_KEY;
+export const GOOGLE_API_KEY = devConfig.google;
+export const BING_API_KEY = devConfig.bing;
 export default {
   GOOGLE_API_KEY,
   BING_API_KEY


### PR DESCRIPTION
Fixes wrong pull: https://github.com/g3w-suite/g3w-client/pull/121

- rename `BING_API_KEY` into `bing`
- rename `GOOGLE_API_KEY` into `google`

Related to: https://github.com/g3w-suite/g3w-client/pull/111