### PR TITLE
Fix `geometryFields` circular dependency found between `core/utils/geo.js` and `core/layers/features/feature.js`

### DIFF
--- a/src/app/core/layers/features/feature.js
+++ b/src/app/core/layers/features/feature.js
@@ -1,5 +1,7 @@
+import CONSTANT from '../../../constant';
+const geometryFields = CONSTANT.GEOMETRY_FIELDS;
 const {uniqueId} = require('core/utils/utils');
-const {geometryFields} =  require('core/utils/geo');
+
 const Feature = function(options={}) {
   ol.Feature.call(this);
   this._uid = uniqueId();


### PR DESCRIPTION
Fix issue of importing geometryFields from utils/geo.js. The issue is coming from refactoring of file and due of circular dependencies

Related to: https://github.com/g3w-suite/g3w-client/pull/130