### PR TITLE
Change css datetime widgets skin color

### DIFF
--- a/src/assets/style/less/g3w-skins/blue/g3w-form.less
+++ b/src/assets/style/less/g3w-skins/blue/g3w-form.less
@@ -72,12 +72,17 @@
     }
   }
   .bootstrap-datetimepicker-widget {
-    a > span.glyphicon-remove {
+    a > span.glyphicon-remove,
+    a > span.glyphicon-time,
+    a > span.glyphicon-calendar,
+    a > span.glyphicon-chevron-up,
+    a > span.glyphicon-chevron-down {
       color: @light-blue;
     }
     .datepicker .active{
       background-color: @light-blue;
     }
+
   }
 
 }

--- a/src/assets/style/less/g3w-skins/green/g3w-form.less
+++ b/src/assets/style/less/g3w-skins/green/g3w-form.less
@@ -71,7 +71,11 @@
     }
   }
   .bootstrap-datetimepicker-widget {
-    a > span.glyphicon-remove {
+    a > span.glyphicon-remove,
+    a > span.glyphicon-time,
+    a > span.glyphicon-calendar,
+    a > span.glyphicon-chevron-up,
+    a > span.glyphicon-chevron-down {
       color: @green
     }
     .datepicker .active{

--- a/src/assets/style/less/g3w-skins/purple/g3w-form.less
+++ b/src/assets/style/less/g3w-skins/purple/g3w-form.less
@@ -71,7 +71,11 @@
     }
   }
   .bootstrap-datetimepicker-widget {
-    a > span.glyphicon-remove {
+    a > span.glyphicon-remove,
+    a > span.glyphicon-time,
+    a > span.glyphicon-calendar,
+    a > span.glyphicon-chevron-up,
+    a > span.glyphicon-chevron-down {
       color: @purple;
     }
     .datepicker .active{

--- a/src/assets/style/less/g3w-skins/red/g3w-form.less
+++ b/src/assets/style/less/g3w-skins/red/g3w-form.less
@@ -70,7 +70,11 @@
     }
   }
   .bootstrap-datetimepicker-widget {
-    a > span.glyphicon-remove {
+    a > span.glyphicon-remove,
+    a > span.glyphicon-time,
+    a > span.glyphicon-calendar,
+    a > span.glyphicon-chevron-up,
+    a > span.glyphicon-chevron-down {
       color: @red;
     }
     .datepicker .active{

--- a/src/assets/style/less/g3w-skins/yellow/g3w-form.less
+++ b/src/assets/style/less/g3w-skins/yellow/g3w-form.less
@@ -71,7 +71,11 @@
     }
   }
   .bootstrap-datetimepicker-widget {
-    a > span.glyphicon-remove {
+    a > span.glyphicon-remove,
+    a > span.glyphicon-time,
+    a > span.glyphicon-calendar,
+    a > span.glyphicon-chevron-up,
+    a > span.glyphicon-chevron-down {
       color: @yellow;
     }
     .datepicker .active{

--- a/src/components/GlobalDateTime.vue
+++ b/src/components/GlobalDateTime.vue
@@ -51,21 +51,6 @@
       }
     },
     methods: {
-      play(){
-
-      },
-      pause(){
-
-      },
-      stop(){
-
-      },
-      back(step=1){
-
-      },
-      forward(step=1){
-
-      },
       changeInput(evt){},
       change(value) {
         const date = moment(value).format(this.format);
@@ -94,20 +79,23 @@
         this.change(date);
       });
       this.datetimeinputelement.on("dp.hide", evt => {
+        /**
+         * for developement purpose. It used to leave open datimepicker open
+         */
         //$(this.$refs.iddatetimepicker).data("DateTimePicker").show();
       });
-      ApplicationState.ismobile && setTimeout(()=>datetimeinputelement.blur());
+      ApplicationState.ismobile && setTimeout(() => datetimeinputelement.blur());
     },
     watch: {
       value(datetime){
         this.datetimevalue = datetime;
         this.datetimeinputelement.data("DateTimePicker").date(datetime)
       },
-      async minDate(datetime){
-        this.datetimeinputelement.data("DateTimePicker").minDate(datetime);
+      async minDate(mindatetime){
+        this.datetimeinputelement.data("DateTimePicker").minDate(mindatetime);
       },
-      async maxDate(datetime){
-        this.datetimeinputelement.data("DateTimePicker").maxDate(datetime);
+      async maxDate(maxdatetime){
+        this.datetimeinputelement.data("DateTimePicker").maxDate(maxdatetime);
       },
       enabledDates(dates){
         this.datetimeinputelement.data("DateTimePicker").enabledDates(dates);


### PR DESCRIPTION
Align css skin color to datetime bootstrap widget also for hours, minute and seconds

![Screenshot from 2022-11-10 10-58-35](https://user-images.githubusercontent.com/1051694/201060692-b8f71dba-9466-4d01-93a8-b4e657d5cf0e.png)
