### PR TITLE
Fix issue on vue-template-compiler using named slot.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
   "dependencies": {
     "regenerator-runtime": "^0.13.9",
     "shp-write": "^0.3.2",
-    "vue": "^2.6.12",
+    "vue": "2.6.12",
     "vue-cookie-law": "^1.13.3"
   },
-  "resolutions": {
-    "graceful-fs": "4.2.3"
+  "overrides": {
+    "graceful-fs": "^4.2.10"
   },
   "devDependencies": {
     "babel-core": "^6.26.3",
@@ -118,13 +118,14 @@
     "vinyl-buffer": "^1.0.0",
     "vinyl-paths": "^2.1.0",
     "vinyl-source-stream": "^1.1.0",
+    "vue-template-compiler": "2.6.12",
     "vueify": "^9.4.1",
     "watchify": "^3.7.0",
     "yargs": "^8.0.2"
   },
   "browserslist": "defaults",
   "engines": {
-    "node": ">=16.13.2",
-    "npm": ">=8.1.2"
+    "node": ">=16.15.0",
+    "npm": ">=8.5.5"
   }
 }

--- a/src/components/Field.vue
+++ b/src/components/Field.vue
@@ -1,8 +1,6 @@
 <!-- ORIGINAL SOURCE: -->
 <!-- gui/fields/field.vue@v3.4 -->
 
-<!-- FIXME: default content not displayed if no "slot" is provided (eg. see components/FieldText.vue) -->
-
 <template>
   <div class="field" :style="{fontSize: isMobile() && '0.8em'}">
     <div v-if="state.label" class="col-sm-6  field_label">

--- a/src/components/FieldText.vue
+++ b/src/components/FieldText.vue
@@ -2,10 +2,7 @@
 <!-- gui/fields/text.vue@v3.4 -->
 
 <template>
-  <field :state="state">
-    <span v-if="state.label" slot="label">{{state.label}}</span>
-    <span v-if="state.value" slot="field" style="word-wrap: break-word;" v-html="state.value"></span>
-  </field>
+  <field :state="state"></field>
 </template>
 
 <script>


### PR DESCRIPTION
To fix issue on empty slot name value when parent component doesn't fill slot, at moment we need to use vue version 2.6.12 and same version for vue-template-compiler.

---

**NB** This pull also upgrade `"graceful-fs"` and package.json's `"engines"`.

Based on https://stackoverflow.com/questions/55921442/how-to-fix-referenceerror-primordials-is-not-defined-in-node-js :

**If you are using npm >= 8.3.0 in your package.json file:**

```
{
  // Your current package.json
  "overrides": {
    "graceful-fs": "^4.2.10"
  }
}
```
the solution above is the only on that solve the issue on npm install related to gulp@3
