### PR TITLE
Handle single on off categories of a layer

### DIFF
--- a/src/app/core/layers/legend/wmslegend.js
+++ b/src/app/core/layers/legend/wmslegend.js
@@ -32,21 +32,27 @@ function WMSLegend({layer, params, options={}}) {
   /*
    to check if used or passed
    */
-  const {categories=false} = options;
+  const {categories=false, all=false} = options;
+  bbox = all ? null : bbox; // all=true meas no filter parameters as BBOX
   let url = layer.getWmsUrl({type: 'legend'});
-  const STYLES = categories && encodeURIComponent(layer.getCurrentStyle().name);
+  let STYLES;
+  let FORMAT = 'image/png';
   if (categories) {
     //set 16 for symbol of chart or other legend symbol
     symbolwidth = symbolheight = 16;
+    STYLES = encodeURIComponent(layer.getCurrentStyle().name);
+    FORMAT = 'application/json'
   }
   const ProjectsRegistry = require('core/project/projectsregistry');
   const dynamicLegend = ProjectsRegistry.getCurrentProject().getContextBaseLegend();
-  const {LEGEND_ON, LEGEND_OFF} = dynamicLegend ? get_LEGEND_ON_LEGEND_OFF_Params(layer) : {};
+  // in case of GetLegendGraphic of format application/json LEGEND_ON and LEGEND_OFF need to be undefined
+  // because it create some strange behaviour on wms getMap when switch between style of layer
+  const {LEGEND_ON, LEGEND_OFF} = dynamicLegend && !categories ? get_LEGEND_ON_LEGEND_OFF_Params(layer) : {};
   const sep = (url.indexOf('?') > -1) ? '&' : '?';
   return [`${url}${sep}SERVICE=WMS&VERSION=1.3.0&REQUEST=GetLegendGraphic&SLD_VERSION=${sld_version}`,
     `${width ? '&WIDTH=' + width: ''}`,
     `${height ? '&HEIGHT=' + height: ''}`,
-    `&FORMAT=${categories ? 'application/json' : 'image/png'}`,
+    `&FORMAT=${FORMAT}`,
     `&TRANSPARENT=${transparent}`,
     `&ITEMFONTCOLOR=${color}`,
     `&LAYERFONTCOLOR=${color}`,

--- a/src/components/CatalogLayerLegend.vue
+++ b/src/components/CatalogLayerLegend.vue
@@ -5,10 +5,10 @@
   <div v-show="show" class="layer-legend" @click.stop.prevent="">
     <bar-loader v-if="legend" :loading="legend.loading"></bar-loader>
     <figure>
-      <div v-for="(legendurl, index) in legend.url"  style="display: flex; align-items: center; width: 100%" v-disabled="legendurl.disabled">
-        <span v-if="legendurl.ruleKey" @click.stop.prevent="showHideLayerCategory(index)" style="padding-right: 3px;" :class="g3wtemplate.getFontClass(legendurl.checked ? 'check': 'uncheck')"></span>
-        <img v-if ="legendplace === 'toc'" :src="legendurl.icon && `data:image/png;base64,${legendurl.icon}`" @error="setError()" @load="urlLoaded()">
-        <span v-if="(legendplace === 'tab' && legendurl.ruleKey) || (legendplace === 'toc' && showCategoriesCheckBox)" class="new_line_too_long_text" style="padding-left: 3px;">{{legendurl.title}}</span>
+      <div v-for="(category, index) in categories"  style="display: flex; align-items: center; width: 100%" v-disabled="category.disabled">
+        <span v-if="category.ruleKey" @click.stop.prevent="showHideLayerCategory(index)" style="padding-right: 3px;" :class="g3wtemplate.getFontClass(category.checked ? 'check': 'uncheck')"></span>
+        <img v-if ="legendplace === 'toc'" :src="category.icon && `data:image/png;base64,${category.icon}`" @error="setError()" @load="urlLoaded()">
+        <span v-if="(legendplace === 'tab' && category.ruleKey) || (legendplace === 'toc' && showCategoriesCheckBox)" class="new_line_too_long_text" style="padding-left: 3px;">{{category.title}}</span>
       </div>
     </figure>
   </div>
@@ -17,7 +17,6 @@
 <script>
   import CatalogEventHub from 'gui/catalog/vue/catalogeventhub';
 
-  const ApplicationService = require('core/applicationservice');
   const ProjectsRegistry = require('core/project/projectsregistry');
   const CatalogLayersStoresRegistry = require('core/catalog/cataloglayersstoresregistry');
   const {XHR} = require('core/utils/utils');
@@ -34,28 +33,34 @@
       }
     },
     data(){
-      return {}
+      return {
+        categories: []
+      }
     },
     computed:{
       legend(){
         return this.layer.legend;
       },
       show(){
-        return this.layer.visible && this.legend.show;
+        return this.layer.visible && this.legend.show && (this.legendplace === 'toc' || this.legendplace === 'tab' && this.layer.categories);
       },
       showCategoriesCheckBox(){
-        return this.legend.url.length > 1;
+        return this.categories.length > 1;
       }
     },
     methods: {
+      getProjectLayer(){
+        return CatalogLayersStoresRegistry.getLayerById(this.layer.id);
+      },
       isDisabled(index){
-        return this.legend.url[index].disabled;
+        return this.categories[index].disabled;
       },
       showHideLayerCategory(index) {
-        this.layer.categories[index].checked = this.legend.url[index].checked = !this.legend.url[index].checked;
-        CatalogLayersStoresRegistry.getLayerById(this.layer.id).change();
+        const projectLayer = this.getProjectLayer();
+        this.categories[index].checked = this.categories[index].checked = !this.categories[index].checked;
+        projectLayer.change();
         if (this.legendplace === 'tab') CatalogEventHub.$emit('layer-change-categories', this.layer);
-        else if (this.layer.categories[index].checked && this.mapReady) this.disableAddCategories(this.layer);
+        else if (this.categories[index].checked && this.mapReady) this.setLayerCategories(false);
       },
       setError() {
         this.legend.error = true;
@@ -64,163 +69,88 @@
       async urlLoaded() {
         this.legend.loading = false;
       },
-      handlerChangeLegend(options={}){
+      async handlerChangeLegend(options={}){
         const { layerId } = options;
-        layerId === this.layer.id && this.getLegendSrc();
+        layerId === this.layer.id && await this.setLayerCategories(true);
+        this.dynamic && await this.setLayerCategories(false);
       },
-      async disableAddCategories(){
+      async setLayerCategories(all=false) {
         try {
-          const legendurl = CatalogLayersStoresRegistry.getLayerById(this.layer.id).getLegendUrl(this.legendParams, {
-            categories: true
-          });
-          const legendGraphics = await XHR.get({
-            url: legendurl
-          });
-          const {nodes=[]} = legendGraphics;
-          if (nodes.length) {
-            nodes.forEach(({icon, title, symbols=[]}) => {
-              if (this.layer.categories) {
-                if (symbols.length < this.layer.categories.length){
-                  /**
-                   * In case of only one symbol, getLegendGraphic return icon and title
-                   */
-                  if (icon && symbols.length === 0) symbols.push({
-                    title,
-                    icon
-                  });
-                  this.layer.categories.forEach(category => {
-                    //if (category.checked) {
-                    if (typeof category.checked === "undefined" || category.checked) {
-                      const findCategory = symbols.find(symbol => symbol.title === category.title && symbol.icon === category.icon);
-                      category.disabled = !findCategory;
-                    }
-                  })
-                  /*
-                  * */
-                } else this.layer.categories.forEach(category => category.disabled = false);
-              }
-            });
-          } else if (this.layer.categories)
-            this.layer.categories.forEach(category => category.disabled = category.checked);
-        } catch(err){}
-      },
-      setLayerCategoriesBySymbols(symbols){
-        /**
-         * filter symbol without checked property (undefined)
-         * it mean that is coming from a categories (for example charts associated)
-         * that is not the categories legend associated to layer
-         */
-        this.layer.categories = symbols.length ? symbols.map(symbol => ({
-          ...symbol,
-          _checked: symbol.checked,
-          disabled: false
-        })) : null;
-      },
-      async getSingleLayerLegendCategories() {
-        const responseObject = {
-          type: null,
-          data: null
-        };
-        try {
-          const legendurl = CatalogLayersStoresRegistry.getLayerById(this.layer.id).getLegendUrl(this.legendParams, {
-            categories: true
-          });
-          const legendGraphics = await XHR.get({
-            url: legendurl
-          });
-          const {nodes=[]} = legendGraphics;
-          nodes.forEach(({icon, title, symbols=[]}) => {
-            if (icon) {
-              /**
-               * if exist categories on layer and return only one icon,
-               * then need to return all categories
-               */
-              if (this.layer.categories) {
-                responseObject.type = 'categories';
-                responseObject.data = {
-                  categories: this.layer.categories
-                }
-              } else {
-                responseObject.type = 'icon';
-                responseObject.data = {
-                  icon,
-                  title
-                }
-              }
-            } else {
-              if (this.layer.categories) {
-                symbols.forEach(symbol =>{
-                  const findSymbol = this.layer.categories.find(({icon, title}) => symbol.icon === icon && symbol.title === title);
-                  if (!findSymbol) {
-                    symbol._checked = symbol.checked;
-                    symbol.disabled = false;
-                    this.layer.categories.push(symbol);
+          const projectLayer = this.getProjectLayer();
+          // get current categories from layer and check if exist
+          const categories = projectLayer.getCategories();
+          if (all && categories) this.categories = categories;
+          else {
+            try {
+              const legendGraphics = await projectLayer.getLegendGraphic({
+                all
+              });
+              const {nodes = []} = legendGraphics;
+              // case of all categories
+              if (all) {
+                const categories = [];
+                nodes.forEach(({icon, title, symbols = []}) => {
+                  if (icon) {
+                    categories.push({
+                      icon,
+                      title,
+                      disabled: false
+                    })
+                  } else {
+                    symbols.forEach(symbol => {
+                      symbol._checked = symbol.checked;
+                      symbol.disabled = false;
+                      categories.push(symbol);
+                    });
                   }
                 });
-              } else this.setLayerCategoriesBySymbols(symbols);
-              responseObject.type = 'categories';
-              responseObject.data = {
-                categories: this.layer.categories
+                projectLayer.setCategories(categories);
+                this.categories = categories;
+              } else {
+                projectLayer.setCategories(categories);
+                this.categories = categories;
+                // case to update current categories
+                if (nodes.length) {
+                  nodes.forEach(({icon, title, symbols = []}) => {
+                    if (icon) symbols = [{icon, title}];
+                    categories.forEach(category  => {
+                      const find = symbols.find(symbol => symbol.icon === category.icon && symbol.title === category.title);
+                      const disabled = typeof category.checked !== "undefined" ? category.checked : true;
+                      category.disabled = disabled && !find;
+                    });
+                  })
+                } else categories.forEach(category => category.disabled = typeof category.checked !== "undefined" ? category.checked : true);
               }
-            }
-          });
-        } catch(err){
-          responseObject.type = 'error';
-          responseObject.data = err;
-        }
-        return responseObject;
-      },
-      getLegendUrl() {
-        return CatalogLayersStoresRegistry.getLayerById(this.layer.id).getLegendUrl(this.legendParams);
-      },
-      createLegendUrl({type, data={}}){
-        switch(type) {
-          case 'icon':
-            const {icon, title, disabled=false, checked=true} = data;
-            this.legend.url = [{
-              icon,
-              title,
-              disabled,
-              checked
-            }];
-            break;
-          case 'categories':
-            this.legend.url = this.layer.categories;
-            break;
-        }
-      },
-      async getLegendSrc() {
-        try {
-          const layerLegendCategories = await this.getSingleLayerLegendCategories();
-          const {type, data={}} = layerLegendCategories;
-          this.createLegendUrl({
-            type,
-            data
-          })
-        } catch(err) {}
+            } catch(err) {this.setError();}
+          }
+        } catch(err) {this.setError();}
       }
     },
     watch: {
       'layer.visible'(visible){
-        if (this.dynamic && visible) this.disableAddCategories();
+        this.dynamic && visible && this.setLayerCategories(false);
       }
     },
-    created() {
+    async created() {
+      /**
+       * store legend url icons base on current style of layer
+       * It use to cache all symbol of a style without get a new request to server
+       * @type {{}}
+       */
       this.dynamic = ProjectsRegistry.getCurrentProject().getContextBaseLegend();
-      this.legendParams = ApplicationService.getConfig().layout ? ApplicationService.getConfig().layout.legend : {};
       this.mapReady = false;
       CatalogEventHub.$on('layer-change-style', this.handlerChangeLegend);
       /**
        * Get all legend graphics of a layer when start
        */
-      this.getLegendSrc();
+      this.layer.visible && this.setLayerCategories(true);
     },
     async mounted() {
       await this.$nextTick();
       const mapService = GUI.getService('map');
       this.dynamic && mapService.on('change-map-legend-params', async () => {
         this.mapReady = true;
-        this.layer.visible && this.disableAddCategories();
+        this.layer.visible && this.setLayerCategories(false);
       });
     },
     beforeDestroy() {

--- a/src/components/CatalogTristateTree.vue
+++ b/src/components/CatalogTristateTree.vue
@@ -4,7 +4,7 @@
 
 <template>
   <li
-    class="tree-item" @contextmenu.prevent.stop="showLayerMenu(layerstree, $event)" @click.prevent="select" :style="{paddingLeft: !isGroup ? '5px' : '2px'}"
+    class="tree-item" @contextmenu.prevent.stop="showLayerMenu(layerstree, $event)" @click.prevent="select" :style="{marginLeft: !isGroup ? '5px' : '2px'}"
     :class="{selected: !isGroup || !isTable ? layerstree.selected : false, itemmarginbottom: !isGroup,  disabled: isInGrey, group: isGroup  }">
     <span v-if="isGroup"
       style="padding-right: 2px;"


### PR DESCRIPTION
Add handle of single layer categories on off map wms element and legend. It sync also changing layer map style

**Example 1:** All Building categories are ON:

![Screenshot from 2022-11-10 11-43-04](https://user-images.githubusercontent.com/1051694/201070522-1ee560c0-eec3-4bcb-997f-4191ac822a35.png)

**Example 2**: Only _Commercial_ Build categories is ON:

![Screenshot from 2022-11-10 11-46-35](https://user-images.githubusercontent.com/1051694/201071214-f4c87cac-b886-4721-916c-350e35133ab0.png)

**Example 3** : Change current map style of a Building layer. See new categories

![Screenshot from 2022-11-10 11-48-26](https://user-images.githubusercontent.com/1051694/201071833-e0d6ed80-75b7-4de1-ad18-7c6fcd4465da.png)

![Screenshot from 2022-11-10 11-50-34](https://user-images.githubusercontent.com/1051694/201072205-c1c1de83-adc6-4b25-9e36-04a2f8f35f8b.png)

**Example 4** If set _"Filter Legend By Map Content"_ from Qgis project

![Screenshot from 2022-11-10 11-56-45](https://user-images.githubusercontent.com/1051694/201073734-c28ed6b1-b472-4205-afa1-c6cf4d441a5d.png)

All layer Categories that are not visible on current map extent are setted disabled (grey color) and is not possible to turn on off the categories disabled

![Screenshot from 2022-11-10 11-54-07](https://user-images.githubusercontent.com/1051694/201072938-204cdc11-8693-4ed8-81f7-055b2466cb47.png)



