### PR TITLE
Fix issue on wrong old dev template.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -529,11 +529,10 @@ gulp.task('add_external_resources_to_main_html',  function() {
       .pipe(rename('index.html'))
       .pipe(gulp.dest(srcFolder));
   } else {
-    return gulp.src(srcFolder + '/index.html.template')
+    return gulp.src(srcFolder + '/index.dev.html')
       .pipe(rename('index.html'))
       .pipe(gulp.dest(srcFolder));
   }
-
 });
 
 /**


### PR DESCRIPTION
Change old dev template reference template **index.html.template**  to index.dev.html.
When run `npm run build:client` it create `vendor.js` and `vendor.css`