### PR TITLE
Prevent form submit on Enter key press (editing form)

### DIFF
--- a/src/components/FormFooter.vue
+++ b/src/components/FormFooter.vue
@@ -55,13 +55,6 @@ export default Vue.extend({
     },
     isValid() {
       return this.state.valid;
-    },
-    _enterEventHandler(evt) {
-      if (evt.which === 13) {
-        evt.preventDefault();
-        const domEL = $(this.$el);
-        if (domEL.is(':visible') && this.isValid() && this.active) domEL.find('button').click();
-      }
     }
   },
   watch: {
@@ -74,13 +67,6 @@ export default Vue.extend({
   },
   deactivated() {
     this.active = false;
-  },
-  async mounted() {
-    await this.$nextTick();
-    document.addEventListener('keydown', this._enterEventHandler);
-  },
-  beforeDestroy() {
-    document.removeEventListener('keydown', this._enterEventHandler)
   }
 });
 </script>


### PR DESCRIPTION
Remove `Enter Key` (Return) listener handler on buttons of editing form

![Screenshot from 2022-10-18 15-13-48](https://user-images.githubusercontent.com/1051694/196439690-7dd2b34d-d975-4222-b600-74f8a715577d.png)
