### PR TITLE
Remove promise return from function `ApplicationService::changeProject({ gid, host })`

### DIFF
--- a/src/components/ProjectsMenu.vue
+++ b/src/components/ProjectsMenu.vue
@@ -51,21 +51,7 @@ export default {
         const {gid} = item;
         item.cbk.call(item, {
           gid
-        }).then(promise => {
-            //changeProject is a setter so it return a promise
-            promise
-              .then(project=>document.title = project.state.html_page_title)
-              .fail(() => {
-                GUI.notify.error("<h4>" + t("error_map_loading") + "</h4>" +
-                  "<h5>"+ t("check_internet_connection_or_server_admin") + "</h5>");
-              })
-              .always(() => {
-                GUI.showFullModal({
-                  show: false
-                });
-                GUI.setLoadingContent(false);
-              })
-          })
+        })
       }
       else if (item.href) window.open(item.href, '_blank');
       else if (item.route) GUI.goto(item.route);

--- a/src/services/application.js
+++ b/src/services/application.js
@@ -600,14 +600,11 @@ const ApplicationService = function() {
    * @private
    */
   this._changeProject = function({gid, host}={}) {
-    const d = $.Deferred();
     this._gid = gid;
     const projectUrl = ProjectsRegistry.getProjectUrl(gid);
     const url = GUI.getService('map').addMapExtentUrlParameterToUrl(projectUrl);
     history.replaceState(null, null, url);
     location.replace(url);
-    d.resolve();
-    return d.promise();
   };
 
   /**


### PR DESCRIPTION
No more return promise is used when changeProject is run because  location.replace(url) reload page