### PR TITLE
Add new setter method `FeaturesStore::featuresLockedByOtherUser` (editing mode)

### DIFF
--- a/src/app/core/editing/editor.js
+++ b/src/app/core/editing/editor.js
@@ -92,9 +92,7 @@ proto.setLayer = function(layer) {
 };
 
 proto.removeNotEditablePropriertiesFromFeature = function(feature){
-  this._noteditablefileds.forEach(field => {
-    feature.unset([field]);
-  });
+  this._noteditablefileds.forEach(field => feature.unset([field]));
 };
 
 //clone features method
@@ -112,25 +110,21 @@ proto._doGetFeaturesRequest = function(options={}) {
   return doRequest && this._canDoGetFeaturesRequest(options)
 };
 
-// fget features methods
+// get features from server method
 proto._getFeatures = function(options={}) {
   const d = $.Deferred();
   const doRequest = this._doGetFeaturesRequest(options);
   if (!doRequest) d.resolve();
   else
     this._layer.getFeatures(options)
-      .then((promise) => {
-        promise.then((features) => {
+      .then(promise => {
+        promise.then(features => {
           this._addFeaturesFromServer(features);
           this._allfeatures = !options.filter;
           return d.resolve(features);
-        }).fail((err) => {
-          return d.reject(err);
-        })
+        }).fail(err => d.reject(err))
       })
-      .fail(function (err) {
-        d.reject(err);
-      });
+      .fail(err => d.reject(err));
   return d.promise();
 };
 
@@ -156,9 +150,7 @@ proto.applyChangesToNewRelationsAfterCommit = function(relationsResponse) {
     const layer = this.getLayerById(relationLayerId);
     const editingLayerSource = this.getEditingLayer(relationLayerId).getEditingSource();
     const features = editingLayerSource.readFeatures();
-    features.forEach((feature) => {
-      feature.clearState();
-    });
+    features.forEach(feature => feature.clearState());
     layer.getSource().setFeatures(features);
     layer.applyCommitResponse({
       response,

--- a/src/app/core/layers/tablelayer.js
+++ b/src/app/core/layers/tablelayer.js
@@ -99,7 +99,7 @@ function TableLayer(config={}, options={}) {
           };
           this._setOtherConfigParameters(vector);
           vector.style && this.setColor(vector.style.color);
-          // creare an instance of editor
+          // create an instance of editor
           this._editor = new Editor({
             layer: this
           });
@@ -112,14 +112,14 @@ function TableLayer(config={}, options={}) {
           this.setReady(false);
         })
     });
-    this.state = _.merge({
+    this.state = {
+      ...this.state,
       editing: {
         started: false,
         modified: false,
         ready: false
       }
-    }, this.state);
-
+    };
   }
   this._featuresstore = new FeaturesStore({
     provider: this.providers.data
@@ -443,32 +443,40 @@ proto.setFieldsWithValues = function(feature, fields) {
 };
 
 proto.getFieldsWithValues = function(obj, options={}) {
-  const exclude = options.exclude || [];
+  const {exclude=[], get_default_value=true}  = options;
   let fields = JSON.parse(JSON.stringify(this.getEditingFields()));
   let feature;
   if (obj instanceof Feature) feature = obj;
   else if (obj instanceof ol.Feature) feature = new Feature({
-      feature: obj
-    });
+    feature: obj
+  });
   else feature = obj && this.getFeatureById(obj);
   if (feature) {
     const attributes = feature.getProperties();
-    fields = fields.filter(field => exclude.indexOf(field.name) === -1);
+
     fields.forEach(field => {
+
       field.value = attributes[field.name];
-      if (field.type !== 'child' && field.input && field.input.type === 'select_autocomplete' && !field.input.options.usecompleter) {
+      if (field.input) {
         const _configField = this.getEditingFields().find(_field => _field.name === field.name);
         const options = _configField.input.options;
-        field.input.options.loading = options.loading;
+        field.input.options.loading = options.loading || {state: null};
         field.input.options.values = options.values;
       }
+      /**
+       * exclude contain field to set visible false
+       */
+      field.visible = exclude.indexOf(field.name) === -1;
       // for editing purpose
       if (field.validate === undefined) field.validate = {};
       field.forceNull = false;
       field.validate.valid = true;
       field.validate._valid = true; //useful to get previous value in certain case
-      field.validate.unique = true;
-      field.validate.required = field.validate.required === undefined ? false : field.validate.required;
+      field.value_from_default_value = false; // need to be check if default value is set by server configuration field
+      field.get_default_value = get_default_value; // specify if need to get value from form field.input.options.default value in case of missing value of field.value
+      field.validate.unique = field.validate.unique || false;
+      field.validate.exclude_values = new Set(); // for validate.unique purpose to check is new value iserted or change need to be di
+      field.validate.required = field.validate.required || false;
       field.validate.mutually_valid = true;
       field.validate.empty = !field.validate.required;
       field.validate.message = null;

--- a/src/app/core/layers/vectorlayer.js
+++ b/src/app/core/layers/vectorlayer.js
@@ -2,7 +2,7 @@ const {base, inherit, mixin} = require('core/utils/utils');
 const Layer = require('./layer');
 const TableLayer = require('./tablelayer');
 const GeoLayerMixin = require('./geolayermixin');
-const VectoMapLayer = require('./map/vectorlayer');
+const VectorMapLayer = require('./map/vectorlayer');
 
 function VectorLayer(config={}, options) {
   base(this, config, options);
@@ -10,7 +10,7 @@ function VectorLayer(config={}, options) {
   this.type = Layer.LayerTypes.VECTOR;
   // need a ol layer for add to map
   this.setup(config, options);
-  this.onafter('setColor', color => {})
+  this.onafter('setColor', color => {});
 }
 
 inherit(VectorLayer, TableLayer);
@@ -43,7 +43,7 @@ proto.getMapLayer = function() {
   const color = this.getColor();
   const style = this.isEditingLayer() ? this.getEditingStyle() : this.getCustomStyle();
   const provider = this.getProvider('data');
-  this._mapLayer = new VectoMapLayer({
+  this._mapLayer = new VectorMapLayer({
     id,
     geometryType,
     color,
@@ -53,6 +53,5 @@ proto.getMapLayer = function() {
   });
   return this._mapLayer;
 };
-
 
 module.exports = VectorLayer;


### PR DESCRIPTION
When try load editing features and some features are locked by another user (is in editing by another user), we need to let the user know about this situation. 

Add a `featuresLockedByOtherUser` setter (method) to `FeaturesStore`, in all code we con know when this happen and show eventually a warning message to the user.
