### PR TITLE
Let geocoding map control results and marker stay visible on map after click

### DIFF
--- a/src/app/g3w-ol/controls/geocodingcontrol.js
+++ b/src/app/g3w-ol/controls/geocodingcontrol.js
@@ -615,9 +615,7 @@ function GeocodingControl(options={}) {
                 header,
                 results
               });
-              if (results) this.listenMapClick();
             }
-
           }
         });
         utils.removeClass(this.reset, cssClasses.spin);
@@ -696,7 +694,6 @@ function GeocodingControl(options={}) {
     utils.removeClass(this.input, cssClasses.spin);
     utils.addClass(this.control, cssClasses.glass.expanded);
     setTimeout( () =>  this.input.focus(), 100);
-    this.listenMapClick();
   };
   this.collapse = function() {
     this.input.value = '';
@@ -704,18 +701,7 @@ function GeocodingControl(options={}) {
     utils.addClass(this.reset, cssClasses.hidden);
     this.clearResults();
   };
-  this.listenMapClick = function() {
-    // already registered
-    if (this.registeredListeners.mapClick) return;
-    const mapElement = this.getMap().getTargetElement();
-    this.registeredListeners.mapClick = true;
-    //one-time fire click
-    mapElement.addEventListener('click', evt => {
-      this.clearResults(true);
-      mapElement.removeEventListener(evt.type, this, false);
-      this.registeredListeners.mapClick = false;
-    }, false);
-  };
+
   this.clearResults = function() {
     utils.removeAllChildren(this.result);
     this.hideMarker();


### PR DESCRIPTION
Closes https://github.com/g3w-suite/g3w-client/issues/162

Now if we click on map, results and marker from Geocoding map control stay visible:

![Screenshot from 2022-08-30 14-41-33](https://user-images.githubusercontent.com/1051694/187439386-053ec200-79b0-4c0b-a83a-12d3dff33cb4.png)
