### PR TITLE
Fix `TypeError: geometry.getLinearRing is not a function` when measuring a MultiPolygon layer (editing plugin)

### DIFF
--- a/src/app/core/utils/ol.js
+++ b/src/app/core/utils/ol.js
@@ -123,7 +123,7 @@ const utils = {
         segments_info_meausure+=`${this.getLengthMessageText({
           unit, 
           projection,
-          geometry: new ol.geom.LineString([segments[segmentLength-3], segments[segmentLength-2]])
+          geometry: new ol.geom.LineString(segments)
         })} <br>`;
       }
       switch (unit) {
@@ -140,7 +140,7 @@ const utils = {
     },
     formatMeasure({geometry, projection}={}, options={}){
       // FIXME: circular dependency (ie. empty object when importing at top level), ref: #130
-      const { Geometry } = require('core/utils/geo');
+      const { Geometry, multiGeometryToSingleGeometries } = require('core/utils/geo');
       //
       const geometryType = geometry.getType();
       const unit = this.getCurrentMapUnit();
@@ -151,7 +151,13 @@ const utils = {
           geometry
         });
       } else if (Geometry.isPolygonGeometryType(geometryType)){
-        const segments = geometry.getLinearRing().getCoordinates();
+        let segments;
+        if (Geometry.isMultiGeometry(geometryType)) {
+          segments = [];
+          multiGeometryToSingleGeometries(geometry).forEach(geometry => {
+            geometry.getLinearRing().getCoordinates().forEach(coordinates => segments.push(coordinates))
+          })
+        } else segments = geometry.getLinearRing().getCoordinates();
         return this.getAreaMessageText({unit, geometry, projection, segments});
       }
     },


### PR DESCRIPTION
Close https://github.com/g3w-suite/g3w-client/issues/186