### PR TITLE
Decrease z-index values for `UserMessage.vue` component and for the `g3w-view-content` container (Viewport.vue)

### DIFF
--- a/src/app/constant.js
+++ b/src/app/constant.js
@@ -303,6 +303,12 @@ export const VIEWPORT = {
   }
 };
 
+export const ZINDEXES = {
+  usermessage: {
+    tool: 2
+  }
+};
+
 export default {
   APP_VERSION,
   DEFAULT_EDITING_CAPABILITIES,
@@ -321,4 +327,5 @@ export default {
   TOC_LAYERS_INIT_STATUS,
   TOC_THEMES_INIT_STATUS,
   VIEWPORT,
+  ZINDEXES
 };

--- a/src/assets/style/less/g3w-mapcontrols.less
+++ b/src/assets/style/less/g3w-mapcontrols.less
@@ -49,7 +49,7 @@
 .ol-mouse-position-default {
   right: 50px;
   border-radius: 4px;
-  z-index: 100;
+  z-index: 1;
 }
 
 .ol-mouse-position-default {
@@ -231,7 +231,7 @@
   }
   .gcd-gl-input {
     position: absolute;
-    z-index: 99;
+    z-index: 1;
     top: 0.25em;
     left: 2.5em;
     width: 14.84375em;
@@ -245,7 +245,7 @@
   }
   .gcd-gl-reset {
     position: absolute;
-    z-index: 100;
+    z-index: 1;
     top: 0;
     right: 0;
     width: 1.5625em;
@@ -355,7 +355,7 @@
   #search_nominatim {
     position: absolute;
     right: 0;
-    z-index: 100;
+    z-index: 1;
     width: 2.5em;
     height: 100%;
     border-radius: 0;
@@ -373,7 +373,7 @@
   }
   .gcd-txt-reset {
     position: absolute;
-    z-index: 100;
+    z-index: 1;
     top: 0;
     right: 30px;
     width: 2.5em;
@@ -391,7 +391,7 @@
   }
   .gcd-txt-input {
     position: absolute;
-    z-index: 99;
+    z-index: 1;
     top: 0;
     left: 0;
     width: 100%;
@@ -489,7 +489,7 @@
 
 .controls-toggle {
   position: absolute;
-  z-index: 10000;
+  z-index: 1;
   left:0 !important;
   top: 50px;
   cursor: pointer;
@@ -535,7 +535,7 @@
 .g3w-map-controls {
   position: absolute;
   flex-wrap: wrap;
-  z-index: 100;
+  z-index: 1;
   display: flex;
   .tooltip {
     font-weight: bold;

--- a/src/components/UserMessage.vue
+++ b/src/components/UserMessage.vue
@@ -54,6 +54,21 @@
       fontWeight: "bold"
     },
   };
+  /**
+   * Add custom style to handle different type of usermessage
+   * @type {{alert: {}, success: {}, warning: {}, loading: {}, tool: {"z-index": string}, info: {}}}
+   */
+  const STYLES = {
+    success: {},
+    info: {},
+    warning: {},
+    alert: {},
+    tool: {
+      "z-index": "900"
+    },
+    loading: {},
+  };
+
   export default {
     name: "usermessage",
     props: {
@@ -156,8 +171,9 @@
         }
       }
       this.style = {
-      ...COLORS[this.type],
-      ...position,
+        ...COLORS[this.type],
+        ...position,
+        ...STYLES[this.type]
       }
     },
     async mounted(){
@@ -207,16 +223,16 @@
     font-size: 1.1em;
   }
 
- .usermessage-header-title, .usermessage-header-title h4 {
+  .usermessage-header-title, .usermessage-header-title h4 {
     font-weight: bold;
-   text-align: center;
+    text-align: center;
   }
 
   .usermessage-content.mobile  .usermessage-header-title h4 {
     margin: 3px;
   }
 
- .usermessage-header-right {
+  .usermessage-header-right {
     padding: 5px;
   }
 

--- a/src/components/UserMessage.vue
+++ b/src/components/UserMessage.vue
@@ -26,6 +26,8 @@
 </template>
 
 <script>
+  import {ZINDEXES} from "../app/constant";
+
   const GUI = require('gui/gui');
   const COLORS = {
     success: {
@@ -64,7 +66,8 @@
     warning: {},
     alert: {},
     tool: {
-      "z-index": "900"
+      "z-index": ZINDEXES.usermessage.tool,
+      left: "40px"
     },
     loading: {},
   };

--- a/src/components/Viewport.vue
+++ b/src/components/Viewport.vue
@@ -80,6 +80,7 @@
   import downloadNotify from 'components/NotifyDownload.vue';
   import pluginsNotify from 'components/NotifyPlugins.vue';
   import {viewport as viewportConstraints} from 'gui/constraints';
+  import {ZINDEXES} from "../app/constant";
   import viewportService from 'services/viewport';
   const GUI = require('gui/gui');
 
@@ -140,6 +141,7 @@
           content: {
             width: `${this.state.content.sizes.width}px`,
             height: `${this.state.content.sizes.height}px`,
+            zIndex: ZINDEXES.usermessage.tool + 1,
             minHeight: this.state.split === 'v' ? `${viewportConstraints.resize.content.min}px` : null
           }
         }
@@ -216,10 +218,5 @@
 </script>
 
 <style scoped>
-  #g3w-view-content {
-    /**
-     * used in with with user message component
-     */
-    z-index: 999;
-  }
+
 </style>

--- a/src/components/Viewport.vue
+++ b/src/components/Viewport.vue
@@ -216,5 +216,10 @@
 </script>
 
 <style scoped>
-
+  #g3w-view-content {
+    /**
+     * used in with with user message component
+     */
+    z-index: 999;
+  }
 </style>


### PR DESCRIPTION
Changing z-index of elements it is possible to overlap result content over boox and query by polygon query map

Closes: #232 

## Before

![193859715-72309548-1cee-4b40-8c7d-2986429a03a2.png](https://user-images.githubusercontent.com/1051694/193859715-72309548-1cee-4b40-8c7d-2986429a03a2.png)

## After

![Screenshot from 2022-10-04 17-18-50](https://user-images.githubusercontent.com/1051694/193860615-e2533a7a-5cf1-41c1-8dee-52db5e647944.png)