### PR TITLE
Change default geocoding control marker icon (`yellow circle` --> `red marker`)

### DIFF
--- a/src/app/gui/map/mapservice.js
+++ b/src/app/gui/map/mapservice.js
@@ -1044,21 +1044,6 @@ proto._setupControls = function() {
               notresponseserver: "mapcontrols.nominatim.notresponseserver",
             }
           });
-          /**
-           * event emit when an address location is clicked
-           */
-          control.on('address', evt => {
-            const coordinate = evt.coordinate;
-            const geometry =  new ol.geom.Point(coordinate);
-            this.highlightGeometry(geometry);
-          });
-
-          control.on('lonlat', ({lonlat}={}) => {
-            const coordinates = ol.proj.transform(lonlat, 'EPSG:4326', mapCrs);
-            this.zoomToExtent([...coordinates, ...coordinates]);
-            setTimeout(() => this.showMarker(coordinates), 1000);
-          });
-
           break;
         case 'geolocation':
           control = this.createMapControl(controlType);


### PR DESCRIPTION
## List of changes:

- update default geocoding marker icon (`yellow circle` --> `red marker`)
- let marker icon stay visible on map until a new research is done (or the user clear results)

## Before

![circle](https://user-images.githubusercontent.com/9614886/186841914-5d06d5b8-585f-4f87-887f-b32bc7909710.png)

## After

![marker](https://user-images.githubusercontent.com/9614886/186841224-9d7359e4-3699-4a07-bb94-5986c0bf6a77.png)

Related to https://github.com/g3w-suite/g3w-client/pull/131 