### PR TITLE
Leave editing plugin to zoom to feature after click on result pencil icon 

### DIFF
--- a/src/app/gui/queryresults/queryresultsservice.js
+++ b/src/app/gui/queryresults/queryresultsservice.js
@@ -162,7 +162,7 @@ function QueryResultsService() {
     /**
      *  setter hook to relation table
      */
-    editFeature({layerId, featureId}={}){},
+    editFeature({layer, feature}={}){},
     /**
      * Method to listen open/close feature info data content.
      * @param open
@@ -617,15 +617,10 @@ proto.setActionsForLayers = function(layers, options={add: false}) {
         class: GUI.getFontClass('pencil'),
         hint: 'Editing',
         cbk: (layer, feature) => {
-          const layerId = layer.id;
-          const featureId = feature.attributes[G3W_FID];
-          feature.geometry && this.mapService.zoomToGeometry(feature.geometry);
-          setTimeout(()=>{
-            this.editFeature({
-              layerId,
-              featureId
-            });
-          }, 300)
+          this.editFeature({
+            layer,
+            feature
+          })
         }
       });
     });


### PR DESCRIPTION
Referred to https://github.com/g3w-suite/g3w-client-plugin-editing/commit/0dc28e89aad83a9fb4f7b6ad11a708d572d9dd0e

![Screenshot from 2022-11-15 12-41-57](https://user-images.githubusercontent.com/1051694/201911435-2c2839c6-e245-4997-a512-df06feb86996.png)

moved function behavior  to editing plugin service
