### PR TITLE
List only fields with `show: true` attribute on Query Builder form (sidebar panel)

### DIFF
--- a/src/components/QueryBuilder.vue
+++ b/src/components/QueryBuilder.vue
@@ -216,9 +216,9 @@ export default {
       return {
         id: layer.id,
         label: layer.name,
-        fields: layer.fields.map(field => ({
-          label:field.label,
-          name: field.name
+        fields: layer.fields.filter(field => field.show).map(({label, name}) => ({
+          label,
+          name
         })).filter(field => excludejoinfields.indexOf(field) === -1)
       }
     });


### PR DESCRIPTION
As for query result layer fields or show layer table attributes filds, Query builder has to show only fields of selected layer that have `show: true` aligned with QGIS project layer form setting

![Screenshot from 2022-10-18 15-28-01](https://user-images.githubusercontent.com/1051694/196443362-eda8b9e9-bc23-4733-8e9e-e476698ecd11.png)