### PR TITLE
Change Nominatim label to Nominatim (OSM) on geocoding search result

### DIFF
--- a/src/app/g3w-ol/controls/geocodingcontrol.js
+++ b/src/app/g3w-ol/controls/geocodingcontrol.js
@@ -247,7 +247,7 @@ const utils = {
  */
 class Nominatim {
   constructor(options={}) {
-    this.id = 'Nominatim';
+    this.id = 'Nominatim (OSM)';
     this.active = true;
     const extent = ol.proj.transformExtent(options.viewbox, options.mapCrs, 'EPSG:4326');
     this.settings = {


### PR DESCRIPTION
![Screenshot from 2022-08-12 11-54-28_pre_nominatim](https://user-images.githubusercontent.com/1051694/184331130-b783bb70-5ba3-4a1a-b354-73c35c2a57de.png)

to

![Screenshot from 2022-08-12 11-54-28](https://user-images.githubusercontent.com/1051694/184331165-3da7f518-3d3b-4f21-be9e-bbd541283548.png)

