### PR TITLE
Fix missing response table headings and values on WMS Layer set as `external` (preview attributes)

### DIFF
--- a/src/app/gui/queryresults/queryresultsservice.js
+++ b/src/app/gui/queryresults/queryresultsservice.js
@@ -1148,7 +1148,8 @@ proto._parseAttributes = function(layerAttributes, feature, sourceType) {
       return {
         name: featureAttributesName,
         label: featureAttributesName,
-        show: featureAttributesName !== G3W_FID && (sourceType === undefined || showSourcesTypes.indexOf(sourceType) !== -1)
+        show: featureAttributesName !== G3W_FID && (sourceType === undefined || showSourcesTypes.indexOf(sourceType) !== -1),
+        type: 'varchar'
       }
     })
   }


### PR DESCRIPTION
Closes: #230 

Add a type `"varchar"` to response type feature --> see: `QueryResultsService::_parseAttributes()`



Now we can see preview

![Screenshot from 2022-10-03 18-28-36](https://user-images.githubusercontent.com/1051694/193630114-a2f86f01-0522-425b-b09e-7cfadcf8d65e.png)
