### PR TITLE
Dynamically update features count after manually switching layer category style (ref: layers legend)

### DIFF
--- a/src/app/core/layers/layer.js
+++ b/src/app/core/layers/layer.js
@@ -100,7 +100,10 @@ function Layer(config={}, options={}) {
      * @since 3.8.0
      */
     featurecount: config.featurecount,
-    stylesfeaturecount: defaultstyle && config.featurecount && {
+    /**
+     * @since 3.8.0
+     */
+    stylesfeaturecount: config.featurecount && defaultstyle && {
       [defaultstyle]: config.featurecount
     }
   };

--- a/src/app/core/layers/layer.js
+++ b/src/app/core/layers/layer.js
@@ -1133,15 +1133,20 @@ proto.getFeatureCount = function(){
  */
 proto.getStyleFeatureCount = async function(style){
   if ("undefined" === typeof this.state.stylesfeaturecount[style]){
-    this.state.stylesfeaturecount[style] = await XHR.post({
-      url: this.config.urls.featurecount,
-      data: {
-        style
-      },
-      contentType: 'application/json'
-    })
+    try {
+      const {result, data} = await XHR.post({
+        url: `${this.config.urls.featurecount}${this.getId()}/`,
+        data: JSON.stringify({
+          style
+        }),
+        contentType: 'application/json'
+      });
+      this.state.stylesfeaturecount[style] = true === result ? data : {};
+    } catch(err){
+      this.state.stylesfeaturecount[style] = {};
+    }
   }
-  return this.state.stylesfeaturecount[style]
+  return this.state.stylesfeaturecount[style];
 };
 
 /// LAYER PROPERTIES

--- a/src/app/core/layers/layer.js
+++ b/src/app/core/layers/layer.js
@@ -53,6 +53,11 @@ function Layer(config={}, options={}) {
     this.config.urls.widget = {
       unique: `${vectorUrl}widget/unique/data/${suffixUrl}`
     };
+    /**
+     * @since 3.8.0
+     *
+     */
+    this.config.urls.featurecount = project.getUrl('featurecount');
     //set custom parameters based on project qgis version
     this.config.searchParams = {
       I: 0,
@@ -94,7 +99,10 @@ function Layer(config={}, options={}) {
     /**
      * @since 3.8.0
      */
-    featurecount: config.featurecount
+    featurecount: config.featurecount,
+    stylesfeaturecount: defaultstyle && config.featurecount && {
+      [defaultstyle]: config.featurecount
+    }
   };
 
   // add selectionFids
@@ -1116,6 +1124,24 @@ proto.isTable = function(){
  */
 proto.getFeatureCount = function(){
   return this.state.featurecount;
+};
+
+/**
+ * @since 3.8.0
+ * @param style
+ * @returns {Promise<Object>}
+ */
+proto.getStyleFeatureCount = async function(style){
+  if ("undefined" === typeof this.state.stylesfeaturecount[style]){
+    this.state.stylesfeaturecount[style] = await XHR.post({
+      url: this.config.urls.featurecount,
+      data: {
+        style
+      },
+      contentType: 'application/json'
+    })
+  }
+  return this.state.stylesfeaturecount[style]
 };
 
 /// LAYER PROPERTIES

--- a/src/app/core/project/project.js
+++ b/src/app/core/project/project.js
@@ -9,72 +9,94 @@ const LayerFactory = require('core/layers/layerfactory');
 const LayersStore = require('core/layers/layersstore');
 const Projections = require('g3w-ol/projection/projections');
 
+/**
+ * @FIXME options param appears to be unusued
+ * 
+ * @param config.id
+ * @param config.type
+ * @param config.gid
+ * @param config.name
+ * @param config.crs
+ * @param config.extent
+ * @param config.initextent
+ * @param config.layers
+ * @param config.layerstree
+ * @param config.overviewprojectgid
+ * @param config.baselayers
+ * @param config.initbaselayer
+ * @param config.filtertoken
+ * @param config.context_base_legend
+ * @param config.query_point_tolerance
+ * @param config.wps                           array of wps service
+ * @param config.bookmarks                     array of bookmarks
+ * @param { 'POST' | 'GET' }                   config.ows_method
+ * @param {boolean}                            config.wms_use_layer_ids
+ * @param { 'ows' | 'api' }                    config.search_endpoint 
+ * @param { 'tab' | 'toc' }                    config.legend_position 
+ * @param { 'layers', 'baselayers', 'legend' } config.catalog_tab
+ * 
+ * @param options
+ */
 function Project(config={}, options={}) {
-  /* structure 'project' object
-  {
-    id,
-    type,
-    gid,
-    name,
-    crs,
-    extent,
-    initextent,
-    layers,
-    layerstree,
-    overviewprojectgid,
-    baselayers,
-    initbaselayer,
-    filtertoken,
-    context_base_legend
-    ows_method <POST or GET>
-    wms_use_layer_ids: <TRUE OR FALSE>
-    search_endpoint : 'ows', 'api'
-    legend_position: 'tab', 'toc'
-    query_point_tolerance
-    wps: [] // array of wps service
-    bookmarks:[] Array of bookmarks
-  }
-  */
-  // for future implementation catalog tab actived
-  config.catalog_tab = config.toc_tab_default || config._catalog_tab || 'layers'; // values : layers, baselayers, legend
-  config.ows_method = config.ows_method || 'GET';
-  config.toc_layers_init_status = config.toc_layers_init_status || TOC_LAYERS_INIT_STATUS;
-  config.toc_themes_init_status = config.toc_themes_init_status || TOC_THEMES_INIT_STATUS;
-  config.query_point_tolerance = config.query_point_tolerance || QUERY_POINT_TOLERANCE;
-  this.state = config;
   /**
-   * View
-   *
+   * For future implementation catalog tab actived
    */
-  //information about api project
+  config.catalog_tab = config.toc_tab_default || config._catalog_tab || 'layers';
+
+  config.ows_method = config.ows_method || 'GET';
+
+  config.toc_layers_init_status = config.toc_layers_init_status || TOC_LAYERS_INIT_STATUS;
+  
+  config.toc_themes_init_status = config.toc_themes_init_status || TOC_THEMES_INIT_STATUS;
+  
+  config.query_point_tolerance = config.query_point_tolerance || QUERY_POINT_TOLERANCE;
+  
+  this.state = config;
+
+  const type   = this.getType();
+  const id     = this.getId();
+  const vector = this.getVectorUrl();
+
+  /**
+   * View information about project APIs 
+   */
   this.urls = {
-    map_themes: `/${this.getType()}/api/prjtheme/${this.getId()}/`,
-    expression_eval: `/api/expression_eval/${this.getId()}/`,
-    vector_data: `${this.getVectorUrl()}data/${this.getType()}/${this.getId()}/`,
-    featurecount:`${this.getVectorUrl()}featurecount/${this.getType()}/${this.getId()}/`,
-};
-  /*
-   *
-   * End View
-   *
-   */
-  // process layers
+    map_themes:      `/${type}/api/prjtheme/${id}/`,
+    expression_eval: `/api/expression_eval/${id}/`,
+    vector_data:     `${vector}data/${type}/${id}/`,
+    featurecount:    `${vector}featurecount/${type}/${id}/`,
+  };
+
   this._processLayers();
-  // set the project projection to object crs
+
+  /**
+   * Set the project projection to object crs
+   */
   this.state.crs = crsToCrsObject(this.state.crs);
+
   this._projection = Projections.get(this.state.crs);
-  // build a layersstore of the project
+
+  /**
+   * Build a layersstore of the project
+   */
   this._layersStore = this._buildLayersStore();
-  ///
+
+  /**
+   * Hook methods
+   */
   this.setters = {
+
     setBaseLayer(id) {
       this.state.baselayers.forEach(baseLayer => {
         this._layersStore.getLayerById(baseLayer.id).setVisible(baseLayer.id === id);
         baseLayer.visible = (baseLayer.id === id);
       })
-    }
+    },
+
   };
+
   this.setSearchEndPoint();
+
   base(this);
 }
 
@@ -82,14 +104,15 @@ inherit(Project, G3WObject);
 
 const proto = Project.prototype;
 
-//get search end point value (ows or api)
-proto.getSearchEndPoint = function(){
+/**
+ * Get search end point value (ows or api)
+ */
+proto.getSearchEndPoint = function() {
   return this.state.search_endpoint;
 };
 
-proto.setSearchEndPoint = function(){
-  const {search_endpoint, search=[]} = this.state;
-  search.forEach(search => search.search_endpoint = search_endpoint);
+proto.setSearchEndPoint = function() {
+  (this.state.search || []).forEach(search => search.search_endpoint = this.state.search_endpoint);
 };
 
 proto.getAliasUrl = function() {
@@ -100,7 +123,7 @@ proto.getActiveCatalogTab = function() {
   return this.state.catalog_tab;
 };
 
-proto.setActiveCatalogTab = function(tab='layers') {
+proto.setActiveCatalogTab = function(tab = 'layers') {
   this.state.catalog_tab = tab;
 };
 
@@ -108,11 +131,11 @@ proto.isWmsUseLayerIds = function() {
   return this.state.wms_use_layer_ids;
 };
 
-proto.getContextBaseLegend = function(){
+proto.getContextBaseLegend = function() {
   return this.state.context_base_legend;
 };
 
-proto.getQueryPointTolerance = function(){
+proto.getQueryPointTolerance = function() {
   return this.state.query_point_tolerance;
 };
 
@@ -122,18 +145,18 @@ proto.getQueryFeatureCount = function() {
 };
 
 proto.isQueryMultiLayers = function(mapcontrol) {
-  return this.state.querymultilayers && this.state.querymultilayers.indexOf(mapcontrol) !== -1;
+  return this.state.querymultilayers && -1 !== this.state.querymultilayers.indexOf(mapcontrol);
 };
 
 proto.getRelations = function() {
   return this.state.relations;
 };
 
-proto.getRelationById = function(relationId){
+proto.getRelationById = function(relationId) {
   return this.state.relations.find(relation => relation.id === relationId);
 };
 
-proto.getRelationsByLayerId = function({layerId, type}={}){
+proto.getRelationsByLayerId = function({layerId, type}={}) {
   return this.state.relations.filter(relation => relation.referencedLayer === layerId && (type ? relation.type === type : true))
 };
 
@@ -142,7 +165,7 @@ proto.getOwsMethod = function() {
 };
 
 /**
- * process layerstree and baselayers of the project
+ * Process layerstree and baselayers of the project
  */
 proto._processLayers = function() {
 
@@ -186,12 +209,16 @@ proto._processLayers = function() {
   }
 };
 
-// build layersstore and create layersstree
+/**
+ * Build layersstore and create layersstree 
+ */
 proto._buildLayersStore = function() {
   // create a layersStore object
   const layersStore = new LayersStore();
+
   //check if we have owerview project
   const overviewprojectgid = this.state.overviewprojectgid ? this.state.overviewprojectgid.gid : null;
+
   layersStore.setOptions({
     id: this.state.gid,
     projection: this._projection,
@@ -203,6 +230,7 @@ proto._buildLayersStore = function() {
 
   // instance each layer ad area added to layersstore
   const layers = this.getLayers();
+  
   layers.forEach(layerConfig => {
     //check and set crs in objectformat
     layerConfig.crs = crsToCrsObject(layerConfig.crs);
@@ -211,16 +239,18 @@ proto._buildLayersStore = function() {
     //add ows_method
     layerConfig.ows_method = this.getOwsMethod();
     layerConfig.wms_use_layer_ids = this.state.wms_use_layer_ids;
-    const layer = LayerFactory.build(layerConfig, {
-      project: this
-    });
-    layer && layersStore.addLayer(layer);
+    const layer = LayerFactory.build(layerConfig, { project: this });
+    if (layer) {
+      layersStore.addLayer(layer);
+    } 
   });
+  
   // create layerstree from layerstore
   layersStore.createLayersTree(this.state.name, {
     layerstree: this.state.layerstree,
     expanded: this.state.toc_layers_init_status === 'not_collapsed' // config to show layerstrees toc expanded or not
   });
+  
   return layersStore;
 };
 
@@ -238,6 +268,7 @@ proto.getBaseLayers = function() {
 
 /**
  * Get configuration layers array from server config
+ * 
  * @param filter property layer config to filter
  * @returns {*}
  */
@@ -249,11 +280,11 @@ proto.getConfigLayers = function({key}={}) {
  * Legend Position
  */
 
-proto.setLegendPosition = function(legend_position='tab'){
+proto.setLegendPosition = function(legend_position='tab') {
   this.state.legend_position = legend_position;
 };
 
-proto.getLegendPosition = function(){
+proto.getLegendPosition = function() {
   return this.state.legend_position;
 };
 
@@ -265,7 +296,7 @@ proto.getThumbnail = function() {
   return this.state.thumbnail;
 };
 
-proto.getMetadata = function(){
+proto.getMetadata = function() {
   return this.state.metadata || {};
 };
 
@@ -273,11 +304,11 @@ proto.getState = function() {
   return this.state;
 };
 
-proto.getPrint = function(){
+proto.getPrint = function() {
   return this.state.print || [];
 };
 
-proto.getSearches = function(){
+proto.getSearches = function() {
   return this.state.search || [];
 };
 
@@ -285,7 +316,7 @@ proto.getVectorUrl = function() {
   return this.state.vectorurl;
 };
 
-proto.getRasterUrl = function(){
+proto.getRasterUrl = function() {
   return this.state.rasterurl;
 };
 
@@ -313,12 +344,12 @@ proto.getCrs = function() {
   return this._projection.getCode();
 };
 
-/*
-* type: major, minor, patch
-* */
+/**
+ * @param {'major' | 'minor' | 'patch' } qgis.type 
+ */
 proto.getQgisVersion = function({type}={}) {
   const index = ['major', 'minor', 'patch'].indexOf(type);
-  return index === -1 ? this.state.qgis_version: +this.state.qgis_version.split('.')[index];
+  return -1 === index ? this.state.qgis_version : +this.state.qgis_version.split('.')[index];
 };
 
 proto.getProjection = function() {
@@ -340,11 +371,12 @@ proto.getLayersStore = function() {
 /// Map Themes
 
 /**
- * Method to set properties ( checked and visible) from view to layerstree
+ * Set properties ( checked and visible) from view to layerstree
+ * 
  * @param map_theme map theme name
  * @param layerstree // current layerstree of TOC
  */
-proto.setLayersTreePropertiesFromMapTheme = async function({map_theme, layerstree=this.state.layerstree}){
+proto.setLayersTreePropertiesFromMapTheme = async function({map_theme, layerstree=this.state.layerstree}) {
   /**
    * mapThemeConfig contain map_theme attributes coming from project map_themes attribute config
    * plus layerstree of map_theme get from api map theme
@@ -416,48 +448,44 @@ proto.setLayersTreePropertiesFromMapTheme = async function({map_theme, layerstre
 /**
  * get map Theme_configuration
  */
-proto.getMapThemeFromThemeName = async function(map_theme){
+proto.getMapThemeFromThemeName = async function(map_theme) {
   // get map theme configuration from map_themes project config
   const mapThemeConfig = this.state.map_themes.find(map_theme_config => map_theme_config.theme === map_theme);
-  // check if mapThemeConfig exist
-  if (mapThemeConfig){
-    // check if has layerstree (property get from server with a specific api
-    const {layerstree} = mapThemeConfig;
-    if (layerstree === undefined) {
-      const layerstree = await this.getMapThemeConfiguration(map_theme);
-      mapThemeConfig.layerstree =  layerstree;
-    }
+  // check if mapThemeConfig exist and if has layerstree (property get from server with a specific api)
+  if (mapThemeConfig && undefined === mapThemeConfig.layerstree ) {
+    mapThemeConfig.layerstree =  await this.getMapThemeConfiguration(map_theme);
   }
   return mapThemeConfig;
 };
 
 /**
- * get map_style from server
+ * Get map_style from server
+ * 
  * @param map_theme
+ * 
  * @returns {Promise<*>}
  */
-proto.getMapThemeConfiguration = async function(map_theme){
-  let config;
-  const url = `${this.urls.map_themes}${map_theme}/`;
+proto.getMapThemeConfiguration = async function(map_theme) {
   try {
-    const response = await XHR.get({
-      url
-    });
-    const {result, data} = response;
-    if (result) config = data;
-  } catch(err){}
-  return config;
+    const response = await XHR.get({ url: `${this.urls.map_themes}${map_theme}/` });
+    if (response.result) {
+      return response.data;
+    }
+  } catch(err) {
+    console.warn('Error while retreiving map theme configuration', err);
+  }
 };
 
-proto.getUrl = function(type){
+proto.getUrl = function(type) {
   return this.urls[type];
 };
 
 /**
  * @returns {Array} spatial bookmarks saved on current QGIS project
+ * 
  * @since v3.8
  */
-proto.getSpatialBookmarks = function(){
+proto.getSpatialBookmarks = function() {
   return this.state.bookmarks || [];
 };
 

--- a/src/app/core/project/project.js
+++ b/src/app/core/project/project.js
@@ -51,6 +51,7 @@ function Project(config={}, options={}) {
     map_themes: `/${this.getType()}/api/prjtheme/${this.getId()}/`,
     expression_eval: `/api/expression_eval/${this.getId()}/`,
     vector_data: `${this.getVectorUrl()}data/${this.getType()}/${this.getId()}/`,
+    featurecount:`${this.getVectorUrl()}featurecount/${this.getType()}/${this.getId()}/`,
 };
   /*
    *
@@ -459,6 +460,5 @@ proto.getUrl = function(type){
 proto.getSpatialBookmarks = function(){
   return this.state.bookmarks || [];
 };
-
 
 module.exports = Project;

--- a/src/components/CatalogLayerContextMenu.vue
+++ b/src/components/CatalogLayerContextMenu.vue
@@ -43,8 +43,7 @@
       <ul v-show="layerMenu.stylesMenu.show" style="position:fixed; padding-left: 0; background-color: #FFFFFF; color:#000000" :style="{ top: layerMenu.stylesMenu.top + 'px', left: `${layerMenu.stylesMenu.left}px`, maxHeight: layerMenu.stylesMenu.maxHeight + 'px', overflowY: layerMenu.stylesMenu.overflowY }">
         <li v-for="(style, index) in layerMenu.layer.styles" @click.stop="setCurrentLayerStyle(index)" :key="style.name">
           <span v-if="style.current" style="font-size: 0.8em;" :class="g3wtemplate.getFontClass('circle')"></span>
-          <span>{{style.name}}
-            <span v-if="style.name === layerMenu.layer.defaultstyle && layerMenu.layer.styles.length > 1">(<span v-t="'default'"></span>)</span></span>
+          <span>{{ getStyleName(style) }}</span>
         </li>
       </ul>
     </li>
@@ -668,8 +667,19 @@
           this.layerMenu.colorMenu.left = elem.offset().left + elem.width() + ((elem.outerWidth() - elem.width()) / 2) - OFFSETMENU.left;
         }
         this.layerMenu.colorMenu.show = bool;
-      }
+      },
+
+      /**
+       * Get category style name eventually suffixed by "(default)" string
+       * 
+       * @since 3.8.0
+       */
+      getStyleName(style) {
+        return style.name + (style.name === this.layerMenu.layer.defaultstyle && this.layerMenu.layer.styles.length > 1 ? ` (${t('default')})` : '');
+      },
+
     },
+
     created() {
       CatalogEventHub.$on('showmenulayer', async (layerstree, evt) => {
         this._hideMenu();
@@ -683,7 +693,8 @@
         this.layerMenu.top = $(evt.target).offset().top - $(this.$refs['layer-menu']).height() + ($(evt.target).height()/ 2);
         $('.catalog-menu-wms[data-toggle="tooltip"]').tooltip();
       });
-    }
+    },
+
   };
 </script>
 <style scoped>

--- a/src/components/CatalogLayerContextMenu.vue
+++ b/src/components/CatalogLayerContextMenu.vue
@@ -611,7 +611,8 @@
           const layer = CatalogLayersStoresRegistry.getLayerById(this.layerMenu.layer.id);
           if (layer) {
             CatalogEventHub.$emit('layer-change-style', {
-              layerId
+              layerId,
+              style: this.layerMenu.stylesMenu.style
             });
             layer.change();
           }

--- a/src/components/CatalogLayerLegend.vue
+++ b/src/components/CatalogLayerLegend.vue
@@ -143,10 +143,14 @@
       },
 
       async handlerChangeLegend(options={}) {
+        const {layerId, style} = options;
         if (this.externallegend) {
           return;
         }
-        if (options.layerId === this.layer.id) {
+        if (layerId === this.layer.id) {
+          if ("undefined" !== typeof style) {
+            this.layer.featurecount = await this.getProjectLayer().getStyleFeatureCount(style);
+          }
           await this.setLayerCategories(true);
         }
         if (this.dynamic) {

--- a/src/components/CatalogLayerLegend.vue
+++ b/src/components/CatalogLayerLegend.vue
@@ -48,7 +48,7 @@
         >
           <span>{{category.title}}</span>
           <span v-if="showfeaturecount && 'undefined' !== typeof category.ruleKey" style="font-weight: bold">
-            [{{layer.featurecount[category.ruleKey]}}]
+            [{{layer.stylesfeaturecount[currentstyle][category.ruleKey]}}]
           </span>
         </span>
 
@@ -78,7 +78,8 @@
     },
     data() {
       return {
-        categories: []
+        categories: [],
+        currentstyle: this.layer.styles.find(style => true === style.current).name
       }
     },
     computed: {
@@ -149,7 +150,8 @@
         }
         if (layerId === this.layer.id) {
           if ("undefined" !== typeof style) {
-            this.layer.featurecount = await this.getProjectLayer().getStyleFeatureCount(style);
+            await this.getProjectLayer().getStyleFeatureCount(style);
+            this.currentstyle = style;
           }
           await this.setLayerCategories(true);
         }

--- a/src/components/CatalogLayerLegend.vue
+++ b/src/components/CatalogLayerLegend.vue
@@ -149,11 +149,14 @@
           return;
         }
         if (layerId === this.layer.id) {
-          if ("undefined" !== typeof style) {
-            await this.getProjectLayer().getStyleFeatureCount(style);
-            this.currentstyle = style;
-          }
-          await this.setLayerCategories(true);
+          try {
+            await this.setLayerCategories(true);
+            if ("undefined" !== typeof style) {
+              await this.getProjectLayer().getStyleFeatureCount(style);
+              this.currentstyle = style;
+            }
+          } catch(err) {}
+
         }
         if (this.dynamic) {
           await this.setLayerCategories(false);


### PR DESCRIPTION
Refer to https://github.com/g3w-suite/g3w-admin/pull/517
Improve of https://github.com/g3w-suite/g3w-client/pull/374

Example **buildings** layer: 

## BEFORE

_WRONG_: After changing the style, the displayed values of the first three categories remain the same as the style of the previous category **(3+4+3 != 13)**

![Screenshot from 2023-04-05 15-00-41](https://user-images.githubusercontent.com/1051694/230088312-16387e06-2fc1-436f-9210-de4c0e5709a4.png)


![Screenshot from 2023-04-04 17-01-20](https://user-images.githubusercontent.com/1051694/229834567-6e20c4c4-1c05-4b79-b5c1-1975fc5f7062.png)

## AFTER

_RIGHT_: Now  the feature count of each category feature is correct **(7+2+4 = 13)** 

![Screenshot from 2023-04-05 15-00-41](https://user-images.githubusercontent.com/1051694/230088312-16387e06-2fc1-436f-9210-de4c0e5709a4.png)


![Screenshot from 2023-04-04 14-43-06](https://user-images.githubusercontent.com/1051694/229795212-3ffcd2c7-00f4-41e6-891c-e8ef9c8098b1.png)




