### PR TITLE
Fix missing context menu on WMS Layers set as `external` (catalog layers)

### DIFF
--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -72,7 +72,7 @@
         </layerslegend>
       </div>
     </div>
-    <cataloglayercontextmenu :external="this.state.external"/>
+    <cataloglayercontextmenu :external="state.external"/>
   </div>
 </template>
 

--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -72,7 +72,7 @@
         </layerslegend>
       </div>
     </div>
-    <cataloglayercontextmenu/>
+    <cataloglayercontextmenu :external="this.state.external"/>
   </div>
 </template>
 

--- a/src/components/CatalogLayerContextMenu.vue
+++ b/src/components/CatalogLayerContextMenu.vue
@@ -161,6 +161,11 @@
 
   export default {
     name: 'Cataloglayermenu',
+    props: {
+      external: {
+        type: Object
+      }
+    },
     data(){
       return {
         layerMenu: {
@@ -415,7 +420,7 @@
       getGeometryType(layerId, external=false){
         let geometryType;
         if (external){
-          const layer = this.state.external.vector.find(layer => layer.id === layerId);
+          const layer = this.external.vector.find(layer => layer.id === layerId);
           if (layer) geometryType = layer.geometryType;
         } else {
           const originalLayer = CatalogLayersStoresRegistry.getLayerById(layerId);


### PR DESCRIPTION
Closes: #228 
