### PR TITLE
Prevent to register event handlers for `undefined` setter methods (G3WObject)

### DIFF
--- a/src/app/core/g3wobject.js
+++ b/src/app/core/g3wobject.js
@@ -73,20 +73,23 @@ proto.un = function(setter, key) {
   type=sync|async
 */
 proto._onsetter = function(when, setter, listener, async, priority=0, once=false) {
-  const settersListeners = this.settersListeners[when];
-  const listenerKey = `${Math.floor(Math.random()*1000000) + Date.now()}`;
+  let listenerKey;
+  const settersListeners = this.settersListeners[when] || {};
   const settersListeneres = settersListeners[setter];
-  settersListeneres.push({
-    key: listenerKey,
-    fnc: listener,
-    async,
-    priority,
-    once
-  });
-  // reader array based on priority
-  settersListeners[setter] = _.sortBy(settersListeneres, setterListener => setterListener.priority);
+  if (settersListeneres) {
+    listenerKey = `${Math.floor(Math.random()*1000000) + Date.now()}`;
+    settersListeneres.push({
+      key: listenerKey,
+      fnc: listener,
+      async,
+      priority,
+      once
+    });
+    // reader array based on priority
+    settersListeners[setter] = _.sortBy(settersListeneres, setterListener => setterListener.priority);
+  }
   // return key
-  return listenerKey;
+  return listenerKey // in case of no setter register return undefined listerKey
 };
 
 proto._setupListenersChain = function(setters) {


### PR DESCRIPTION
In case we are trying to register:

- `foo.onbefore( 'setterName', function() { ... } )`
- `foo.onafter( 'setterName', function() { ... } )`

on a `setterName` method that is not present on `foo` object, we get the following javascript error:

```js
TypeError: Cannot reading properties of undefined (reading 'push')
at proto._onsetter (g3wobject.js:79:21)
at proto._onafter (g3wobject.js:27:15)
```

---
 
![Screenshot from 2022-10-24 12-08-06](https://user-images.githubusercontent.com/1051694/197502972-a1f568e0-4bac-4270-8518-4a126ab1643a.png)
