### PR TITLE
Add new search URL parameter `<url>?ztf=<LAYER_ORIGNAME>` (zoom to layer features)

### DIFF
--- a/src/app/gui/map/mapservice.js
+++ b/src/app/gui/map/mapservice.js
@@ -1148,7 +1148,7 @@ proto.zoomToFid = async function(zoom_to_fid='', separator='|'){
 proto.handleZoomToFeaturesUrlParameter = async function({zoom_to_features='', search_endpoint='api'} = {}) {
   try {
     const [layerNameorIdorOrigname, fieldsValuesSearch] = zoom_to_features.split(':');
-    if (layerNameorId && fieldsValuesSearch) {
+    if (layerNameorIdorOrigname && fieldsValuesSearch) {
       const projectLayer = this.project.getLayers().find(layer =>
         layer.id === layerNameorIdorOrigname ||
         layer.name === layerNameorIdorOrigname ||

--- a/src/app/gui/map/mapservice.js
+++ b/src/app/gui/map/mapservice.js
@@ -1147,11 +1147,13 @@ proto.zoomToFid = async function(zoom_to_fid='', separator='|'){
  */
 proto.handleZoomToFeaturesUrlParameter = async function({zoom_to_features='', search_endpoint='api'} = {}) {
   try {
-    const [layerNameorId, fieldsValuesSearch] = zoom_to_features.split(':');
+    const [layerNameorIdorOrigname, fieldsValuesSearch] = zoom_to_features.split(':');
     if (layerNameorId && fieldsValuesSearch) {
-      const projectLayer = this.project.getLayers().find(layer => {
-        return layer.id === layerNameorId || layer.name === layerNameorId;
-      });
+      const projectLayer = this.project.getLayers().find(layer =>
+        layer.id === layerNameorIdorOrigname ||
+        layer.name === layerNameorIdorOrigname ||
+        layer.origname === layerNameorIdorOrigname
+      );
       if (projectLayer) {
         const layer = this.project.getLayerById(projectLayer.id);
         const filter = createFilterFromString({


### PR DESCRIPTION
Add `LAYER_ORIGNAME` in addition to `LAYER_ID` and `LAYER_NAME`, as **ztf (Zoom to Features)** search parameter,:

```spec
<url>?ztf=<LAYER_ID or LAYER_NAME or LAYER_ORIGNAME>:<FIELD_NAME>=<FIELD_VALUE>
```

---

**Original specs:** https://docs.google.com/document/d/1MthxEvrO7bCAq9ysPfOTFaIEqk3Lr8QtBxtRSWFSwAM/

---

```spec
List of URL Params available on G3W-SUITE (3.3 +)

map_extent (Zoom to map extent):
This parameter is useful set starting project map extent to a specific Map extent
Ex:
<url_project>?map_extent=Xmin,Ymin,Xmax,Ymax

zoom_to_fid (Zoom to a one feature only) 
    This parameter is used to zoom to a specific feature of a layer:
    Ex:
    <url_project>?zoom_to_fid=<layer_id>|<fid value>
    
    Ex: https://dev.g3wsuite.it/it/map/g3w-suite-demo/qdjango/97/?zoom_to_fid=roads_ea006d6f_bd87_4635_aae0_4e9e7842b3f4|1
    
ztf (Zoom to Features) 
    This parameter is used to zoom to Feature of a specific layer:
    Ex:
    <url_project>?ztf=<layer_id or layer name>:<field name>=<field value>

    Ex: https://dev.g3wsuite.it/it/map/g3w-suite-demo/qdjango/97/?ztf=roads_ea006d6f_bd87_4635_aae0_4e9e7842b3f4:id=1
```