### PR TITLE
Hide editing (pencil) button on result content when editing panel is open

### DIFF
--- a/src/app/gui/queryresults/queryresultsservice.js
+++ b/src/app/gui/queryresults/queryresultsservice.js
@@ -612,7 +612,7 @@ proto.setActionsForLayers = function(layers, options={add: false}) {
         },
         cbk: this.copyZoomToFidUrl.bind(this)
       });
-      layer.editable && this.state.layersactions[layer.id].push({
+      layer.editable && !layer.inediting && this.state.layersactions[layer.id].push({
         id: 'editing',
         class: GUI.getFontClass('pencil'),
         hint: 'Editing',
@@ -933,6 +933,7 @@ proto._digestFeaturesForLayers = function(featuresForLayers) {
     let extractRelations = false;
     let external = false;
     let editable = false;
+    let inediting = false;
     const layer = featuresForLayer.layer;
     let downloads = [];
     let infoformats = [];
@@ -941,6 +942,7 @@ proto._digestFeaturesForLayers = function(featuresForLayers) {
     let selection ={};
     if (layer instanceof Layer) {
       editable = layer.isEditable();
+      inediting = layer.isInEditing();
       source = layer.getSource();
       infoformats = layer.getInfoFormats(); // add infoformats property
       infoformat = layer.getInfoFormat();
@@ -1023,6 +1025,7 @@ proto._digestFeaturesForLayers = function(featuresForLayers) {
       },
       external,
       editable,
+      inediting,
       selection,
       expandable: true,
       hasImageField: false,


### PR DESCRIPTION
In case of editing pane is open we need to avoid below case:

![Screenshot from 2022-09-06 16-13-03](https://user-images.githubusercontent.com/1051694/188658569-b952f245-d5f1-4d17-b51b-af288f0e6ec4.png)
Figure 1

need to check if editing panel is open and in this case hide pencil icon. 

![Screenshot from 2022-09-06 16-17-46](https://user-images.githubusercontent.com/1051694/188659191-c6322fbe-d417-4c48-9621-34fc95b1a5a3.png)
Fgure 2

Editing pencil action on Figure 1 (highlighted with red circle) is show only when editing panel is close.


Close https://github.com/g3w-suite/g3w-client/issues/167