### PR TITLE
Prevent parsing of invalid Z values due a incorrect addition (z = 0) when using `ol.format.WMSGetFeatureInfo()`

### DIFF
--- a/src/app/core/utils/geo.js
+++ b/src/app/core/utils/geo.js
@@ -14,6 +14,64 @@ const Geometry = {
    * core/geometry/geometry::GeometryTypes@v3.4
    */
    GeometryTypes,
+  /**
+   * Method to remove Z coordinates from geometry coordinates
+   * It in necessary due an wrong add Z value when using ol.format.WMSGetFeatureInfo readFeatures method from XML (ex. WMS getFeatureInfo);
+   * TO CHECK
+   * @param feature
+   * @param geometryType
+   */
+   removeZValueToOLFeatureGeometry({feature, geometryType}={}){
+    const geometry = feature.getGeometry();
+    geometryType = geometryType || geometry.getType();
+    const originalFeatureCoordinates = geometry.getCoordinates();
+    switch (geometryType){
+      // POINT: [x, y]
+      case GeometryTypes.POINT:
+        if (originalFeatureCoordinates.length === 3) {
+          originalFeatureCoordinates.splice(2);
+          feature.getGeometry().setCoordinates(originalFeatureCoordinates);
+        }
+        break;
+      // MULTIPOINT: [ [x1, y1], [x2, y2] ]
+      case GeometryTypes.MULTIPOINT:
+      // LINE: [ [x1, y1], [x2, y2] ]
+      case GeometryTypes.LINESTRING:
+      case GeometryTypes.LINE:
+        originalFeatureCoordinates.forEach(coordinates => coordinates.splice(2));
+        feature.getGeometry().setCoordinates(originalFeatureCoordinates);
+        break;
+      // MULTILINE: [
+      //   [ [x1, y1], [x2, y2] ],
+      //   [ [x3, y3], [x4, y4] ]
+      // ]
+      case GeometryTypes.MULTILINESTRING:
+      case GeometryTypes.MULTILINE:
+        originalFeatureCoordinates.forEach(singleLine => {
+          singleLine.forEach(coordinates => coordinates.splice(2))
+        });
+        feature.getGeometry().setCoordinates(originalFeatureCoordinates);
+        break;
+      // POLYGON: [
+      //   [ [x1, y1], [x2, y2], [x3, y3], [x1, y1] ]
+      // ]
+      case GeometryTypes.POLYGON:
+        originalFeatureCoordinates[0].forEach(coordinates => coordinates.splice(2));
+        feature.getGeometry().setCoordinates(originalFeatureCoordinates);
+        break;
+      // MULTIPOLYGON:[
+      //   [ [x1, y1], [x2, y2], [x3, y3], [x1, y1] ],
+      //   [ [xa, ya], [xb, yb], [xc, yc], [xa, ya] ]
+      // ]
+      case GeometryTypes.MULTIPOLYGON:
+        originalFeatureCoordinates.forEach(singlePolygon => {
+          singlePolygon[0].forEach(coordinates => coordinates.splice(2))
+        });
+        feature.getGeometry().setCoordinates(originalFeatureCoordinates);
+        break;
+    }
+    return feature;
+  },
 
    /**
     * core/geometry/geometry::addZValueToOLFeatureGeometry@v3.4

--- a/src/app/core/utils/geo.js
+++ b/src/app/core/utils/geo.js
@@ -14,12 +14,9 @@ const Geometry = {
    * core/geometry/geometry::GeometryTypes@v3.4
    */
    GeometryTypes,
+
   /**
-   * Method to remove Z coordinates from geometry coordinates
-   * It in necessary due an wrong add Z value when using ol.format.WMSGetFeatureInfo readFeatures method from XML (ex. WMS getFeatureInfo);
-   * TO CHECK
-   * @param feature
-   * @param geometryType
+   * Remove Z values from geometry coordinates
    */
    removeZValueToOLFeatureGeometry({feature, geometryType}={}){
     const geometry = feature.getGeometry();

--- a/src/app/core/utils/parsers.js
+++ b/src/app/core/utils/parsers.js
@@ -1,7 +1,7 @@
-import {G3W_FID} from 'constant';
-const {toRawType} = require('core/utils/utils');
+import { G3W_FID } from 'constant';
+const { toRawType } = require('core/utils/utils');
 const Feature = require('core/layers/features/feature');
-const {t} = require('core/i18n/i18n.service');
+const { t } = require('core/i18n/i18n.service');
 const olutils = require('core/utils/ol');
 const WORD_NUMERIC_FIELD_ESCAPE = 'GIS3W_ESCAPE_NUMERIC_FIELD_';
 
@@ -99,10 +99,23 @@ const utils = {
     return features;
   },
   parseLayerFeatureCollection({jsonresponse, layer, projections}) {
+    /**
+     * NEED here to avoid circular dependencies
+     */
+    const { Geometry : { is3DGeometry, removeZValueToOLFeatureGeometry } } = require('core/utils/geo');
+    /********************************************************************************************************/
+
     const x2js = new X2JS();
     const layerFeatureCollectionXML = x2js.json2xml_str(jsonresponse);
     const parser = new ol.format.WMSGetFeatureInfo();
     const features = this.transformFeatures(parser.readFeatures(layerFeatureCollectionXML), projections);
+    const geometryType = layer.getGeometryType();
+    if (!is3DGeometry(geometryType)){
+      features.forEach(feature => removeZValueToOLFeatureGeometry({
+        feature,
+        geometryType
+      }))
+    }
     if (features.length && this.hasFieldsStartWithNotPermittedKey) {
       const properties = Object.keys(features[0].getProperties());
       const numericFields = properties.filter(property => property.indexOf(WORD_NUMERIC_FIELD_ESCAPE) !== -1);

--- a/src/app/core/utils/parsers.js
+++ b/src/app/core/utils/parsers.js
@@ -114,12 +114,14 @@ const utils = {
     const parser = new ol.format.WMSGetFeatureInfo();
     const features = this.transformFeatures(parser.readFeatures(layerFeatureCollectionXML), projections);
     const geometryType = layer.getGeometryType();
+
+    // Need to remove Z values due a incorrect addition when using
+    // ol.format.WMSGetFeatureInfo readFeatures method from XML
+    // (eg. WMS getFeatureInfo); 
     if (!is3DGeometry(geometryType)){
-      features.forEach(feature => removeZValueToOLFeatureGeometry({
-        feature,
-        geometryType
-      }))
+      features.forEach(feature => removeZValueToOLFeatureGeometry({ feature, geometryType }));
     }
+
     if (features.length && this.hasFieldsStartWithNotPermittedKey) {
       const properties = Object.keys(features[0].getProperties());
       const numericFields = properties.filter(property => property.indexOf(WORD_NUMERIC_FIELD_ESCAPE) !== -1);

--- a/src/app/core/utils/parsers.js
+++ b/src/app/core/utils/parsers.js
@@ -6,6 +6,11 @@ const olutils = require('core/utils/ol');
 const WORD_NUMERIC_FIELD_ESCAPE = 'GIS3W_ESCAPE_NUMERIC_FIELD_';
 
 /**
+ * FIXME: circular dependency (ie. empty object when importing at top level)
+ */
+// const { Geometry : { is3DGeometry, removeZValueToOLFeatureGeometry } } = require('core/utils/geo');
+
+/**
  * Response parser (internal utilities)
  */
 const utils = {
@@ -100,10 +105,9 @@ const utils = {
   },
   parseLayerFeatureCollection({jsonresponse, layer, projections}) {
     /**
-     * NEED here to avoid circular dependencies
+     * FIXME: circular dependency (ie. empty object when importing at top level)
      */
     const { Geometry : { is3DGeometry, removeZValueToOLFeatureGeometry } } = require('core/utils/geo');
-    /********************************************************************************************************/
 
     const x2js = new X2JS();
     const layerFeatureCollectionXML = x2js.json2xml_str(jsonresponse);


### PR DESCRIPTION
Fix https://github.com/g3w-suite/g3w-client/issues/156