### PR TITLE
Fix disabled `"Add WMS Layers Panel"` after changing projection of current selected layer

### DIFF
--- a/src/components/WMSLayersPanel.vue
+++ b/src/components/WMSLayersPanel.vue
@@ -81,11 +81,13 @@ export default {
         const firstLayer = layers[0];
         if (layers.length === 1) {
           this.epsg = this.layerProjections[firstLayer].crss[0];
-          this.projections = [...this.layerProjections[firstLayer].crss];
+          // take first layer selected supported crss
+          this.projections = this.layerProjections[firstLayer].crss;
         } else this.projections = this.projections.filter(projection => this.layerProjections[layers[layers.length -1]].crss.index(projection) !== -1);
       } else {
+        // Reset epsg and projections to initial values
         this.epsg = null;
-        this.projections.splice(0);
+        this.projections = [];
       }
     },
     async epsg(){

--- a/src/components/WMSLayersPanel.vue
+++ b/src/components/WMSLayersPanel.vue
@@ -31,7 +31,7 @@ export default {
   name: "wmpspanel",
   data(){
     return {
-      laoding: false,
+      loading: false,
       position: undefined,
       name: undefined,
       title: null,
@@ -71,25 +71,21 @@ export default {
     },
     //filter layer based on current epsg
     filterLayerByCurrentEpsg(){
-      this.layers = this.layers.filter(({name}) => this.layerProjections[name].crss.indexOf(this.epsg) !== -1);
+      this.layers = this.epsg !== null ? this.layers.filter(({name}) => this.layerProjections[name].crss.indexOf(this.epsg) !== -1) : this.$options.config.layers;
     }
   },
   watch: {
-    // when chanhe selected layers
+    // when change selected layers
     selectedlayers(layers){
       if (layers.length) {
         const firstLayer = layers[0];
         if (layers.length === 1) {
           this.epsg = this.layerProjections[firstLayer].crss[0];
-          this.projections = this.layerProjections[firstLayer].crss;
+          this.projections = [...this.layerProjections[firstLayer].crss];
         } else this.projections = this.projections.filter(projection => this.layerProjections[layers[layers.length -1]].crss.index(projection) !== -1);
       } else {
         this.epsg = null;
         this.projections.splice(0);
-        this.layers = Object.keys(this.layerProjections).map(name => ({
-          name,
-          title: this.layerProjections[name].title
-        }));
       }
     },
     async epsg(){
@@ -111,8 +107,8 @@ export default {
         }).sort(),
         title: layer.title
       };
-      this.layers.push(layer)
     });
+    this.layers = layers;
     // title of wms
     this.title = title;
     // abstract of wms


### PR DESCRIPTION
Closes: #211

Fix misspelling **loading** attribute of a WMSLayersPanel.vue component.
Fix issue of no layers in select layer when all selected layers are removed

![Screenshot from 2022-09-27 12-06-12](https://user-images.githubusercontent.com/1051694/192498047-776b0b6e-a02b-42c7-a7af-b6418bcd8d90.png)

![Screenshot from 2022-09-27 12-04-48](https://user-images.githubusercontent.com/1051694/192497768-3ba8d89c-6bb6-4af3-b5a5-3d921c8e72e1.png)


