### PR TITLE
Fix application navbar overlaps relation result content (page header)

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -31,7 +31,7 @@
             </div>
           </div>
         </div>
-        <div ref="mainnavbar" class="collapse navbar-collapse" id="main-navbar" style="text-align: center; overflow: hidden">
+        <div ref="mainnavbar" class="collapse navbar-collapse" id="main-navbar" style="text-align: center; overflow: hidden; max-height: 50px;">
           <navbarleftitems></navbarleftitems>
           <navbarrightitems></navbarrightitems>
           <ul ref="app-navbar-nav" class="nav navbar-nav navbar-right app-navbar-nav">

--- a/src/components/GlobalResizeIcon.vue
+++ b/src/components/GlobalResizeIcon.vue
@@ -2,7 +2,7 @@
 <!-- gui/vue/global-components/resize-icon.vue@v3.4 -->
 
 <template>
-  <div>
+  <div style="display: flex; justify-content: space-between">
       <i :class="g3wtemplate.getFontClass(`resize-${type}`)" v-t-tooltip:bottom.create="'enlange_reduce'" style="cursor: pointer; margin-right: 3px;" class="action-button skin-color-dark" @click="toggleFull"></i>
       <i :class="g3wtemplate.getFontClass(`resize-default`)" v-t-tooltip:left.create="'reset_default'" style="cursor: pointer" class="action-button skin-color-dark" @click="resetToDefault"></i>
   </div>


### PR DESCRIPTION
Closes: #241 

---

### Before (navbar overlaps relation data):

![Screenshot from 2022-10-20 09-30-21](https://user-images.githubusercontent.com/1051694/196886038-840c2a43-a8e4-4d5a-92bc-596ec4b9d51d.png)

### After (no more navbar overlap):

![Screenshot from 2022-10-20 09-30-55](https://user-images.githubusercontent.com/1051694/196888361-4ceccdac-f800-4ae7-81c4-f3755b28b8fb.png)

---

### Before (icons wraps over multilines on small widths):

![Screenshot from 2022-10-20 09-32-22](https://user-images.githubusercontent.com/1051694/196886262-2cee401d-f59d-413d-b401-c18e208295a7.png)

### After (icons stays in one line):

![Screenshot from 2022-10-20 09-33-03](https://user-images.githubusercontent.com/1051694/196888218-b7c68c02-d2db-4a13-9169-434c212c821a.png)


