### PR TITLE
Prevent sending `BBOX=` parameter on `GetLegendGraphic` request when project has `context_base_legend: false` and the Legend is set to separate TAB

### DIFF
--- a/src/components/CatalogLayersLegendItems.vue
+++ b/src/components/CatalogLayersLegendItems.vue
@@ -86,7 +86,11 @@ export default {
     getLegendUrl(layer, params={}) {
       const catalogLayer = CatalogLayersStoresRegistry
         .getLayerById(layer.id);
-      return catalogLayer && catalogLayer.getLegendUrl(params, { format: 'image/png', categories: layer.categories });
+      return catalogLayer && catalogLayer.getLegendUrl(params, {
+        all: !this.dynamic,
+        format: 'image/png',
+        categories: layer.categories
+      });
     },
 
     /**

--- a/src/components/CatalogLayersLegendItems.vue
+++ b/src/components/CatalogLayersLegendItems.vue
@@ -84,13 +84,12 @@ export default {
     },
 
     /**
-     * @params object see src/core/layers/legend/wmslegend.js params
-     * layer <Object> contains layer config
-     * @return {string/undefined} get legend url of a layer
+     * @param   {object} params    same as `src/core/layers/legend/wmslegend.js` params
+     * @param   {object} layer     layer config
+     * @returns {string|undefined} legend url of a layer (undefined if `layer.id` is not in CatalogRegistry)
      */
     getLegendUrl(layer, params={}) {
       const catalogLayer = CatalogLayersStoresRegistry.getLayerById(layer.id);
-      // just in case layer.id is not on Catalogo Registry
       if (catalogLayer) {
           return catalogLayer.getLegendUrl(params, {
             all: !this.dynamic, // set true or false based on legend is dynamic or not

--- a/src/components/CatalogLayersLegendItems.vue
+++ b/src/components/CatalogLayersLegendItems.vue
@@ -211,7 +211,7 @@ export default {
       for (const method in urlMethodsLayersName) {
         const urlLayersName = urlMethodsLayersName[method];
         if ('GET' === method) {
-          for (const url in urlLayersName ) {
+          for (let url in urlLayersName ) {
             if (urlLayersName[url].length) {
               url+=`${this.getLegendUrlParams(urlLayersName[url])}`;
             }

--- a/src/components/CatalogLayersLegendItems.vue
+++ b/src/components/CatalogLayersLegendItems.vue
@@ -84,14 +84,13 @@ export default {
     },
 
     /**
-     * @FIXME add parameter types
-     * @FIXME add return type
-     * @FIXME missing return value when `catalogLayer` is not defined
-     * 
-     * @returns {string}
+     * @params object see src/core/layers/legend/wmslegend.js params
+     * layer <Object> contains layer config
+     * @return {string/undefined} get legend url of a layer
      */
     getLegendUrl(layer, params={}) {
       const catalogLayer = CatalogLayersStoresRegistry.getLayerById(layer.id);
+      // just in case layer.id is not on Catalogo Registry
       if (catalogLayer) {
           return catalogLayer.getLegendUrl(params, {
             all: !this.dynamic, // set true or false based on legend is dynamic or not
@@ -181,8 +180,12 @@ export default {
           (layer.source && layer.source.url) || layer.external
             ? urlMethodsLayersName.GET
             : urlMethodsLayersName[layer.ows_method];
-        const url = `${this.getLegendUrl(layer, this.legend.config)}`;
 
+        const url = `${this.getLegendUrl(layer, this.legend.config)}`;
+        // in case of no url is get
+        if ("undefined" === typeof url){
+          continue;
+        }
         if (layer.source && layer.source.url) {
           urlLayersName[url] = [];
         } else {

--- a/src/components/CatalogLayersLegendItems.vue
+++ b/src/components/CatalogLayersLegendItems.vue
@@ -211,9 +211,7 @@ export default {
       for (const method in urlMethodsLayersName) {
         const urlLayersName = urlMethodsLayersName[method];
         if ('GET' === method) {
-          for (const _url in urlLayersName ) {
-            //set base url
-            let url = _url;
+          for (const url in urlLayersName ) {
             if (urlLayersName[url].length) {
               url+=`${this.getLegendUrlParams(urlLayersName[url])}`;
             }

--- a/src/components/CatalogLayersLegendItems.vue
+++ b/src/components/CatalogLayersLegendItems.vue
@@ -87,7 +87,7 @@ export default {
       const catalogLayer = CatalogLayersStoresRegistry
         .getLayerById(layer.id);
       return catalogLayer && catalogLayer.getLegendUrl(params, {
-        all: !this.dynamic,
+        all: !this.dynamic, // set true or false based on legend is dynamic or not
         format: 'image/png',
         categories: layer.categories
       });


### PR DESCRIPTION
Closes: #342 
