### PR TITLE
Fix mapcontrols left alignement on mobile when keyboard is open

### DIFF
--- a/src/app/gui/map/mapservice.js
+++ b/src/app/gui/map/mapservice.js
@@ -1337,7 +1337,7 @@ proto._updateMapControlsLayout = function({width, height}={}) {
         const bottomMapControlTop = bottomMapControls.length ? $(bottomMapControls[bottomMapControls.length - 1]).position().top: height;
         const freeSpace =  bottomMapControlTop > 0 ? bottomMapControlTop - mapControslHeight : height - mapControslHeight;
         if (freeSpace < 10) {
-            this.state.mapControl.currentIndex = this.state.mapControl.currentIndex === this.state.mapControl.grid.length - 1 ? this.state.mapControl.currentIndex : this.state.mapControl.currentIndex +1;
+          this.state.mapControl.currentIndex = this.state.mapControl.currentIndex === this.state.mapControl.grid.length - 1 ? this.state.mapControl.currentIndex : this.state.mapControl.currentIndex +1;
           changedAndMoreSpace.changed = true;
         } else {
           // check if there enought space to expand mapcontrols

--- a/src/app/gui/map/mapservice.js
+++ b/src/app/gui/map/mapservice.js
@@ -1337,10 +1337,6 @@ proto._updateMapControlsLayout = function({width, height}={}) {
         const bottomMapControlTop = bottomMapControls.length ? $(bottomMapControls[bottomMapControls.length - 1]).position().top: height;
         const freeSpace =  bottomMapControlTop > 0 ? bottomMapControlTop - mapControslHeight : height - mapControslHeight;
         if (freeSpace < 10) {
-          if (isMobile.any) {
-            this.setMapControlsAlignement('rh');
-            return;
-          } else
             this.state.mapControl.currentIndex = this.state.mapControl.currentIndex === this.state.mapControl.grid.length - 1 ? this.state.mapControl.currentIndex : this.state.mapControl.currentIndex +1;
           changedAndMoreSpace.changed = true;
         } else {


### PR DESCRIPTION
Remove add rh class on mapcontrols  on mobile because create a strange left alignement

## Before:

![before](https://user-images.githubusercontent.com/9614886/184328258-1c803eb0-3185-46b3-b600-0b8351181a58.png)

## After:

you can check that mapcontrols remain on left

![Screenshot from 2022-08-12 11-24-28](https://user-images.githubusercontent.com/1051694/184325814-3e4876ea-9e8e-4e5a-bc01-b3e2408c56b9.png)
