### PR TITLE
Immediately remove query results layer from map (marker, bbox, etc..) when related control is untoggled

### DIFF
--- a/src/app/g3w-ol/controls/basequerypolygoncontrol.js
+++ b/src/app/g3w-ol/controls/basequerypolygoncontrol.js
@@ -29,7 +29,11 @@ const BaseQueryPolygonControl = function(options = {}) {
       type: 'spatialMethod',
       how: 'toggled' // or hover
     },
-    onhover: true
+    onhover: true,
+    /**
+     * @since 3.8.1
+     */
+    queryResultsLayer: true,
   };
 
   options = merge(options, default_options);

--- a/src/app/g3w-ol/controls/interactioncontrol.js
+++ b/src/app/g3w-ol/controls/interactioncontrol.js
@@ -20,7 +20,8 @@ const InteractionControl = function(options={}) {
     toggledTool,
     interactionClassOptions={},
     layers=[],
-    spatialMethod
+    spatialMethod,
+    queryResultsLayer=false,
   } = options;
 
   /**
@@ -77,6 +78,11 @@ const InteractionControl = function(options={}) {
   this.spatialMethod = spatialMethod;
 
   this.toggledTool;
+
+  /**
+   * @since3.8.1
+   */
+  this._queryResultsLayer = queryResultsLayer;
 
   this._interactionClassOptions = interactionClassOptions;
 
@@ -381,6 +387,10 @@ proto.toggle = function(toggled = !this._toggled) {
     this.removeClassToControlBottom('g3w-ol-toggled');
     this._toolButton && this._toolButton.hide();
     this.toggledTool && this.showToggledTool(false);
+    /**
+     * @since 3.8.1
+     */
+    this._queryResultsLayer && GUI.getService('queryresults').clearResultsQueryLayer();
   }
 
   if (undefined === this._toolButton && this.toggledTool) {

--- a/src/app/g3w-ol/controls/interactioncontrol.js
+++ b/src/app/g3w-ol/controls/interactioncontrol.js
@@ -390,7 +390,9 @@ proto.toggle = function(toggled = !this._toggled) {
     /**
      * @since 3.8.1
      */
-    this._queryResultsLayer && GUI.getService('queryresults').clearResultsQueryLayer();
+    if (true === this._queryResultsLayer) {
+      GUI.closeContent();
+    }
   }
 
   if (undefined === this._toolButton && this.toggledTool) {

--- a/src/app/g3w-ol/controls/querybboxcontrol.js
+++ b/src/app/g3w-ol/controls/querybboxcontrol.js
@@ -61,7 +61,11 @@ const QueryBBoxControl = function(options = {}) {
     help: {
       title:"sdk.mapcontrols.querybybbox.help.title",
       message:"sdk.mapcontrols.querybybbox.help.message",
-    }
+    },
+    /**
+     * @since 3.8.1
+     */
+    queryResultsLayer: true,
   };
 
   InteractionControl.call(this, _options);

--- a/src/app/g3w-ol/controls/querycontrol.js
+++ b/src/app/g3w-ol/controls/querycontrol.js
@@ -15,6 +15,10 @@ const QueryControl = function(options = {}){
     label: options.label || "\uea0f",
     clickmap: true, // set ClickMap
     interactionClass: PickCoordinatesInteraction,
+    /**
+     * @since 3.8.1
+     */
+    queryResultsLayer: true,
   };
 
   options = utils.merge(options, _options);
@@ -36,7 +40,7 @@ proto.setMap = function(map) {
 
   this.on('toggled', ({toggled}) => {
 
-    if (true !== toggled) {
+    if (false === toggled) {
       ol.Observable.unByKey(eventSingleClickKey);
       eventSingleClickKey = null;
     } else if (null === eventSingleClickKey && map) {

--- a/src/app/gui/queryresults/queryresultsservice.js
+++ b/src/app/gui/queryresults/queryresultsservice.js
@@ -752,13 +752,21 @@ proto.copyZoomToFidUrl = function(layer, feature, action){
 };
 
 /**
+ * @since 3.8.1
+ */
+
+proto.clearResultsQueryLayer = function(){
+  this.resultsQueryLayer.getSource().clear();
+}
+
+/**
  * Clear all
  */
 proto.clear = function() {
   this.runAsyncTodo();
   this.unlistenerEventsActions();
   this.mapService.clearHighlightGeometry();
-  this.resultsQueryLayer.getSource().clear();
+  this.clearResultsQueryLayer();
   this.removeAddFeaturesLayerResultInteraction({
     toggle: true
   });


### PR DESCRIPTION
Closes: #416 
