### PR TITLE
Expose g3w-ol interaction control to third party plugins (ref: `g3wsdk.gui.ControlFactory.CONTROLS.ontoggle`)

### DIFF
--- a/src/app/gui/map/control/factory.js
+++ b/src/app/gui/map/control/factory.js
@@ -17,6 +17,7 @@ const ScreenshotControl = require('g3w-ol/controls/screenshotcontrol');
 const geoScreenshotControl = require('g3w-ol/controls/geoscreenshotcontrol');
 const ZoomHistoryControl = require('g3w-ol/controls/zoomhistorycontrol');
 const QueryByDrawPolygonControl = require('g3w-ol/controls/querybydrawpolygoncontrol');
+const InteractionControl = require('g3w-ol/controls/interactioncontrol');
 
 
 const ControlsFactory = {
@@ -45,20 +46,23 @@ ControlsFactory.CONTROLS = {
   'mouseposition': MousePositionControl,
   'scale': ScaleControl,
   'onclick': OnClikControl,
+  /**
+   * @since 3.8.3
+   */
+  'ontoggle': InteractionControl,
   'screenshot': ScreenshotControl,
   'geoscreenshot': geoScreenshotControl,
   'querybydrawpolygon': QueryByDrawPolygonControl,
-  
+
   /**
    * @since 3.8.0
    */
   'zoomhistory': ZoomHistoryControl,
-  
+
   /**
    * @deprecated since version ??. Will be removed in version ??. Use 'geocoding' control instead.
    */
   'nominatim': GeocodingControl,
-
 };
 
 module.exports = ControlsFactory;


### PR DESCRIPTION
Closes: #427 
