### PR TITLE
Fix unhandled error on query response when `QGIS Project setting -> Add geometry to feature response` is set to false

### DIFF
--- a/src/app/core/utils/geo.js
+++ b/src/app/core/utils/geo.js
@@ -20,53 +20,56 @@ const Geometry = {
    */
    removeZValueToOLFeatureGeometry({feature, geometryType}={}){
     const geometry = feature.getGeometry();
-    geometryType = geometryType || geometry.getType();
-    const originalFeatureCoordinates = geometry.getCoordinates();
-    switch (geometryType){
-      // POINT: [x, y]
-      case GeometryTypes.POINT:
-        if (originalFeatureCoordinates.length === 3) {
-          originalFeatureCoordinates.splice(2);
+    if (geometry) {
+      geometryType = geometryType || geometry.getType();
+      const originalFeatureCoordinates = geometry.getCoordinates();
+      switch (geometryType){
+        // POINT: [x, y]
+        case GeometryTypes.POINT:
+          if (originalFeatureCoordinates.length === 3) {
+            originalFeatureCoordinates.splice(2);
+            feature.getGeometry().setCoordinates(originalFeatureCoordinates);
+          }
+          break;
+        // MULTIPOINT: [ [x1, y1], [x2, y2] ]
+        case GeometryTypes.MULTIPOINT:
+        // LINE: [ [x1, y1], [x2, y2] ]
+        case GeometryTypes.LINESTRING:
+        case GeometryTypes.LINE:
+          originalFeatureCoordinates.forEach(coordinates => coordinates.splice(2));
           feature.getGeometry().setCoordinates(originalFeatureCoordinates);
-        }
-        break;
-      // MULTIPOINT: [ [x1, y1], [x2, y2] ]
-      case GeometryTypes.MULTIPOINT:
-      // LINE: [ [x1, y1], [x2, y2] ]
-      case GeometryTypes.LINESTRING:
-      case GeometryTypes.LINE:
-        originalFeatureCoordinates.forEach(coordinates => coordinates.splice(2));
-        feature.getGeometry().setCoordinates(originalFeatureCoordinates);
-        break;
-      // MULTILINE: [
-      //   [ [x1, y1], [x2, y2] ],
-      //   [ [x3, y3], [x4, y4] ]
-      // ]
-      case GeometryTypes.MULTILINESTRING:
-      case GeometryTypes.MULTILINE:
-        originalFeatureCoordinates.forEach(singleLine => {
-          singleLine.forEach(coordinates => coordinates.splice(2))
-        });
-        feature.getGeometry().setCoordinates(originalFeatureCoordinates);
-        break;
-      // POLYGON: [
-      //   [ [x1, y1], [x2, y2], [x3, y3], [x1, y1] ]
-      // ]
-      case GeometryTypes.POLYGON:
-        originalFeatureCoordinates[0].forEach(coordinates => coordinates.splice(2));
-        feature.getGeometry().setCoordinates(originalFeatureCoordinates);
-        break;
-      // MULTIPOLYGON:[
-      //   [ [x1, y1], [x2, y2], [x3, y3], [x1, y1] ],
-      //   [ [xa, ya], [xb, yb], [xc, yc], [xa, ya] ]
-      // ]
-      case GeometryTypes.MULTIPOLYGON:
-        originalFeatureCoordinates.forEach(singlePolygon => {
-          singlePolygon[0].forEach(coordinates => coordinates.splice(2))
-        });
-        feature.getGeometry().setCoordinates(originalFeatureCoordinates);
-        break;
+          break;
+        // MULTILINE: [
+        //   [ [x1, y1], [x2, y2] ],
+        //   [ [x3, y3], [x4, y4] ]
+        // ]
+        case GeometryTypes.MULTILINESTRING:
+        case GeometryTypes.MULTILINE:
+          originalFeatureCoordinates.forEach(singleLine => {
+            singleLine.forEach(coordinates => coordinates.splice(2))
+          });
+          feature.getGeometry().setCoordinates(originalFeatureCoordinates);
+          break;
+        // POLYGON: [
+        //   [ [x1, y1], [x2, y2], [x3, y3], [x1, y1] ]
+        // ]
+        case GeometryTypes.POLYGON:
+          originalFeatureCoordinates[0].forEach(coordinates => coordinates.splice(2));
+          feature.getGeometry().setCoordinates(originalFeatureCoordinates);
+          break;
+        // MULTIPOLYGON:[
+        //   [ [x1, y1], [x2, y2], [x3, y3], [x1, y1] ],
+        //   [ [xa, ya], [xb, yb], [xc, yc], [xa, ya] ]
+        // ]
+        case GeometryTypes.MULTIPOLYGON:
+          originalFeatureCoordinates.forEach(singlePolygon => {
+            singlePolygon[0].forEach(coordinates => coordinates.splice(2))
+          });
+          feature.getGeometry().setCoordinates(originalFeatureCoordinates);
+          break;
+      }
     }
+
     return feature;
   },
 

--- a/src/app/core/utils/parsers.js
+++ b/src/app/core/utils/parsers.js
@@ -117,9 +117,11 @@ const utils = {
 
     // Need to remove Z values due a incorrect addition when using
     // ol.format.WMSGetFeatureInfo readFeatures method from XML
-    // (eg. WMS getFeatureInfo); 
+    // (eg. WMS getFeatureInfo);
+    // Need to check also if feature has geometry in case of
+    // QGIS Project setting -> Add geometry to response is not checked
     if (!is3DGeometry(geometryType)){
-      features.forEach(feature => removeZValueToOLFeatureGeometry({ feature, geometryType }));
+      features.forEach(feature => feature.getGeometry() && removeZValueToOLFeatureGeometry({ feature, geometryType }));
     }
 
     if (features.length && this.hasFieldsStartWithNotPermittedKey) {

--- a/src/app/core/utils/parsers.js
+++ b/src/app/core/utils/parsers.js
@@ -118,10 +118,8 @@ const utils = {
     // Need to remove Z values due a incorrect addition when using
     // ol.format.WMSGetFeatureInfo readFeatures method from XML
     // (eg. WMS getFeatureInfo);
-    // Need to check also if feature has geometry in case of
-    // QGIS Project setting -> Add geometry to response is not checked
     if (!is3DGeometry(geometryType)){
-      features.forEach(feature => feature.getGeometry() && removeZValueToOLFeatureGeometry({ feature, geometryType }));
+      features.forEach(feature => removeZValueToOLFeatureGeometry({ feature, geometryType }));
     }
 
     if (features.length && this.hasFieldsStartWithNotPermittedKey) {


### PR DESCRIPTION
Fix error if features (WMS query) response has no geometry:

![Screenshot from 2022-09-09 10-38-27](https://user-images.githubusercontent.com/1051694/189309263-4bc14934-43f5-4654-a29f-c92ba8a59bdb.png)

![Screenshot from 2022-09-09 10-20-59](https://user-images.githubusercontent.com/1051694/189305794-b740e577-d382-402e-9b35-cd63f8dc68db.png)

## List of changes

Check for feature geometry existence within function `src/app/core/utils/geo::removeZValueToOLFeatureGeometry({feature, geometryType}={})`

Close https://github.com/g3w-suite/g3w-client/issues/172