### PR TITLE
Fix english word mispelling within metadata tab (ref: "References")

### DIFF
--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -125,7 +125,7 @@ export default {
               subfields: {
                 contactinformation: {
                   contactelectronicmailaddress: "Email",
-                  personprimary: 'Refereces',
+                  personprimary: 'References',
                   contactvoicetelephone: 'Phone',
                   contactorganization: 'Organization',
                   ContactOrganization: 'Organization',


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9614886/225947224-a2720ca7-ebc5-46f7-9151-ef5aebb0371b.png)
