### PR TITLE
Add title icons to `release.yml`

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -5,30 +5,36 @@ changelog:
     authors:
       - octocat
   categories:
-    - title: New Features
+    - title: 🚀 New Features
       labels:
         - feature
-    - title: Bug fixed
+    - title: 🐞 Bug fixed
       labels:
         - bug
-    - title: Improvements
+    - title: ✨ Improvements
       labels:
         - ux
-    - title: Documentation
+    - title: 📝 Documentation
       labels:
         - docs
-    - title: Translations
+    - title: 👨‍🚀 Translations
       labels:
         - i18n
-    - title: Config
+    - title: 🐙 Github
+      labels:
+        - github
+    - title: 🧪 Tests
+      labels:
+        - tests
+    - title: 🛠️ Config
       labels:
         - config
-    - title: API changes
+    - title: ♻️ API changes
       labels:
         - refactoring
-    - title: Breaking changes
+    - title: ⚠️ Breaking changes
       labels:
         - breaking
-    - title: Other changes
+    - title: ⚓ Other changes
       labels:
         - "*"


### PR DESCRIPTION
**List of changes:**

- prepend titles with a self-explanatory emoji
- include [`github`](https://github.com/g3w-suite/g3w-client/labels/github) and [`tests`](https://github.com/g3w-suite/g3w-client/labels/tests) labels within automatically generated release notes

## Example release ([v3.6.0](https://github.com/g3w-suite/g3w-client/releases/tag/v3.6.0))

![photo](https://user-images.githubusercontent.com/9614886/190643583-14d6bf74-cf8e-4b36-a8d1-7e95817d8d78.png)
