### PR TITLE
Prevent showing printing controls for map layers that don't have a source URL (ref: `"geoscreenshot"` and `"screenshot"` map controls)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -36,7 +36,7 @@ body:
      Please provide as much information as possible in order to resolve your issue. Need help? [Find out your version](https://github.com/g3w-suite/g3w-admin#version).
     value: |
      - g3w-admin: __version__
-     - g3-client: __version__
+     - g3w-client: __version__
      - browser: __name__
      - operating system: __name and version (desktop or mobile)__
   validations:

--- a/src/app/api.js
+++ b/src/app/api.js
@@ -269,7 +269,7 @@ module.exports = {
         window.console.info(`
 [g3wsdk.info]\n
 - g3w-admin: __${initConfig.version}__
-- g3-client: __${G3W_CONSTANT.APP_VERSION}__
+- g3w-client: __${G3W_CONSTANT.APP_VERSION}__
 - browser: __${platform.name} ${platform.version}__
 - operating system: __${platform.os.toString()}__
 `.trim());

--- a/src/app/core/layers/layersstoresregistry.js
+++ b/src/app/core/layers/layersstoresregistry.js
@@ -7,14 +7,9 @@ function LayersStoresRegistry() {
   this.storesArray = [];
   // to react some application components that are binding to Layerstore
   this.setters = {
-    addLayersStore(layersStore, idx) {
-      this._addLayersStore(layersStore, idx);
-    },
-    removeLayersStore(layerStore) {
-      this._removeLayersStore(layerStore);
-    },
-    removeLayersStores() {
-      this._removeLayersStores();
+    addLayersStore: this._addLayersStore.bind(this),
+    removeLayersStore: this._removeLayersStore.bind(this),
+    removeLayersStores: this._removeLayersStores.bind(this),
     }
   };
 

--- a/src/app/core/layers/layersstoresregistry.js
+++ b/src/app/core/layers/layersstoresregistry.js
@@ -10,7 +10,6 @@ function LayersStoresRegistry() {
     addLayersStore: this._addLayersStore.bind(this),
     removeLayersStore: this._removeLayersStore.bind(this),
     removeLayersStores: this._removeLayersStores.bind(this),
-    }
   };
 
   base(this);

--- a/src/app/g3w-ol/controls/geoscreenshotcontrol.js
+++ b/src/app/g3w-ol/controls/geoscreenshotcontrol.js
@@ -1,10 +1,12 @@
 const ScreenshotControl = require('g3w-ol/controls/screenshotcontrol');
 
 function GeoScreenshotControl(options = {}) {
-  options.name = "maptoimagegeo";
-  options.tipLabel =  "Geo Screenshot";
-  options.label = "\ue900";
-  ScreenshotControl.call(this, options);
+  ScreenshotControl.call(this, {
+    name: "maptoimagegeo",
+    tipLabel: "Geo Screenshot",
+    label: "\ue900",
+    ...options,
+  });
 }
 
 ol.inherits(GeoScreenshotControl, ScreenshotControl);

--- a/src/app/g3w-ol/controls/screenshotcontrol.js
+++ b/src/app/g3w-ol/controls/screenshotcontrol.js
@@ -34,7 +34,11 @@ proto.change = function(layers=[]){
  * @returns {boolean}
  */
 proto.checkVisible = function(layers=[]) {
-  return undefined === layers.find((layer) => !sameOrigin(layer.getSource && layer.getSource() && layer.getSource().url, location));
+  // get layer.getConfig().source instead of layer.getSource()
+  // because for BaseLayer instance src/app/core/layers/baselayers/baselayer.js,
+  // getSource() return ol.source instance and not source
+  // configuration object
+  return undefined === layers.find((layer) => layer.getConfig().source && layer.getConfig().source.url && !sameOrigin(layer.getConfig().source.url, location));
 };
 
 

--- a/src/app/g3w-ol/controls/screenshotcontrol.js
+++ b/src/app/g3w-ol/controls/screenshotcontrol.js
@@ -1,7 +1,22 @@
 import GUI from 'services/gui';
+
 const { sameOrigin } = require('core/utils/utils');
 const OnClickControl = require('g3w-ol/controls/onclickcontrol');
 
+/**
+ * @FIXME prevent tainted canvas error
+ * 
+ * Because the pixels in a canvas's bitmap can come from a variety of sources,
+ * including images or videos retrieved from other hosts, it's inevitable that
+ * security problems may arise. As soon as you draw into a canvas any data that
+ * was loaded from another origin without CORS approval, the canvas becomes
+ * tainted.
+ * 
+ * A tainted canvas is one which is no longer considered secure, and any attempts
+ * to retrieve image data back from the canvas will cause an exception to be thrown.
+ * 
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image
+ */
 function ScreenshotControl(options = {}) {
   options = {
     name: "maptoimage",
@@ -18,10 +33,11 @@ function ScreenshotControl(options = {}) {
 
   OnClickControl.call(this, options);
 
-  this.isVisible() && GUI.getService('map').onafter('loadExternalLayer', this._addLayer.bind(this));
-  /**
-   * Comment because at 3.8.3 need to be find a way to redraw a map canvas
-   */
+  if (this.isVisible()) {
+    GUI.getService('map').onafter('loadExternalLayer', this._addLayer.bind(this));
+  }
+
+  /** @TODO prevent tainted canvas error  */
   //GUI.getService('map').onafter('unloadExternalLayer', this._removeLayer.bind(this));
 }
 
@@ -33,13 +49,11 @@ const proto = ScreenshotControl.prototype;
  * @since 3.8.3 
  */
 proto._addLayer = function(layer) {
-  // only in case visible otherwise we need to find a solution to redraw map canvas
   if (this.isVisible()) {
     this.layers.push(layer);
     this.change(this.layers);
-    /**
-     * Comment because at 3.8.3 need to be find a way to redraw a map canvas
-     */
+
+    /** @TODO prevent tainted canvas error  */
     //layer.on('change:visible', () => this.change(this.layers));
   }
 };
@@ -48,7 +62,7 @@ proto._addLayer = function(layer) {
  * @since 3.8.3 
  */
 proto._removeLayer = function(layer) {
-  this.layers = this.layers.filter(_layer => _layer !== layer);
+  this.layers = this.layers.filter(l => l !== layer);
   this.change(this.layers);
 };
 

--- a/src/app/g3w-ol/controls/screenshotcontrol.js
+++ b/src/app/g3w-ol/controls/screenshotcontrol.js
@@ -39,7 +39,7 @@ proto._addLayer = function(layer) {
  * @since 3.8.3 
  */
 proto._removeLayer = function(layer) {
-  this.layers = this.layers.filter(_layer => _layer !== layer);
+  this.layers = this.layers.filter(l => l !== layer);
   this.change(this.layers);
 };
 
@@ -61,7 +61,7 @@ proto.change = function(layers = []) {
  * @returns {boolean}
  */
 proto.checkVisible = function(layers = []) {
-  return undefined === layers.find((layer) => {
+  return layers.some((layer) => {
     if (isVectorLayer(layer) || !layer.getVisible()) return;
     const source_url = isImageLayer(layer)
       ? layer.getSource().getUrl()

--- a/src/app/g3w-ol/controls/screenshotcontrol.js
+++ b/src/app/g3w-ol/controls/screenshotcontrol.js
@@ -34,7 +34,7 @@ proto.change = function(layers=[]){
  * @returns {boolean}
  */
 proto.checkVisible = function(layers=[]) {
-  return "undefined" === typeof layers.find((layer) => !sameOrigin(layer.getSource() && layer.getSource().url, location));
+  return undefined === layers.find((layer) => !sameOrigin(layer.getSource() && layer.getSource().url, location));
 };
 
 

--- a/src/app/g3w-ol/controls/screenshotcontrol.js
+++ b/src/app/g3w-ol/controls/screenshotcontrol.js
@@ -32,7 +32,11 @@ proto.change = function(layers=[]){
  * @returns {boolean}
  */
 proto.checkVisible = function(layers=[]) {
-  return undefined === layers.find((layer) => !sameOrigin(layer.getSource() && layer.getSource().url, location));
+  return "undefined" === typeof layers
+    //exclude base layers and layers that have not a source url
+    .filter(layer => !layer.isBaseLayer() && layer.getSource() && layer.getSource().url)
+    .find((layer) => !sameOrigin(layer.getSource().url, location));
 };
+
 
 module.exports = ScreenshotControl;

--- a/src/app/g3w-ol/controls/screenshotcontrol.js
+++ b/src/app/g3w-ol/controls/screenshotcontrol.js
@@ -18,8 +18,11 @@ function ScreenshotControl(options = {}) {
 
   OnClickControl.call(this, options);
 
-  GUI.getService('map').onafter('loadExternalLayer', this._addLayer.bind(this));
-  GUI.getService('map').onafter('unloadExternalLayer', this._removeLayer.bind(this));
+  this.isVisible() && GUI.getService('map').onafter('loadExternalLayer', this._addLayer.bind(this));
+  /**
+   * Comment because at 3.8.3 need to be find a way to redraw a map canvas
+   */
+  //GUI.getService('map').onafter('unloadExternalLayer', this._removeLayer.bind(this));
 }
 
 ol.inherits(ScreenshotControl, OnClickControl);
@@ -30,9 +33,15 @@ const proto = ScreenshotControl.prototype;
  * @since 3.8.3 
  */
 proto._addLayer = function(layer) {
-  this.layers.push(layer);
-  this.change(this.layers);
-  layer.on('change:visible', () => this.change(this.layers));
+  // only in case visible otherwise we need to find a solution to redraw map canvas
+  if (this.isVisible()) {
+    this.layers.push(layer);
+    this.change(this.layers);
+    /**
+     * Comment because at 3.8.3 need to be find a way to redraw a map canvas
+     */
+    //layer.on('change:visible', () => this.change(this.layers));
+  }
 };
 
 /**

--- a/src/app/g3w-ol/controls/screenshotcontrol.js
+++ b/src/app/g3w-ol/controls/screenshotcontrol.js
@@ -33,12 +33,8 @@ function ScreenshotControl(options = {}) {
 
   OnClickControl.call(this, options);
 
-  if (this.isVisible()) {
-    GUI.getService('map').onafter('loadExternalLayer', this._addLayer.bind(this));
-  }
-
-  /** @TODO prevent tainted canvas error  */
-  //GUI.getService('map').onafter('unloadExternalLayer', this._removeLayer.bind(this));
+  GUI.getService('map').onafter('loadExternalLayer', this._addLayer.bind(this));
+  GUI.getService('map').onafter('unloadExternalLayer', this._removeLayer.bind(this));
 }
 
 ol.inherits(ScreenshotControl, OnClickControl);
@@ -49,13 +45,9 @@ const proto = ScreenshotControl.prototype;
  * @since 3.8.3 
  */
 proto._addLayer = function(layer) {
-  if (this.isVisible()) {
-    this.layers.push(layer);
-    this.change(this.layers);
-
-    /** @TODO prevent tainted canvas error  */
-    //layer.on('change:visible', () => this.change(this.layers));
-  }
+  this.layers.push(layer);
+  this.change(this.layers);
+  layer.on('change:visible', () => this.change(this.layers));
 };
 
 /**
@@ -88,7 +80,7 @@ proto.checkVisible = function(layers = []) {
 };
 
 function isCrossOrigin(layer) {
-  if (isVectorLayer(layer)) return;
+  if (isVectorLayer(layer) || (layer.getVisible && !layer.getVisible())) return;
   const source_url = isImageLayer(layer)
     ? layer.getSource().getUrl()
     : layer.getConfig().source && layer.getConfig().source.url;

--- a/src/app/g3w-ol/controls/screenshotcontrol.js
+++ b/src/app/g3w-ol/controls/screenshotcontrol.js
@@ -45,20 +45,22 @@ proto.change = function(layers=[]){
  * @returns {boolean}
  */
 proto.checkVisible = function(layers=[]) {
-  // get layer.getConfig().source instead of layer.getSource()
-  // because for BaseLayer instance src/app/core/layers/baselayers/baselayer.js,
-  // getSource() return ol.source instance and not source
-  // configuration object
   return undefined === layers.find((layer) => {
-    // case wms external layer
-    if (layer instanceof ol.layer.Vector) return;
-    if ((layer instanceof ol.layer.Tile) || (layer instanceof ol.layer.Image)) {
-      return !sameOrigin(layer.getSource().getUrl(), location);
-    } else {
-      // project layer
-      return layer.getConfig().source && layer.getConfig().source.url && !sameOrigin(layer.getConfig().source.url, location)
-    }
+    if (isVectorLayer(layer)) return;
+    const source_url = isImageLayer(layer)
+      ? layer.getSource().getUrl()
+      : layer.getConfig().source && layer.getConfig().source.url;
+    return source_url && !sameOrigin(source_url, location);
   });
 };
+
+function isVectorLayer(layer) {
+  return layer instanceof ol.layer.Vector;
+}
+
+function isImageLayer(layer) {
+  return (layer instanceof ol.layer.Tile || layer instanceof ol.layer.Image);
+}
+
 
 module.exports = ScreenshotControl;

--- a/src/app/g3w-ol/controls/screenshotcontrol.js
+++ b/src/app/g3w-ol/controls/screenshotcontrol.js
@@ -31,12 +31,8 @@ const proto = ScreenshotControl.prototype;
  */
 proto._addLayer = function(layer) {
   this.layers.push(layer);
-  // in case of image layer
-  if (isImageLayer(layer)) {
-    // listen change visibility of layer
-    layer.on('change:visible', () => this.change(this.layers));
-  }
   this.change(this.layers);
+  layer.on('change:visible', () => this.change(this.layers));
 };
 
 /**
@@ -66,8 +62,7 @@ proto.change = function(layers = []) {
  */
 proto.checkVisible = function(layers = []) {
   return undefined === layers.find((layer) => {
-    if (isVectorLayer(layer)) return;
-    if (isImageLayer(layer) && !layer.getVisible()) return;
+    if (isVectorLayer(layer) || !layer.getVisible()) return;
     const source_url = isImageLayer(layer)
       ? layer.getSource().getUrl()
       : layer.getConfig().source && layer.getConfig().source.url;

--- a/src/app/g3w-ol/controls/screenshotcontrol.js
+++ b/src/app/g3w-ol/controls/screenshotcontrol.js
@@ -3,13 +3,18 @@ const { sameOrigin } = require('core/utils/utils');
 const OnClickControl = require('g3w-ol/controls/onclickcontrol');
 
 function ScreenshotControl(options = {}) {
-  this.layers      = options.layers || [];
+  options = {
+    name: "maptoimage",
+    tipLabel: "Screenshot",
+    label: "\ue90f",
+    toggled: false,
+    visible: false,
+    layers: [],
+    ...options
+  };
 
-  options.visible  = this.checkVisible(this.layers);
-  options.name     = options.name || "maptoimage";
-  options.tipLabel = options.tipLabel || "Screenshot";
-  options.label    = options.label || "\ue90f";
-  options.toggled  = false;
+  this.layers     = options.layers;
+  options.visible = this.checkVisible(this.layers);
 
   OnClickControl.call(this, options);
 

--- a/src/app/g3w-ol/controls/screenshotcontrol.js
+++ b/src/app/g3w-ol/controls/screenshotcontrol.js
@@ -34,7 +34,7 @@ proto.change = function(layers=[]){
  * @returns {boolean}
  */
 proto.checkVisible = function(layers=[]) {
-  return undefined === layers.find((layer) => !sameOrigin(layer.getSource() && layer.getSource().url, location));
+  return undefined === layers.find((layer) => !sameOrigin(layer.getSource && layer.getSource() && layer.getSource().url, location));
 };
 
 

--- a/src/app/g3w-ol/controls/screenshotcontrol.js
+++ b/src/app/g3w-ol/controls/screenshotcontrol.js
@@ -51,6 +51,7 @@ proto.checkVisible = function(layers=[]) {
   // configuration object
   return undefined === layers.find((layer) => {
     // case wms external layer
+    if (layer instanceof ol.layer.Vector) return;
     if ((layer instanceof ol.layer.Tile) || (layer instanceof ol.layer.Image)) {
       return !sameOrigin(layer.getSource().getUrl(), location);
     } else {

--- a/src/app/g3w-ol/controls/screenshotcontrol.js
+++ b/src/app/g3w-ol/controls/screenshotcontrol.js
@@ -74,7 +74,7 @@ proto.checkVisible = function(layers = []) {
 };
 
 function isCrossOrigin(layer) {
-  if (isVectorLayer(layer) || (layer.getVisible && !layer.getVisible())) return;
+  if (isVectorLayer(layer)) return;
   const source_url = isImageLayer(layer)
     ? layer.getSource().getUrl()
     : layer.getConfig().source && layer.getConfig().source.url;

--- a/src/app/g3w-ol/controls/screenshotcontrol.js
+++ b/src/app/g3w-ol/controls/screenshotcontrol.js
@@ -62,7 +62,7 @@ proto.change = function(layers = []) {
  */
 proto.checkVisible = function(layers = []) {
   return layers.some((layer) => {
-    if (isVectorLayer(layer) || !layer.getVisible()) return;
+    if (isVectorLayer(layer) || (layer.getVisible && !layer.getVisible())) return;
     const source_url = isImageLayer(layer)
       ? layer.getSource().getUrl()
       : layer.getConfig().source && layer.getConfig().source.url;

--- a/src/app/g3w-ol/controls/screenshotcontrol.js
+++ b/src/app/g3w-ol/controls/screenshotcontrol.js
@@ -39,7 +39,7 @@ proto._addLayer = function(layer) {
  * @since 3.8.3 
  */
 proto._removeLayer = function(layer) {
-  this.layers = this.layers.filter(l => l !== layer);
+  this.layers = this.layers.filter(_layer => _layer !== layer);
   this.change(this.layers);
 };
 
@@ -61,14 +61,16 @@ proto.change = function(layers = []) {
  * @returns {boolean}
  */
 proto.checkVisible = function(layers = []) {
-  return layers.some((layer) => {
-    if (isVectorLayer(layer) || (layer.getVisible && !layer.getVisible())) return;
-    const source_url = isImageLayer(layer)
-      ? layer.getSource().getUrl()
-      : layer.getConfig().source && layer.getConfig().source.url;
-    return source_url && !sameOrigin(source_url, location);
-  });
+  return !layers.some(isCrossOrigin);
 };
+
+function isCrossOrigin(layer) {
+  if (isVectorLayer(layer) || (layer.getVisible && !layer.getVisible())) return;
+  const source_url = isImageLayer(layer)
+    ? layer.getSource().getUrl()
+    : layer.getConfig().source && layer.getConfig().source.url;
+  return source_url && !sameOrigin(source_url, location);
+}
 
 function isVectorLayer(layer) {
   return layer instanceof ol.layer.Vector;
@@ -77,6 +79,5 @@ function isVectorLayer(layer) {
 function isImageLayer(layer) {
   return (layer instanceof ol.layer.Tile || layer instanceof ol.layer.Image);
 }
-
 
 module.exports = ScreenshotControl;

--- a/src/app/g3w-ol/controls/screenshotcontrol.js
+++ b/src/app/g3w-ol/controls/screenshotcontrol.js
@@ -26,6 +26,11 @@ const proto = ScreenshotControl.prototype;
  */
 proto._addLayer = function(layer) {
   this.layers.push(layer);
+  // in case of image layer
+  if (isImageLayer(layer)) {
+    // listen change visibility of layer
+    layer.on('change:visible', () => this.change(this.layers));
+  }
   this.change(this.layers);
 };
 
@@ -57,6 +62,7 @@ proto.change = function(layers = []) {
 proto.checkVisible = function(layers = []) {
   return undefined === layers.find((layer) => {
     if (isVectorLayer(layer)) return;
+    if (isImageLayer(layer) && !layer.getVisible()) return;
     const source_url = isImageLayer(layer)
       ? layer.getSource().getUrl()
       : layer.getConfig().source && layer.getConfig().source.url;

--- a/src/app/g3w-ol/controls/screenshotcontrol.js
+++ b/src/app/g3w-ol/controls/screenshotcontrol.js
@@ -27,15 +27,14 @@ proto.change = function(layers=[]){
  * same origin URL of current application in order to avoid
  * CORS issue while getting map image.
  * 
+ * Layers that don't have a source URL are excluded (eg. base layers)
+ * 
  * @param {array} layers
  * 
  * @returns {boolean}
  */
 proto.checkVisible = function(layers=[]) {
-  return "undefined" === typeof layers
-    //exclude base layers and layers that have not a source url
-    .filter(layer => !layer.isBaseLayer() && layer.getSource() && layer.getSource().url)
-    .find((layer) => !sameOrigin(layer.getSource().url, location));
+  return "undefined" === typeof layers.find((layer) => !sameOrigin(layer.getSource() && layer.getSource().url, location));
 };
 
 

--- a/src/app/gui/map/mapservice.js
+++ b/src/app/gui/map/mapservice.js
@@ -309,25 +309,21 @@ proto.setUpMapOlEvents = function(){
 
 //clear methods to remove all listeners events
 proto.clear = function() {
-  Object.keys(this._keyEvents).forEach(type => {
-    switch(type) {
-      case 'ol':
-        this._keyEvents[type].forEach(keyEvent => ol.Observable.unByKey(keyEvent));
-        break;
-      case 'g3wobject':
-        this._keyEvents[type].forEach(eventObject => {
-          const {who, setter, key} = eventObject;
-          who.un(setter, key);
-        });
-        break;
-      case 'eventemitter':
-        this._keyEvents[type].forEach(eventObject => {
-          const {event, listener } = eventObject;
-          this.removeListener(event, listener);
-        });
-        break;
-    }
-  });
+  Object
+    .keys(this._keyEvents)
+    .forEach(type => {
+      switch(type) {
+        case 'ol':
+          this._keyEvents[type].forEach(key => ol.Observable.unByKey(key));
+          break;
+        case 'g3wobject':
+          this._keyEvents[type].forEach(({ who, setter, key }) => { who.un(setter, key); });
+          break;
+        case 'eventemitter':
+          this._keyEvents[type].forEach(({ event, listener }) => { this.removeListener(event, listener); });
+          break;
+      }
+    });
   this._keyEvents = null;
   MapLayersStoresRegistry.getLayersStores().forEach(this._removeEventsKeysToLayersStore.bind(this))
 };

--- a/src/app/gui/map/mapservice.js
+++ b/src/app/gui/map/mapservice.js
@@ -1550,41 +1550,24 @@ proto._removeListeners = function() {
 };
 
 // remove all events of layersStore
-proto._removeEventsKeysToLayersStore = function(layerStore) {
-  const layerStoreId = layerStore.getId();
-  if (this._layersStoresEventKeys[layerStoreId]) {
-    this._layersStoresEventKeys[layerStoreId].forEach(eventObj => {
-      Object.entries(eventObj).forEach(([event, eventKey]) => layerStore.un(event, eventKey));
-    });
-    delete this._layersStoresEventKeys[layerStoreId];
+proto._removeEventsKeysToLayersStore = function(store) {
+  const id = store.getId();
+  if (this._layersStoresEventKeys[id]) {
+    this._layersStoresEventKeys[id].forEach(evt => { Object.entries(evt).forEach(([event, key]) => store.un(event, key)); });
+    delete this._layersStoresEventKeys[id];
   }
 };
 
 // register all events of layersStore and relative keys
-proto._setUpEventsKeysToLayersStore = function(layerStore) {
-  const layerStoreId = layerStore.getId();
+proto._setUpEventsKeysToLayersStore = function(store) {
+  const id = store.getId();
   // check if already store a key of events
-  this._layersStoresEventKeys[layerStoreId] = [];
-  //ADD LAYER
-  const addLayerKey = layerStore.onafter('addLayer', layer => {
-    if (layer.getType() === 'vector') {
-      const mapLayer = layer.getMapLayer();
-      this.addLayerToMap(mapLayer);
-    }
+  this._layersStoresEventKeys[id] = [];
+  this._layersStoresEventKeys[id].push({
+    addLayer: store.onafter('addLayer', layer => { 'vector' === layer.getType() && this.addLayerToMap(layer.getMapLayer()) }),
   });
-  this._layersStoresEventKeys[layerStoreId].push({
-    addLayer: addLayerKey
-  });
-  // REMOVE LAYER
-  const removeLayerKey = layerStore.onafter('removeLayer',  layer => {
-    if (layer.getType() === 'vector') {
-      const olLayer = layer.getOLLayer();
-      this.viewer.map.removeLayer(olLayer);
-    }
-  });
-
-  this._layersStoresEventKeys[layerStoreId].push({
-    removeLayer: removeLayerKey
+  this._layersStoresEventKeys[id].push({
+    removeLayer: store.onafter('removeLayer', layer => { 'vector' === layer.getType() && this.viewer.map.removeLayer(layer.getOLLayer()) }),
   });
 };
 

--- a/src/app/gui/map/mapservice.js
+++ b/src/app/gui/map/mapservice.js
@@ -602,16 +602,11 @@ proto.showAddLayerModal = function() {
 };
 
 proto._checkMapControls = function() {
-  this._changeMapMapControls.forEach(({control, getLayers}) => {
-    const layers = getLayers();
-    control.change(layers);
-  });
+  this._changeMapMapControls.forEach(({ control, getLayers }) => { control.change(getLayers()); });
 };
 
 proto._setupControls = function() {
-  const baseLayers = getMapLayersByFilter({
-    BASELAYER: true
-  });
+  const baseLayers = getMapLayersByFilter({ BASELAYER: true });
   this.getMapLayers().forEach(mapLayer => mapLayer.getSource().setAttributions(this.getApplicationAttribution()));
   // check if base layer is set. If true add attribution control
   if (this.getApplicationAttribution() || baseLayers.length) {

--- a/src/app/gui/map/mapservice.js
+++ b/src/app/gui/map/mapservice.js
@@ -1564,10 +1564,10 @@ proto._setUpEventsKeysToLayersStore = function(store) {
   // check if already store a key of events
   this._layersStoresEventKeys[id] = [];
   this._layersStoresEventKeys[id].push({
-    addLayer: store.onafter('addLayer', layer => { 'vector' === layer.getType() && this.addLayerToMap(layer.getMapLayer()) }),
+    addLayer: store.onafter('addLayer', l => { 'vector' === l.getType() && this.addLayerToMap(l.getMapLayer()) }),
   });
   this._layersStoresEventKeys[id].push({
-    removeLayer: store.onafter('removeLayer', layer => { 'vector' === layer.getType() && this.viewer.map.removeLayer(layer.getOLLayer()) }),
+    removeLayer: store.onafter('removeLayer', l => { 'vector' === l.getType() && this.viewer.map.removeLayer(l.getOLLayer()) }),
   });
 };
 

--- a/src/app/gui/map/mapservice.js
+++ b/src/app/gui/map/mapservice.js
@@ -278,12 +278,19 @@ function MapService(options={}) {
     listener: extraParamsSet
   });
 
-  this.once('viewerset', () => {
-    // CHECK IF MAPLAYESRSTOREREGISTRY HAS LAYERSTORE
-    MapLayersStoresRegistry.getLayersStores().forEach(this._setUpEventsKeysToLayersStore.bind(this));
-    MapLayersStoresRegistry.onafter('addLayersStore', this._setUpEventsKeysToLayersStore.bind(this));
-    MapLayersStoresRegistry.onafter('removeLayersStore', this._removeEventsKeysToLayersStore.bind(this));
-  });
+  /**
+   * @since 3.8.3
+   * internal promise. Resolved when view is set
+   */
+  this._ready = new Promise((resolve, reject) => {
+    this.once('viewerset', () => {
+      // CHECK IF MAPLAYESRSTOREREGISTRY HAS LAYERSTORE
+      MapLayersStoresRegistry.getLayersStores().forEach(this._setUpEventsKeysToLayersStore.bind(this));
+      MapLayersStoresRegistry.onafter('addLayersStore', this._setUpEventsKeysToLayersStore.bind(this));
+      MapLayersStoresRegistry.onafter('removeLayersStore', this._removeEventsKeysToLayersStore.bind(this));
+      resolve();
+    });
+  })
 
   base(this);
 }
@@ -291,6 +298,14 @@ function MapService(options={}) {
 inherit(MapService, G3WObject);
 
 const proto = MapService.prototype;
+
+/**
+ * @since 3.8.3
+ * return promise ready
+ */
+proto.isReady = function(){
+  return this._ready;
+};
 
 proto.setUpMapOlEvents = function() {
   const dynamicLegend = this.project.getContextBaseLegend();

--- a/src/app/gui/map/mapservice.js
+++ b/src/app/gui/map/mapservice.js
@@ -412,8 +412,6 @@ proto.createMapImage = function({map, background} = {}) {
       else canvas.toBlob(blob => resolve(blob));
     } catch (err) {
       reject(err);
-      // TODO ??
-      // throw err;
     }
   })
 };

--- a/src/app/gui/map/mapservice.js
+++ b/src/app/gui/map/mapservice.js
@@ -396,7 +396,6 @@ proto.createMapImage = function({map, background} = {}) {
       else canvas.toBlob(blob => resolve(blob));
     } catch (err) {
       reject(err);
-      
       // TODO ??
       // throw err;
     }
@@ -2639,11 +2638,10 @@ proto._handlePrint = async function(controlType) {
       );
     }
   } catch (err) {
-    console.warn(err)
     GUI.showUserMessage({
-      type: 'alert',
-      message: t("mapcontrols.screenshot.error"),
-      autoclose: true
+      type: 'SecurityError' === err.name ? 'warning' : 'alert',
+      message: 'SecurityError' === err.name ? 'mapcontrols.screenshot.securityError' : 'mapcontrols.screenshot.error',
+      autoclose: false
     });
   }
   // End download

--- a/src/app/gui/map/mapservice.js
+++ b/src/app/gui/map/mapservice.js
@@ -73,6 +73,21 @@ function MapService(options={}) {
     mapunits: ['metric']
   };
   this.id = 'MapService';
+
+  /**
+   * @since 3.8.3
+   * internal promise. Resolved when view is set
+   */
+  this._ready = new Promise((resolve, reject) => {
+    this.once('viewerset', () => {
+      // CHECK IF MAPLAYESRSTOREREGISTRY HAS LAYERSTORE
+      MapLayersStoresRegistry.getLayersStores().forEach(this._setUpEventsKeysToLayersStore.bind(this));
+      MapLayersStoresRegistry.onafter('addLayersStore', this._setUpEventsKeysToLayersStore.bind(this));
+      MapLayersStoresRegistry.onafter('removeLayersStore', this._removeEventsKeysToLayersStore.bind(this));
+      resolve();
+    });
+  })
+
   this.viewer = null;
   this.target = options.target || null;
   this.layersCount = 0; // useful to set Zindex to layer order on map
@@ -277,20 +292,6 @@ function MapService(options={}) {
     event: 'extraParamsSet',
     listener: extraParamsSet
   });
-
-  /**
-   * @since 3.8.3
-   * internal promise. Resolved when view is set
-   */
-  this._ready = new Promise((resolve, reject) => {
-    this.once('viewerset', () => {
-      // CHECK IF MAPLAYESRSTOREREGISTRY HAS LAYERSTORE
-      MapLayersStoresRegistry.getLayersStores().forEach(this._setUpEventsKeysToLayersStore.bind(this));
-      MapLayersStoresRegistry.onafter('addLayersStore', this._setUpEventsKeysToLayersStore.bind(this));
-      MapLayersStoresRegistry.onafter('removeLayersStore', this._removeEventsKeysToLayersStore.bind(this));
-      resolve();
-    });
-  })
 
   base(this);
 }

--- a/src/app/gui/map/mapservice.js
+++ b/src/app/gui/map/mapservice.js
@@ -396,6 +396,9 @@ proto.createMapImage = function({map, background} = {}) {
       else canvas.toBlob(blob => resolve(blob));
     } catch (err) {
       reject(err);
+      
+      // TODO ??
+      // throw err;
     }
   })
 };
@@ -2513,11 +2516,13 @@ proto.addExternalLayer = async function(externalLayer, options={}) {
   }
 
   const loadExternalLayer = (layer, type) => {
-    let extent;
     // skip if is not a valid layer
     if (!layer) {
       return Promise.reject();
     }
+
+    let extent;
+
     if (type === 'vector') {
       const features = layer.getSource().getFeatures();
       if (features.length) {
@@ -2530,16 +2535,23 @@ proto.addExternalLayer = async function(externalLayer, options={}) {
       extent = layer.getSource().getExtent();
       externalLayer.bbox = { minx: extent[0], miny: extent[1], maxx: extent[2], maxy: extent[3] };
     }
+
     layer.set('position', position);
     layer.setOpacity(opacity);
     layer.setVisible(visible);
+
     map.addLayer(layer);
+
     this._externalLayers.push(layer);
+
     QueryResultService.registerVectorLayer(layer);
+
     catalogService.addExternalLayer({ layer: externalLayer, type });
+
     if (extent) {
       map.getView().fit(extent);
     }
+
     this.loadExternalLayer(layer);
 
     return Promise.resolve(layer);
@@ -2627,12 +2639,12 @@ proto._handlePrint = async function(controlType) {
       );
     }
   } catch (err) {
+    console.warn(err)
     GUI.showUserMessage({
       type: 'alert',
       message: t("mapcontrols.screenshot.error"),
       autoclose: true
     });
-    console.warn(err)
   }
   // End download
   ApplicationService.setDownload(false, download_id);

--- a/src/app/gui/map/mapservice.js
+++ b/src/app/gui/map/mapservice.js
@@ -278,19 +278,11 @@ function MapService(options={}) {
     listener: extraParamsSet
   });
 
-  this.once('viewerset', ()=> {
-    //CHECK IF MAPLAYESRSTOREREGISTRY HAS LAYERSTORE
-    MapLayersStoresRegistry.getLayersStores().forEach(layersStore => {
-      this._setUpEventsKeysToLayersStore(layersStore);
-    });
-    // LISTEN ON EVERY ADDED LAYERSSTORE
-    MapLayersStoresRegistry.onafter('addLayersStore', layersStore => {
-      this._setUpEventsKeysToLayersStore(layersStore);
-    });
-    // LISTENER ON REMOVE LAYERSTORE
-    MapLayersStoresRegistry.onafter('removeLayersStore', layerStore => {
-      this._removeEventsKeysToLayersStore(layerStore);
-    });
+  this.once('viewerset', () => {
+    // CHECK IF MAPLAYESRSTOREREGISTRY HAS LAYERSTORE
+    MapLayersStoresRegistry.getLayersStores().forEach(this._setUpEventsKeysToLayersStore.bind(this));
+    MapLayersStoresRegistry.onafter('addLayersStore', this._setUpEventsKeysToLayersStore.bind(this));
+    MapLayersStoresRegistry.onafter('removeLayersStore', this._removeEventsKeysToLayersStore.bind(this));
   });
 
   base(this);
@@ -337,9 +329,7 @@ proto.clear = function() {
     }
   });
   this._keyEvents = null;
-  MapLayersStoresRegistry.getLayersStores().forEach(layerStore => {
-    this._removeEventsKeysToLayersStore(layerStore);
-  })
+  MapLayersStoresRegistry.getLayersStores().forEach(this._removeEventsKeysToLayersStore.bind(this))
 };
 
 proto.showMapSpinner = function(){

--- a/src/app/gui/map/mapservice.js
+++ b/src/app/gui/map/mapservice.js
@@ -161,7 +161,7 @@ function MapService(options={}) {
 
   this._decrementLoaders = () => {
     this._howManyAreLoading -= 1;
-    if (this._howManyAreLoading === 0){
+    if (this._howManyAreLoading === 0) {
       this.emit('loadend');
       GUI.hideSpinner('maploadspinner');
     }
@@ -214,7 +214,7 @@ function MapService(options={}) {
     }
   };
   this.setters = {
-    setupControls(){
+    setupControls() {
       return this._setupControls()
     },
     addHideMap({ratio, layers=[], mainview=false, switchable=false} = {}) {
@@ -252,8 +252,8 @@ function MapService(options={}) {
       this.emit('viewerset');
     },
     controlClick(mapcontrol, info={}) {},
-    loadExternalLayer(layer){}, // used in general to alert external layer is  loaded
-    unloadExternalLayer(layer){}
+    loadExternalLayer(layer) {}, // used in general to alert external layer is  loaded
+    unloadExternalLayer(layer) {}
   };
 
   this._onCatalogSelectLayer = function(layer) {
@@ -292,7 +292,7 @@ inherit(MapService, G3WObject);
 
 const proto = MapService.prototype;
 
-proto.setUpMapOlEvents = function(){
+proto.setUpMapOlEvents = function() {
   const dynamicLegend = this.project.getContextBaseLegend();
   // set change resolution
   this._keyEvents.ol.forEach(keyEvent => ol.Observable.unByKey(keyEvent));
@@ -328,7 +328,7 @@ proto.clear = function() {
   MapLayersStoresRegistry.getLayersStores().forEach(this._removeEventsKeysToLayersStore.bind(this))
 };
 
-proto.showMapSpinner = function(){
+proto.showMapSpinner = function() {
   GUI.showSpinner({
     container: $('#map-spinner'),
     id: 'maploadspinner',
@@ -336,7 +336,7 @@ proto.showMapSpinner = function(){
   });
 };
 
-proto.hideMapSpinner = function(){
+proto.hideMapSpinner = function() {
   GUI.hideSpinner('maploadspinner')
 };
 
@@ -376,7 +376,7 @@ proto._addHideMap = function({ratio, layers=[], mainview=false} = {}) {
 proto.removeHideMap = function(id) {
   let index;
   for (let i = 0; i < this.state.hidemaps.length; i++) {
-    if (id === this.state.hidemaps[i].id){
+    if (id === this.state.hidemaps[i].id) {
       index = i;
       break;
     }
@@ -411,7 +411,7 @@ proto.slaveOf = function(mapService, sameLayers) {
   sameLayers = sameLayers || false;
 };
 
-proto.setLayersExtraParams = function(params,update){
+proto.setLayersExtraParams = function(params,update) {
   this.layersExtraParams = _.assign(this.layersExtraParams, params);
   this.emit('extraParamsSet',params,update);
 };
@@ -435,7 +435,7 @@ proto.getProjection = function() {
   return this.project.getProjection();
 };
 
-proto.isMapHidden = function(){
+proto.isMapHidden = function() {
   return this.state.hidden;
 };
 
@@ -447,11 +447,11 @@ proto.getCrs = function() {
   return this.getProjection().getCode();
 };
 
-proto.getViewerElement = function(){
+proto.getViewerElement = function() {
   return this.viewer.map.getTargetElement();
 };
 
-proto.getViewport = function(){
+proto.getViewport = function() {
   return this.viewer.map.getViewport();
 };
 
@@ -586,11 +586,11 @@ proto.createMapControl = function(type, {id, add=true, toggled=false, visible, o
 };
 
 
-proto.addScaleLineUnits = function(units=[]){
+proto.addScaleLineUnits = function(units=[]) {
   units.forEach(unit => this.state.mapunits.push(unit));
 };
 
-proto.changeScaleLineUnit = function(unit){
+proto.changeScaleLineUnit = function(unit) {
   const scalelinecontrol = this.getMapControlByType({
     type: 'scaleline'
   });
@@ -601,7 +601,7 @@ proto.showAddLayerModal = function() {
   this.emit('addexternallayer');
 };
 
-proto._checkMapControls = function(){
+proto._checkMapControls = function() {
   this._changeMapMapControls.forEach(({control, getLayers}) => {
     const layers = getLayers();
     control.change(layers);
@@ -765,7 +765,7 @@ proto._setupControls = function() {
                 });
                 const view = new ol.View(viewOptions);
                 const mainView = this.getMap().getView();
-                view.on('change:center', function(){
+                view.on('change:center', function() {
                   const currentCenter = this.getCenter();
                   const center = mainView.constrainCenter(currentCenter);
                   center[0] !== currentCenter[0] || center[1] !== currentCenter[1] && view.setCenter(center);
@@ -861,7 +861,7 @@ proto._setupControls = function() {
 /**
  *  Set ZIndex layer from fa stack
  */
-proto.setZIndexLayer = function({layer, zindex=this.getMap().getLayers().getLength()}={}){
+proto.setZIndexLayer = function({layer, zindex=this.getMap().getLayers().getLength()}={}) {
   layer && layer.setZIndex(zindex);
 };
 
@@ -869,11 +869,11 @@ proto.setZIndexLayer = function({layer, zindex=this.getMap().getLayers().getLeng
  *
  * Get map stack layer position
  */
-proto.getLayerZindex = function(layer){
+proto.getLayerZindex = function(layer) {
   return layer && layer.getZIndex();
 };
 
-proto.getCenter = function(){
+proto.getCenter = function() {
   const map = this.getMap();
   return map.getView().getCenter();
 };
@@ -882,9 +882,9 @@ proto.getCenter = function(){
  *
  *method to zoom to feature
  */
-proto.zoomToFid = async function(zoom_to_fid='', separator='|'){
+proto.zoomToFid = async function(zoom_to_fid='', separator='|') {
   const [layerId, fid] = zoom_to_fid.split(separator);
-  if (layerId !== undefined && fid !== undefined){
+  if (layerId !== undefined && fid !== undefined) {
     const layer = this.project.getLayerById(layerId);
     const {data=[]}= await DataRouterService.getData('search:fids', {
       inputs: {
@@ -894,7 +894,7 @@ proto.zoomToFid = async function(zoom_to_fid='', separator='|'){
       outputs: {
         show: {
           loading: false,
-          condition({data=[]}={}){
+          condition({data=[]}={}) {
             return data[0] && data[0].features.length > 0;
           }
         }
@@ -940,12 +940,12 @@ proto.handleZoomToFeaturesUrlParameter = async function({zoom_to_features='', se
         data && data[0] && data[0].features && this.zoomToFeatures(data[0].features)
       }
     }
-  } catch(err){
+  } catch(err) {
     console.log(err)
   }
 };
 
-proto.getMapExtent = function(){
+proto.getMapExtent = function() {
   const map = this.getMap();
   return map.getView().calculateExtent(map.getSize());
 };
@@ -969,14 +969,14 @@ proto.addMapExtentUrlParameterToUrl = function(url, epsg) {
   return url.toString()
 };
 
-proto.getMapExtentUrl = function(){
+proto.getMapExtentUrl = function() {
   const url = new URL(location.href);
   const map_extent = this.getMapExtent().toString();
   url.searchParams.set('map_extent', map_extent);
   return url.toString()
 };
 
-proto.createCopyMapExtentUrl = function(){
+proto.createCopyMapExtentUrl = function() {
   const url = this.getMapExtentUrl();
   copyUrl(url);
 };
@@ -1193,7 +1193,7 @@ proto.addControl = function(id, type, control, addToMapControls=true, visible=tr
     trigger : GUI.isMobile() ? 'click': 'hover'
   });
   // in case of mobile hide tooltip after click
-  GUI.isMobile() && buttonControl.on('shown.bs.tooltip', function(){
+  GUI.isMobile() && buttonControl.on('shown.bs.tooltip', function() {
     setTimeout(()=>$(this).tooltip('hide'), 600);
   });
   if (addToMapControls) this._addControlToMapControls(control, visible);
@@ -1305,7 +1305,7 @@ proto.deactiveMapControls = function() {
  *
  * Method to disable
  */
-proto.disableClickMapControls = function(bool=true){
+proto.disableClickMapControls = function(bool=true) {
   this._mapControls.forEach(controlObj => {
     const {control} = controlObj;
     const clickmap = control.isClickMap ? control.isClickMap() : false;
@@ -1320,7 +1320,7 @@ proto.addMapLayers = function(mapLayers) {
   mapLayers.reverse().forEach(mapLayer => this.addMapLayer(mapLayer));
 };
 
-proto._setupCustomMapParamsToLegendUrl = function(bool=true){
+proto._setupCustomMapParamsToLegendUrl = function(bool=true) {
   if (bool) {
     const map = this.getMap();
     const size = map && map.getSize().filter(value => value > 0) || null;
@@ -1345,7 +1345,7 @@ proto.addMapLayer = function(mapLayer) {
   this.addLayerToMap(mapLayer)
 };
 
-proto.getMapLayerByLayerId = function(layerId){
+proto.getMapLayerByLayerId = function(layerId) {
   return this.getMapLayers().find(mapLayer => {
     return mapLayer.getLayerConfigs().find(layer => layer.getId() === layerId);
   })
@@ -1370,7 +1370,7 @@ proto.getProjectLayer = function(layerId) {
   return MapLayersStoresRegistry.getLayerById(layerId);
 };
 
-proto._setSettings = function(){
+proto._setSettings = function() {
   const {ZOOM} = MAP_SETTINGS;
   const maxScale = this.getScaleFromExtent(this.project.state.initextent);
   // settings maxScale
@@ -1547,7 +1547,7 @@ proto._setupAllLayers = function() {
 };
 
 //SETUP BASELAYERS
-proto._setupBaseLayers = function(){
+proto._setupBaseLayers = function() {
   const baseLayers = getMapLayersByFilter({
     BASELAYER: true
   });
@@ -1577,7 +1577,7 @@ proto._setupMapLayers = function() {
   let qtimeseries_multilayerid_split_values = {};
   const multiLayers = _.groupBy(layers, layer => {
     let multiLayerId = layer.getMultiLayerId();
-    if (layer.isQtimeseries()){
+    if (layer.isQtimeseries()) {
       qtimeseries_multilayerid_split_values[multiLayerId] = qtimeseries_multilayerid_split_values[multiLayerId] === undefined ? 0 : qtimeseries_multilayerid_split_values[multiLayerId] + 1;
       multiLayerId = `${multiLayerId}_${qtimeseries_multilayerid_split_values[multiLayerId]}`;
     } else multiLayerId = qtimeseries_multilayerid_split_values[multiLayerId] === undefined ?
@@ -1628,7 +1628,7 @@ proto._setupVectorLayers = function() {
   })
 };
 
-proto._setUpDefaultLayers = function(){
+proto._setUpDefaultLayers = function() {
   // follow the order that i want
   this.getMap().addLayer(this.defaultsLayers.highlightLayer);
   this.getMap().addLayer(this.defaultsLayers.selectionLayer);
@@ -1638,7 +1638,7 @@ proto._setUpDefaultLayers = function(){
  * Method to set Default layers (selectionLayer, and highlightLayer)
  * always on top of layers stack of map to be always visible
  */
-proto.moveDefaultLayersOnTop = function(zindex){
+proto.moveDefaultLayersOnTop = function(zindex) {
   this.setZIndexLayer({
     layer: this.defaultsLayers.highlightLayer,
     zindex: zindex+1
@@ -1649,18 +1649,18 @@ proto.moveDefaultLayersOnTop = function(zindex){
   });
 };
 
-proto.removeDefaultLayers = function(){
+proto.removeDefaultLayers = function() {
   this.defaultsLayers.highlightLayer.getSource().clear();
   this.defaultsLayers.selectionLayer.getSource().clear();
   this.getMap().removeLayer(this.defaultsLayers.highlightLayer);
   this.getMap().removeLayer(this.defaultsLayers.selectionLayer);
 };
 
-proto.setDefaultLayerStyle = function(type, style={}){
+proto.setDefaultLayerStyle = function(type, style={}) {
   if (type && this.defaultsLayers[type]) this.defaultsLayers._style[type] = style;
 };
 
-proto.resetDefaultLayerStyle = function(type, style={}){
+proto.resetDefaultLayerStyle = function(type, style={}) {
   if (type && this.defaultsLayers[type]) this.defaultsLayers._style[type] = {
     color: type === 'highlightLayer' ? undefined : 'red'
   };
@@ -1673,12 +1673,12 @@ proto.removeLayers = function() {
   this.removeDefaultLayers();
 };
 
-proto.removeAllLayers = function(){
+proto.removeAllLayers = function() {
   this.viewer.removeLayers();
 };
 
 //set ad increase layerIndex
-proto.setLayerZIndex = function({layer, zindex=this.layersCount+=1}){
+proto.setLayerZIndex = function({layer, zindex=this.layersCount+=1}) {
   layer.setZIndex(zindex);
   return zindex;
 };
@@ -1802,7 +1802,7 @@ proto.setTarget = function(elId) {
   this.target = elId;
 };
 
-proto.getCurrentToggledMapControl = function(){
+proto.getCurrentToggledMapControl = function() {
   const mapControl = this._mapControls.find(({control}) => control && control.isToggled && control.isToggled());
   return mapControl && mapControl.control;
 };
@@ -1855,7 +1855,7 @@ proto.showMapInfo = function({info, style} = {}) {
   this.state.map_info.style = style || this.state.map_info.style;
 };
 
-proto.hideMapInfo = function(){
+proto.hideMapInfo = function() {
   this.state.map_info.info = null;
   this.state.map_info.style = null;
 };
@@ -1871,13 +1871,13 @@ proto.goTo = function(coordinates,zoom) {
   this.viewer.goTo(coordinates, options);
 };
 
-proto.goToRes = function(coordinates, resolution){
+proto.goToRes = function(coordinates, resolution) {
   this.viewer.goToRes(coordinates, {
     resolution
   });
 };
 
-proto.getGeometryAndExtentFromFeatures = function(features=[]){
+proto.getGeometryAndExtentFromFeatures = function(features=[]) {
   let extent;
   let geometryType;
   let geometry;
@@ -1908,14 +1908,14 @@ proto.getGeometryAndExtentFromFeatures = function(features=[]){
     const olClassGeomType = geometryType.includes('Multi') ? geometryType : `Multi${geometryType}`;
     geometry = new ol.geom[olClassGeomType](geometryCoordinates);
     if (extent === undefined) extent = geometry.getExtent();
-  } catch(err){}
+  } catch(err) {}
   return {
     extent,
     geometry
   }
 };
 
-proto.highlightFeatures = function(features, options={}){
+proto.highlightFeatures = function(features, options={}) {
   const {geometry} = this.getGeometryAndExtentFromFeatures(features);
   //force zoom false
   options.zoom = false;
@@ -1926,7 +1926,7 @@ proto.highlightFeatures = function(features, options={}){
  * Zoom methods
  */
 
-proto.zoomToGeometry = function(geometry, options={highlight: false}){
+proto.zoomToGeometry = function(geometry, options={highlight: false}) {
   const extent = geometry && geometry.getExtent();
   const {highlight} = options;
   if (highlight && extent) options.highLightGeometry = geometry;
@@ -1956,7 +1956,7 @@ proto.zoomToExtent = function(extent, options={}) {
   return Promise.resolve();
 };
 
-proto.zoomToProjectInitExtent = function(){
+proto.zoomToProjectInitExtent = function() {
   this.zoomToExtent(this.project.state.initextent);
 };
 
@@ -1964,7 +1964,7 @@ proto.zoomToProjectInitExtent = function(){
  * End zoom methods
  */
 
-proto.compareExtentWithProjectMaxExtent = function(extent){
+proto.compareExtentWithProjectMaxExtent = function(extent) {
   const projectExtent = this.project.state.extent;
   const inside = ol.extent.containsExtent(projectExtent, extent);
   return inside ? extent : projectExtent;
@@ -1975,7 +1975,7 @@ proto.compareExtentWithProjectMaxExtent = function(extent){
  * @param   {{ force?: boolean }} [options] if force is undefined calculate `resolution` from given `extent`
  * @returns {number} resolution (in pixels?)
  */
-proto.getResolutionForZoomToExtent = function(extent, options={force:false}){
+proto.getResolutionForZoomToExtent = function(extent, options={force:false}) {
   const map = this.getMap();
 
   // if outside project extent, return max resolution
@@ -2004,12 +2004,12 @@ proto.goToBBox = function(bbox, epsg=this.getEpsg()) {
   this.viewer.fit(this.compareExtentWithProjectMaxExtent(bbox));
 };
 
-proto.goToWGS84 = function(coordinates,zoom){
+proto.goToWGS84 = function(coordinates,zoom) {
   coordinates = ol.proj.transform(coordinates,'EPSG:4326',this.project.state.crs.epsg);
   this.goTo(coordinates,zoom);
 };
 
-proto.extentToWGS84 = function(extent){
+proto.extentToWGS84 = function(extent) {
   return ol.proj.transformExtent(extent,this.project.state.crs.epsg,'EPSG:4326');
 };
 
@@ -2027,7 +2027,7 @@ let animatingHighlight = false;
 *                             clear: remove selectionLayer
 *                             remove: remove feature from selection layer. If no more feature are in selectionLayer it will be removed
 * */
-proto.setSelectionFeatures = function(action='add', options={}){
+proto.setSelectionFeatures = function(action='add', options={}) {
   const {feature, color} = options;
   color && this.setDefaultLayerStyle('selectionLayer', {
     color
@@ -2051,7 +2051,7 @@ proto.setSelectionFeatures = function(action='add', options={}){
   }
 };
 
-proto.clearSelectionFeatures = function(){
+proto.clearSelectionFeatures = function() {
   this.defaultsLayers.selectionLayer.getSource().clear();
 };
 
@@ -2070,7 +2070,7 @@ proto.highlightGeometry = function(geometryObj, options = {}) {
     let hide = options.hide;
     if (hide) hide = typeof hide === 'function' ? hide: null;
     const customStyle = options.style;
-    const defaultStyle = function(feature){
+    const defaultStyle = function(feature) {
       let styles = [];
       const geometryType = feature.getGeometry().getType();
       const style = createSelectedStyle({
@@ -2157,7 +2157,7 @@ proto.layout = function({width, height}) {
 };
 
 //remove BaseLayers
-proto._removeBaseLayers = function(){
+proto._removeBaseLayers = function() {
   Object.keys(this.mapBaseLayers).forEach(baseLayerId=>{
     this.viewer.map.removeLayer(this.mapBaseLayers[baseLayerId].getOLLayer())
   })
@@ -2309,7 +2309,7 @@ proto.stopDrawGreyCover = function() {
   map.render();
 };
 
-proto.removeExternalLayers = function(){
+proto.removeExternalLayers = function() {
   this._externalLayers.forEach(layer =>{
     const name = layer.get('name');
     this.removeExternalLayer(name);
@@ -2317,7 +2317,7 @@ proto.removeExternalLayers = function(){
   this._externalLayers = [];
 };
 
-proto.changeLayerVisibility = function({id, external=false, visible}){
+proto.changeLayerVisibility = function({id, external=false, visible}) {
   const layer = this.getLayerById(id);
   if (layer) {
     layer.setVisible(visible);
@@ -2326,15 +2326,15 @@ proto.changeLayerVisibility = function({id, external=false, visible}){
 
 };
 
-proto.changeLayerOpacity = function({id, opacity=1}={}){
+proto.changeLayerOpacity = function({id, opacity=1}={}) {
   const layer = this.getLayerById(id);
   layer && layer.setOpacity(opacity);
   this.emit('change-layer-opacity', {id, opacity});
 };
 
-proto.changeLayerMapPosition = function({id, position=MAP_SETTINGS.LAYER_POSITIONS.default}){
+proto.changeLayerMapPosition = function({id, position=MAP_SETTINGS.LAYER_POSITIONS.default}) {
   const layer = this.getLayerById(id);
-  switch(position){
+  switch(position) {
     case 'top':
       layer.setZIndex(this.layersCount);
       break;
@@ -2378,7 +2378,7 @@ proto.removeExternalLayer = function(name) {
  * @param position
  * @returns {Promise<unknown>}
  */
-proto.addExternalWMSLayer = function({url, layers, name, epsg=this.getEpsg(), position=MAP_SETTINGS.LAYER_POSITIONS.default, opacity, visible=true}={}){
+proto.addExternalWMSLayer = function({url, layers, name, epsg=this.getEpsg(), position=MAP_SETTINGS.LAYER_POSITIONS.default, opacity, visible=true}={}) {
   const projection = ol.proj.get(epsg);
   return new Promise((resolve, reject) =>{
     const {wmslayer, olLayer} = createWMSLayer({
@@ -2417,11 +2417,11 @@ proto.addExternalWMSLayer = function({url, layers, name, epsg=this.getEpsg(), po
  * Return extanla layers added to map
  * @returns {[]|*[]|T[]}
  */
-proto.getExternalLayers = function(){
+proto.getExternalLayers = function() {
   return this._externalLayers;
 };
 
-proto.addExternalMapLayer = function(externalMapLayer, projectLayer=false){
+proto.addExternalMapLayer = function(externalMapLayer, projectLayer=false) {
   this._externalMapLayers.push(externalMapLayer);
   this.registerMapLayerListeners(externalMapLayer, projectLayer);
 };

--- a/src/app/gui/map/mapservice.js
+++ b/src/app/gui/map/mapservice.js
@@ -715,7 +715,7 @@ proto._setupControls = function() {
           if (!isMobile.any ) {
             control = this.createMapControl(controlType, {
               options: {
-                layers: MapLayersStoresRegistry.getLayers(),
+                layers: [...MapLayersStoresRegistry.getLayers(), ...this._externalLayers],
                 onclick: async () => {
                   // Start download show Image
                   const caller_download_id = ApplicationService.setDownload(true);
@@ -2627,6 +2627,7 @@ proto.addExternalLayer = async function(externalLayer, options={}) {
       map.getView().fit(extent);
     }
     this.loadExternalLayer(layer);
+
     return Promise.resolve(layer);
   };
 

--- a/src/app/gui/wms/service.js
+++ b/src/app/gui/wms/service.js
@@ -15,12 +15,16 @@ function Service(options={}){
     adminwmsurls: wmsurls, // coming from admin wmsurls
     localwmsurls: [] // contain array of object {id, url}
   };
-  this.loadClientWmsUrls()
-    .then(urls => this.state.localwmsurls = urls);
+
+  GUI.isReady().then(()=> {
+    GUI.getService('map').isReady().then(async ()=>{
+      this.state.localwmsurls = await this.loadClientWmsUrls();
+    })
+  })
+
   ProjectsRegistry.onafter('setCurrentProject', async project => {
     this.projectId = project.getId();
     this.state.adminwmsurls = project.wmsurls || [];
-    this.state.localwmsurls = await this.loadClientWmsUrls();
   })
 }
 

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -512,15 +512,13 @@ export default {
       screenshot: {
         error: "Screenshot Fehlererstellung",
         securityError: `  
-         [<span style="font-weight: bold">securityError</span>] An external layer is preventing the map from being printed.<br>
-          To check, proceed as follows:
-          <ol>
-            <li>remove any manually added external layers (eg. WMS layers)</li>
-            <li>reload the page (CTRL + F5)</li>
-            <li>print again the map</li>
-          </ol>
-          If the error persists please contact the server administrator.<br>
-          For more info: <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image">security and tainted canvases</a>
+        <p><b>Sicherheitsfehler</b>: Eine externe Ebene verhindert, dass die Karte gedruckt wird. Gehen Sie zur Überprüfung wie folgt vor:</p>
+        <ol>
+          <li>Entfernen Sie alle manuell hinzugefügten externen Ebenen (z. B. WMS-Ebenen)</li>
+          <li>Neuladen der Seite erzwingen: <code>STRG + F5</code></li>
+          <li>Drucken Sie die Karte erneut</li>
+        </ol>
+        <p>Für weitere Informationen wenden Sie sich bitte an den Serveradministrator zu: <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image" style="color: #000 !important;font -weight: fett;">&#x2139;&#xFE0F; Sicherheit und befleckte Leinwände</a></p>
         `
       }
     },

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -510,7 +510,18 @@ export default {
         tooltip: "Area"
       },
       screenshot: {
-        error: "Screenshot Fehlererstellung"
+        error: "Screenshot Fehlererstellung",
+        securityError: `  
+         [<span style="font-weight: bold">securityError</span>] An external layer is preventing the map from being printed.<br>
+          To check, proceed as follows:
+          <ol>
+            <li>remove any manually added external layers (eg. WMS layers)</li>
+            <li>reload the page (CTRL + F5)</li>
+            <li>print again the map</li>
+          </ol>
+          If the error persists please contact the server administrator.<br>
+          For more info: <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image">security and tainted canvases</a>
+        `
       }
     },
     catalog_items: {

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -512,15 +512,13 @@ export default {
       screenshot: {
         error: "Screenshot error creation",
         securityError: `  
-         [<span style="font-weight: bold">securityError</span>] An external layer is preventing the map from being printed.<br>
-          To check, proceed as follows:
-          <ol>
-            <li>remove any manually added external layers (eg. WMS layers)</li>
-            <li>reload the page (CTRL + F5)</li>
-            <li>print again the map</li>
-          </ol>
-          If the error persists please contact the server administrator.<br>
-          For more info: <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image">security and tainted canvases</a>
+        <p><b>Security Error</b>: an external layer is preventing map from being printed. To check, proceed as follows:</p>
+        <ol>
+          <li>remove any manually added external layers (eg. WMS layers)</li>
+          <li>force page reload: <code>CTRL + F5</code></li>
+          <li>print again the map</li>
+        </ol>
+        <p>For more info please contact server administrator about: <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image" style="color: #000 !important;font-weight: bold;">&#x2139;&#xFE0F; security and tainted canvases</a></p>
         `
       }
     },

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -510,7 +510,18 @@ export default {
         tooltip: "Area"
       },
       screenshot: {
-        error: "Screenshot error creation"
+        error: "Screenshot error creation",
+        securityError: `  
+         [<span style="font-weight: bold">securityError</span>] An external layer is preventing the map from being printed.<br>
+          To check, proceed as follows:
+          <ol>
+            <li>remove any manually added external layers (eg. WMS layers)</li>
+            <li>reload the page (CTRL + F5)</li>
+            <li>print again the map</li>
+          </ol>
+          If the error persists please contact the server administrator.<br>
+          For more info: <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image">security and tainted canvases</a>
+        `
       }
     },
     catalog_items: {

--- a/src/locales/fi.js
+++ b/src/locales/fi.js
@@ -512,15 +512,13 @@ export default {
       screenshot: {
         error: "Screenshot error creation",
         securityError: `  
-         [<span style="font-weight: bold">securityError</span>] An external layer is preventing the map from being printed.<br>
-          To check, proceed as follows:
-          <ol>
-            <li>remove any manually added external layers (eg. WMS layers)</li>
-            <li>reload the page (CTRL + F5)</li>
-            <li>print again the map</li>
-          </ol>
-          If the error persists please contact the server administrator.<br>
-          For more info: <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image">security and tainted canvases</a>
+        <p><b>Turvallisuusvirhe</b>: ulkoinen kerros estää karttaa tulostamasta. Tarkistaaksesi, toimi seuraavasti:</p>
+        <ol>
+          <li>poista manuaalisesti lisätyt ulkoiset tasot (esim. WMS-tasot)</li>
+          <li>Pakota sivun uudelleenlataus: <code>CTRL + F5</code></li>
+          <li>tulosta kartta uudelleen</li>
+        </ol>
+        <p>Saat lisätietoja palvelimen järjestelmänvalvojalta seuraavista aiheista: <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image" style="color: #000 !important;font -paino: lihavoitu;">&#x2139;&#xFE0F; turvallisuus ja likaiset kankaat</a></p>
         `
       }
     },

--- a/src/locales/fi.js
+++ b/src/locales/fi.js
@@ -510,7 +510,18 @@ export default {
         tooltip: "Pinta-ala"
       },
       screenshot: {
-        error: "Screenshot error creation"
+        error: "Screenshot error creation",
+        securityError: `  
+         [<span style="font-weight: bold">securityError</span>] An external layer is preventing the map from being printed.<br>
+          To check, proceed as follows:
+          <ol>
+            <li>remove any manually added external layers (eg. WMS layers)</li>
+            <li>reload the page (CTRL + F5)</li>
+            <li>print again the map</li>
+          </ol>
+          If the error persists please contact the server administrator.<br>
+          For more info: <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image">security and tainted canvases</a>
+        `
       }
     },
     catalog_items: {

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -514,15 +514,13 @@ export default {
       screenshot: {
         error: "Erreur de création de la capture d'écran",
         securityError: `  
-         [<span style="font-weight: bold">securityError</span>] An external layer is preventing the map from being printed.<br>
-          To check, proceed as follows:
-          <ol>
-            <li>remove any manually added external layers (eg. WMS layers)</li>
-            <li>reload the page (CTRL + F5)</li>
-            <li>print again the map</li>
-          </ol>
-          If the error persists please contact the server administrator.<br>
-          For more info: <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image">security and tainted canvases</a>
+        <p><b>Erreur de sécurité</b> : une couche externe empêche l'impression de la carte. Pour vérifier, procédez comme suit :</p>
+        <ol>
+          <li>supprimer toutes les couches externes ajoutées manuellement (par exemple, les couches WMS)</li>
+          <li>forcer le rechargement de la page : <code>CTRL + F5</code></li>
+          <li>imprimer à nouveau la carte</li>
+        </ol>
+        <p>Pour plus d'informations, veuillez contacter l'administrateur du serveur à propos de : <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image" style="color: #000 !important;font -poids : gras ;">&#x2139;&#xFE0F ; sécurité et toiles souillées</a></p>
         `
       }
     },

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -512,7 +512,18 @@ export default {
         tooltip: "Zone"
       },
       screenshot: {
-        error: "Erreur de création de la capture d'écran"
+        error: "Erreur de création de la capture d'écran",
+        securityError: `  
+         [<span style="font-weight: bold">securityError</span>] An external layer is preventing the map from being printed.<br>
+          To check, proceed as follows:
+          <ol>
+            <li>remove any manually added external layers (eg. WMS layers)</li>
+            <li>reload the page (CTRL + F5)</li>
+            <li>print again the map</li>
+          </ol>
+          If the error persists please contact the server administrator.<br>
+          For more info: <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image">security and tainted canvases</a>
+        `
       }
     },
     catalog_items: {

--- a/src/locales/it.js
+++ b/src/locales/it.js
@@ -515,15 +515,13 @@ export default {
       screenshot: {
         error: "Errore nella creazione dello screenshot",
         securityError: `  
-         [<span style="font-weight: bold">securityError</span>] An external layer is preventing the map from being printed.<br>
-          To check, proceed as follows:
-          <ol>
-            <li>remove any manually added external layers (eg. WMS layers)</li>
-            <li>reload the page (CTRL + F5)</li>
-            <li>print again the map</li>
-          </ol>
-          If the error persists please contact the server administrator.<br>
-          For more info: <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image">security and tainted canvases</a>
+        <p><b>Errore di sicurezza</b>: uno strato esterno impedisce la stampa della mappa. Per verificare, procedere come segue:</p>
+        <ol>
+          <li>rimuovi eventuali layer esterni aggiunti manualmente (es. layer WMS)</li>
+          <li>forza il ricaricamento della pagina: <code>CTRL + F5<code></li>
+          <li>stampa nuovamente la mappa</li>
+        </ol>
+        <p>Per maggiori informazioni contattare l'amministratore del server in merito a: <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image" style="color: #000 !important;font-weight: bold;">&#x2139;&#xFE0F; security and tainted canvases</a></p>
         `
       }
     },

--- a/src/locales/it.js
+++ b/src/locales/it.js
@@ -513,7 +513,18 @@ export default {
         tooltip: "Area"
       },
       screenshot: {
-        error: "Errore nella creazione dello screenshot"
+        error: "Errore nella creazione dello screenshot",
+        securityError: `  
+         [<span style="font-weight: bold">securityError</span>] An external layer is preventing the map from being printed.<br>
+          To check, proceed as follows:
+          <ol>
+            <li>remove any manually added external layers (eg. WMS layers)</li>
+            <li>reload the page (CTRL + F5)</li>
+            <li>print again the map</li>
+          </ol>
+          If the error persists please contact the server administrator.<br>
+          For more info: <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image">security and tainted canvases</a>
+        `
       }
     },
     catalog_items: {

--- a/src/locales/ro.js
+++ b/src/locales/ro.js
@@ -512,15 +512,13 @@ export default {
       screenshot: {
         error: "Eroare captură ecran",
         securityError: `  
-         [<span style="font-weight: bold">securityError</span>] An external layer is preventing the map from being printed.<br>
-          To check, proceed as follows:
-          <ol>
-            <li>remove any manually added external layers (eg. WMS layers)</li>
-            <li>reload the page (CTRL + F5)</li>
-            <li>print again the map</li>
-          </ol>
-          If the error persists please contact the server administrator.<br>
-          For more info: <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image">security and tainted canvases</a>
+        <p><b>Eroare de securitate</b>: un strat extern împiedică imprimarea hărții. Pentru a verifica, procedați după cum urmează:</p>
+        <ol>
+          <li>eliminați orice straturi externe adăugate manual (de exemplu, straturi WMS)</li>
+          <li>forțați reîncărcarea paginii: <code>CTRL + F5</code></li>
+          <li>tipărește din nou harta</li>
+        </ol>
+        <p>Pentru mai multe informații, vă rugăm să contactați administratorul serverului despre: <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image" style="color: #000 !important;font -greutate: bold;">&#x2139;&#xFE0F; securitate și pânze contaminate</a></p>
         `
       }
     },

--- a/src/locales/ro.js
+++ b/src/locales/ro.js
@@ -510,7 +510,18 @@ export default {
         tooltip: "Arie"
       },
       screenshot: {
-        error: "Eroare captură ecran"
+        error: "Eroare captură ecran",
+        securityError: `  
+         [<span style="font-weight: bold">securityError</span>] An external layer is preventing the map from being printed.<br>
+          To check, proceed as follows:
+          <ol>
+            <li>remove any manually added external layers (eg. WMS layers)</li>
+            <li>reload the page (CTRL + F5)</li>
+            <li>print again the map</li>
+          </ol>
+          If the error persists please contact the server administrator.<br>
+          For more info: <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image">security and tainted canvases</a>
+        `
       }
     },
     catalog_items: {

--- a/src/locales/se.js
+++ b/src/locales/se.js
@@ -511,7 +511,18 @@ export default {
         tooltip: "Areal"
       },
       screenshot: {
-        error: "Screenshot error creation"
+        error: "Screenshot error creation",
+        securityError: `  
+         [<span style="font-weight: bold">securityError</span>] An external layer is preventing the map from being printed.<br>
+          To check, proceed as follows:
+          <ol>
+            <li>remove any manually added external layers (eg. WMS layers)</li>
+            <li>reload the page (CTRL + F5)</li>
+            <li>print again the map</li>
+          </ol>
+          If the error persists please contact the server administrator.<br>
+          For more info: <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image">security and tainted canvases</a>
+        `
       }
     },
     catalog_items: {

--- a/src/locales/se.js
+++ b/src/locales/se.js
@@ -513,15 +513,13 @@ export default {
       screenshot: {
         error: "Screenshot error creation",
         securityError: `  
-         [<span style="font-weight: bold">securityError</span>] An external layer is preventing the map from being printed.<br>
-          To check, proceed as follows:
-          <ol>
-            <li>remove any manually added external layers (eg. WMS layers)</li>
-            <li>reload the page (CTRL + F5)</li>
-            <li>print again the map</li>
-          </ol>
-          If the error persists please contact the server administrator.<br>
-          For more info: <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image">security and tainted canvases</a>
+        <p><b>Säkerhetsfel</b>: ett externt lager hindrar kartan från att skrivas ut. Gör så här för att kontrollera:</p>
+        <ol>
+          <li>ta bort alla manuellt tillagda externa lager (t.ex. WMS-lager)</li>
+          <li>tvinga om inläsning av sidan: <code>CTRL + F5</code></li>
+          <li>skriv ut kartan igen</li>
+        </ol>
+        <p>För mer information kontakta serveradministratören om: <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image" style="color: #000 !important;font -vikt: fet;">&#x2139;&#xFE0F; säkerhet och nedsmutsade dukar</a></p>
         `
       }
     },


### PR DESCRIPTION
Related to: #390 

Geoscreenshot and Screenshot map controls appear when layer has source with url white the same domain of application.
