### PR TITLE
Move `core/applicationstate` into `store/application-state`

### DIFF
--- a/src/app/core/applicationstate.js
+++ b/src/app/core/applicationstate.js
@@ -1,47 +1,5 @@
-// state of application reactive
-const STATE = Vue.observable({
-  ready: false, // true whe application is ready
-  iframe: false, // true if is loaded inside an iframe
-  online: false, // true if is connected
-  ismobile: false, // true if application is loaded on mobile device
-  download: false, // true if there is a downloaded that is waiting
-  upload: false, // upload
-  baseLayerId: null,
-  lng: 'en', // language default
-  changeProjectview: false,
-  plugins: [],
-  user: null,
-  map: {
-    epsg: '',
-    unit: 'metric'
-  },
-  gui: {
-    app: {
-      disabled: false // if application is disable non cliccable (in waiting)
-    },
-    sidebar: {
-      disabled: false // true if sidebar is disabled (not responsive)
-    },
-    layout: {
-      __current: 'app', // store the current layout owner (app at beginning)
-      app: {}
-    }
-  },
-  keys: {
-    vendorkeys: {
-      google: undefined,
-      bing: undefined
-    }
-  },
-  tokens: {
-    filtertoken: undefined
-  }
-});
-
 /**
- * Object that store method to query STATE OF application
- * @type {{getCurrentLayout()}}
+ * DEPRECATED: this file will be removed after v3.4 (use "store/application-state.js" instead)
  */
-export const STATE_METHODS = {};
-
-export default STATE;
+export * from 'store/application-state';
+export { default } from 'store/application-state';

--- a/src/app/core/plugin/pluginservice.js
+++ b/src/app/core/plugin/pluginservice.js
@@ -1,4 +1,4 @@
-import ApplicationState from '../applicationstate';
+import ApplicationState from 'core/applicationstate';
 const {base, inherit} = require('core/utils/utils');
 const ApplicationService = require('core/applicationservice');
 const G3WObject = require('core/g3wobject');

--- a/src/app/g3w-ol/controls/geocodingcontrol.js
+++ b/src/app/g3w-ol/controls/geocodingcontrol.js
@@ -1,4 +1,4 @@
-import ApplicationState from "../../core/applicationstate";
+import ApplicationState from "core/applicationstate";
 const Control = require('./control');
 const { toRawType, XHR } = require('core/utils/utils');
 const GUI = require('gui/gui');

--- a/src/app/gui/map/vue/map.js
+++ b/src/app/gui/map/vue/map.js
@@ -1,4 +1,4 @@
-import ApplicationState from '../../../core/applicationstate';
+import ApplicationState from 'core/applicationstate';
 import { createCompiledTemplate } from 'gui/vue/utils';
 const {base, merge, inherit} = require('core/utils/utils');
 const Component = require('gui/component/component');

--- a/src/app/gui/viewport/viewport.js
+++ b/src/app/gui/viewport/viewport.js
@@ -1,4 +1,4 @@
-import ApplicationState from '../../core/applicationstate';
+import ApplicationState from 'core/applicationstate';
 import {viewport as viewportConstraints} from 'gui/constraints';
 import userMessage from 'gui/usermessage/vue/usermessage.vue';
 import onlineNotify from 'gui/notifications/online/vue/online.vue';

--- a/src/app/gui/vue/global-components/datetime.vue
+++ b/src/app/gui/vue/global-components/datetime.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script>
-  import ApplicationState from '../../../core/applicationstate';
+  import ApplicationState from 'core/applicationstate';
   const {getUniqueDomId} = require('core/utils/utils');
   export default {
     name: "datetime",

--- a/src/store/application-state.js
+++ b/src/store/application-state.js
@@ -1,0 +1,51 @@
+/**
+ * ORIGINAL SOURCE: src/app/core/applicationstate.js@v3.4
+ */
+
+// state of application reactive
+const STATE = Vue.observable({
+  ready: false, // true whe application is ready
+  iframe: false, // true if is loaded inside an iframe
+  online: false, // true if is connected
+  ismobile: false, // true if application is loaded on mobile device
+  download: false, // true if there is a downloaded that is waiting
+  upload: false, // upload
+  baseLayerId: null,
+  lng: 'en', // language default
+  changeProjectview: false,
+  plugins: [],
+  user: null,
+  map: {
+    epsg: '',
+    unit: 'metric'
+  },
+  gui: {
+    app: {
+      disabled: false // if application is disable non cliccable (in waiting)
+    },
+    sidebar: {
+      disabled: false // true if sidebar is disabled (not responsive)
+    },
+    layout: {
+      __current: 'app', // store the current layout owner (app at beginning)
+      app: {}
+    }
+  },
+  keys: {
+    vendorkeys: {
+      google: undefined,
+      bing: undefined
+    }
+  },
+  tokens: {
+    filtertoken: undefined
+  }
+});
+
+/**
+ * Object that store method to query STATE OF application
+ * @type {{getCurrentLayout()}}
+ */
+export const STATE_METHODS = {};
+
+export default STATE;


### PR DESCRIPTION
- add `src/store/application-state.js`
- deprecate notice for `src/app/core/applicationstate.js`

Related to: https://github.com/g3w-suite/g3w-client/pull/94