### PR TITLE
Ensure setting default value for input fields (editing plugin)

### DIFF
--- a/src/app/gui/inputs/service.js
+++ b/src/app/gui/inputs/service.js
@@ -35,8 +35,7 @@ proto.getValue = function() {
  * @returns {void}
  */
 proto.setValue = function(value) {
-
-  if (null !== value || undefined !== value) {
+  if (null !== value && "undefined" !== typeof value) {
     return;
   }
 


### PR DESCRIPTION
Closes: #424

Before: **value** input is not set

![Screenshot from 2023-06-12 09-40-14](https://github.com/g3w-suite/g3w-client/assets/1051694/4a10895f-8d71-4cff-8621-089057c8e494)


After: **value** input is set to 10

![Screenshot from 2023-06-12 09-39-21](https://github.com/g3w-suite/g3w-client/assets/1051694/123214eb-1371-4336-afbb-e3262693934b)
