### PR TITLE
Fire `changeinput` event also on initial default value of input fields

### DIFF
--- a/src/app/gui/inputs/service.js
+++ b/src/app/gui/inputs/service.js
@@ -5,7 +5,7 @@ function Service(options = {}) {
   // set state of input
   this.state = options.state || {};
   // in case is set default input value to input
-  this.set_input_default_value = false;
+  this.has_default_value = false;
   // type of input
   //this.state.validate.required && this.setValue(this.state.value);
   /*
@@ -44,7 +44,7 @@ proto.setValue = function(value) {
       }
     } else {
       this.state.value = this.state.input.options.default;
-      this.set_input_default_value = true;
+      this.has_default_value = true;
     }
   }
 };

--- a/src/app/gui/inputs/service.js
+++ b/src/app/gui/inputs/service.js
@@ -4,6 +4,8 @@ const {t} = require('core/i18n/i18n.service');
 function Service(options = {}) {
   // set state of input
   this.state = options.state || {};
+  // in case is set default input value to input
+  this.set_input_default_value = false;
   // type of input
   //this.state.validate.required && this.setValue(this.state.value);
   /*
@@ -40,7 +42,10 @@ proto.setValue = function(value) {
             || this.state.input.options.values[0]
         }
       }
-    } else this.state.value = this.state.input.options.default;
+    } else {
+      this.state.value = this.state.input.options.default;
+      this.set_input_default_value = true;
+    }
   }
 };
 

--- a/src/mixins/base-input.js
+++ b/src/mixins/base-input.js
@@ -24,7 +24,7 @@ export default {
     },
     // called when input value change
     change() {
-      this.state.setEmpty && this.service.setEmpty();
+      this.service.setEmpty && this.service.setEmpty();
       // validate input
       this.state.validate.required && this.service.validate();
       // emit change input

--- a/src/mixins/base-input.js
+++ b/src/mixins/base-input.js
@@ -24,7 +24,7 @@ export default {
     },
     // called when input value change
     change() {
-      this.service.setEmpty && this.service.setEmpty();
+      this.service.setEmpty();
       // validate input
       this.state.validate.required && this.service.validate();
       // emit change input

--- a/src/mixins/base-input.js
+++ b/src/mixins/base-input.js
@@ -33,6 +33,6 @@ export default {
     isVisible() {},
   },
   mounted() {
-    this.service && this.service.set_input_default_value && this.change();
+    this.service && this.service.has_default_value && this.change();
   }
 };

--- a/src/mixins/base-input.js
+++ b/src/mixins/base-input.js
@@ -24,12 +24,15 @@ export default {
     },
     // called when input value change
     change() {
-      this.service.setEmpty();
+      this.state.setEmpty && this.service.setEmpty();
       // validate input
       this.state.validate.required && this.service.validate();
       // emit change input
       this.$emit('changeinput', this.state);
     },
-    isVisible() {}
+    isVisible() {},
+  },
+  mounted() {
+    this.service && this.service.set_input_default_value && this.change();
   }
 };


### PR DESCRIPTION
When create new editing feature and layer editing configuration layer has a default value to set when feature is created, can happen that if value of new feature is set with default value, not trigger change is fired. This missing trigger event can create a bug if another field of the feature is related whit an qgis field expression linked with the field.
This fix trigger change event input when a new feature is created and one or mode field have a default value

Closes #199 