### PR TITLE
Fix unselectable Layer Style containing a special character in name (catalog layers)

### DIFF
--- a/src/components/CatalogLayersLegendItems.vue
+++ b/src/components/CatalogLayersLegendItems.vue
@@ -102,7 +102,7 @@ export default {
         const urlLayersName = urlMethodsLayersName[method];
         if (method === 'GET')
           for (const url in urlLayersName ) {
-            const legendUrl = urlLayersName[url].length ? `${url}&LAYER=${urlLayersName[url].map(layerObj => layerObj.layerName).join(',')}&STYLES=${urlLayersName[url].map(layerObj => layerObj.style).join(',')}${ApplicationService.getFilterToken() ? '&filtertoken=' + ApplicationService.getFilterToken(): '' }`: url;
+            const legendUrl = urlLayersName[url].length ? `${url}&LAYER=${encodeURIComponent(urlLayersName[url].map(layerObj => layerObj.layerName).join(','))}&STYLES=${encodeURIComponent(urlLayersName[url].map(layerObj => layerObj.style).join(','))}${ApplicationService.getFilterToken() ? '&filtertoken=' + ApplicationService.getFilterToken(): '' }`: url;
             const legendUrlObject = {
               loading: true,
               url: legendUrl,


### PR DESCRIPTION
Closes: https://github.com/g3w-suite/g3w-client/issues/195

Make use of `encodeURIComponent("prova1 + prova2")` in order to safely handle special characters.

Now the payload id is right:

![Screenshot from 2022-09-16 15-15-34](https://user-images.githubusercontent.com/1051694/190647732-d516e9c5-93f4-4b4e-b576-17e4eefe4d21.png)

```log
..
LAYER: edifici20180829155021867
STYLES: prova1 + prova2
```