### PR TITLE
Allow third party plugins to register an external `downloadUrl` server for specific layers (eg. external download providers)

### DIFF
--- a/src/app/gui/map/mapservice.js
+++ b/src/app/gui/map/mapservice.js
@@ -2431,7 +2431,6 @@ proto.addExternalMapLayer = function(layer, projectLayer=false) {
  * @returns { Promise<unknown> }
  */
 proto.addExternalLayer = async function(externalLayer, options={}) {
-  console.log(options)
   let vectorLayer,
     name,
     data,

--- a/src/app/gui/map/mapservice.js
+++ b/src/app/gui/map/mapservice.js
@@ -2487,9 +2487,22 @@ proto.addExternalLayer = async function(externalLayer, options={}) {
       crs: options.crs,
       type: options.type,
       _type: type,
-      //@since 3.8.3. Contain an external custom url do download
-      downloadUrl: options.downloadUrl,
       download: options.download || false,
+      /**
+       * An alternate (external) server url where to perfom download.
+       * 
+       * @example
+       * 
+       * ```js
+       * GUI.getService('map').addExternalLayer(layer, {
+       *   type: 'geojson',
+       *   downloadUrl:  _<URL WHERE DOWNLOAD FILE>_
+       * });
+       * ```
+       * 
+       * @since 3.8.3
+       */
+      downloadUrl: options.downloadUrl,
       visible,
       checked: true,
       position,
@@ -2497,7 +2510,10 @@ proto.addExternalLayer = async function(externalLayer, options={}) {
       color,
       filter: vectorLayer.filter,
       selection: vectorLayer.selection,
-      tochighlightable: false //@since 3.8.0
+      /**
+       * @since 3.8.0
+       */
+      tochighlightable: false
     };
   }
 

--- a/src/app/gui/map/mapservice.js
+++ b/src/app/gui/map/mapservice.js
@@ -2431,6 +2431,7 @@ proto.addExternalMapLayer = function(layer, projectLayer=false) {
  * @returns { Promise<unknown> }
  */
 proto.addExternalLayer = async function(externalLayer, options={}) {
+  console.log(options)
   let vectorLayer,
     name,
     data,
@@ -2487,6 +2488,8 @@ proto.addExternalLayer = async function(externalLayer, options={}) {
       crs: options.crs,
       type: options.type,
       _type: type,
+      //@since 3.8.3. Contain an external custom url do download
+      downloadUrl: options.downloadUrl,
       download: options.download || false,
       visible,
       checked: true,

--- a/src/components/CatalogLayerContextMenu.vue
+++ b/src/components/CatalogLayerContextMenu.vue
@@ -93,7 +93,7 @@
     </li>
 
     <!-- Download an external layer file from a proxy server url -->
-    <li @click.prevent.stop="" v-if="isExternalVectorLayer(layerMenu.layer) && layer.downloadUrl" v-download>
+    <li @click.prevent.stop="" v-if="isExternalVectorLayer(layerMenu.layer) && layerMenu.layer.downloadUrl" v-download>
       <div @click.prevent.stop="downloadExternal(layerMenu.layer.downloadUrl)">
         <bar-loader :loading="layerMenu.loading.unknow" />
         <span class="menu-icon skin-color-dark" :class="g3wtemplate.getFontClass('download')"></span>
@@ -102,7 +102,7 @@
     </li>
 
     <!-- Download an external layer file as shapefile -->
-    <li @click.prevent.stop="" v-if="isExternalVectorLayer(layerMenu.layer) && !layer.downloadUrl" v-download>
+    <li @click.prevent.stop="" v-if="isExternalVectorLayer(layerMenu.layer) && !layerMenu.layer.downloadUrl" v-download>
       <div @click.prevent.stop="downloadExternalShapefile(layerMenu.layer)">
         <bar-loader :loading="layerMenu.loading.shp" />
         <span class="menu-icon skin-color-dark" :class="g3wtemplate.getFontClass('shapefile')"></span>

--- a/src/components/CatalogLayerContextMenu.vue
+++ b/src/components/CatalogLayerContextMenu.vue
@@ -91,6 +91,7 @@
       </ul>
     </li>
     <template v-if="!layerMenu.layer.projectLayer && layerMenu.layer._type !== 'wms'">
+
       <!-- When is provided an download url        -->
       <li @click.prevent.stop="" v-if="layerMenu.layer.downloadUrl" v-download>
         <div @click.prevent.stop="downloadExternal(layerMenu.layer.downloadUrl)" >
@@ -100,7 +101,7 @@
         </div>
       </li>
 
-      <!-- TODO add item description -->
+      <!-- Download a shapefile version of the layer -->
       <li @click.prevent.stop="" v-else v-download>
         <div @click.prevent.stop="downloadExternalShapefile(layerMenu.layer)" >
           <bar-loader :loading="layerMenu.loading.shp"/>

--- a/src/components/CatalogLayerContextMenu.vue
+++ b/src/components/CatalogLayerContextMenu.vue
@@ -22,7 +22,10 @@
     <!-- TODO add item description -->
     <li v-if="!layerMenu.layer.projectLayer">
       <div style="display: flex; justify-content: space-between; align-items: center">
-        <layerspositions @layer-position-change="changeLayerMapPosition({position:$event, layer: layerMenu.layer})" style="display: flex; flex-direction: column; justify-content: space-between" :position="layerMenu.layer.position"></layerspositions>
+        <layerspositions
+          @layer-position-change="changeLayerMapPosition({position:$event, layer: layerMenu.layer})"
+          style="display: flex; flex-direction: column; justify-content: space-between"
+          :position="layerMenu.layer.position"/>
       </div>
     </li>
 
@@ -83,19 +86,30 @@
             v-model="layerMenu.colorMenu.color"
             @input="onChangeColor"
             style="width: 100%"
-          ></chrome-picker>
+          />
         </li>
       </ul>
     </li>
+    <template v-if="!layerMenu.layer.projectLayer && layerMenu.layer._type !== 'wms'">
+      <!-- When is provided an download url        -->
+      <li @click.prevent.stop="" v-if="layerMenu.layer.downloadUrl" v-download>
+        <div @click.prevent.stop="downloadExternal(layerMenu.layer.downloadUrl)" >
+          <bar-loader :loading="layerMenu.loading.unknow"/>
+            <span class="menu-icon skin-color-dark" :class="g3wtemplate.getFontClass('download')"></span>
+            <span class="item-text" v-t="'sdk.catalog.menu.download.unknow'"></span>
+        </div>
+      </li>
 
-    <!-- TODO add item description -->
-    <li @click.prevent.stop="" v-if="!layerMenu.layer.projectLayer && layerMenu.layer._type !== 'wms'" v-download>
-      <div @click.prevent.stop="downloadExternalShapefile(layerMenu.layer)" >
-        <bar-loader :loading="layerMenu.loading.shp"></bar-loader>
-        <span class="menu-icon skin-color-dark" :class="g3wtemplate.getFontClass('shapefile')"></span>
-        <span class="item-text" v-t="'sdk.catalog.menu.download.shp'"></span>
-      </div>
-    </li>
+      <!-- TODO add item description -->
+      <li @click.prevent.stop="" v-else v-download>
+        <div @click.prevent.stop="downloadExternalShapefile(layerMenu.layer)" >
+          <bar-loader :loading="layerMenu.loading.shp"/>
+          <span class="menu-icon skin-color-dark" :class="g3wtemplate.getFontClass('shapefile')"></span>
+          <span class="item-text" v-t="'sdk.catalog.menu.download.shp'"></span>
+        </div>
+      </li>
+
+    </template>
 
     <!-- TODO add item description -->
     <li @click.prevent.stop="" v-if="!layerMenu.layer.projectLayer && layerMenu.layer._type === 'wms'" >
@@ -103,13 +117,13 @@
         <span class="item-text" v-t="'sdk.catalog.menu.setwmsopacity'"></span>
         <span style="font-weight: bold; margin-left: 5px;">{{layerMenu.layer.opacity}}</span>
       </div>
-      <range :value="layerMenu.layer.opacity" :min="0" :max="1" :step="0.1" :sync="true" @changed="_hideMenu" @change-range="setWMSOpacity"></range>
+      <range :value="layerMenu.layer.opacity" :min="0" :max="1" :step="0.1" :sync="true" @changed="_hideMenu" @change-range="setWMSOpacity"/>
     </li>
 
     <!-- Download as GeoTIFF -->
     <li v-if="canDownloadGeoTIFF(layerMenu.layer.id)" v-download>
       <div @click.prevent.stop="downloadGeoTIFF(layerMenu.layer.id)" >
-        <bar-loader :loading="layerMenu.loading.geotiff"></bar-loader>
+        <bar-loader :loading="layerMenu.loading.geotiff"/>
         <span class="menu-icon skin-color-dark" :class="g3wtemplate.getFontClass('geotiff')"></span>
         <span class="item-text" v-t="'sdk.catalog.menu.download.geotiff'"></span>
       </div>
@@ -118,7 +132,7 @@
     <!-- Download as GeoTIFF -->
     <li v-if="canDownloadGeoTIFF(layerMenu.layer.id)" v-download>
       <div @click.prevent.stop="downloadGeoTIFF(layerMenu.layer.id, true)" style="position: relative">
-        <bar-loader :loading="layerMenu.loading.geotiff"></bar-loader>
+        <bar-loader :loading="layerMenu.loading.geotiff"/>
         <span class="menu-icon skin-color-dark" style="color:#777" :class="g3wtemplate.getFontClass('geotiff')"></span>
         <span style="position: absolute; left: -7px; bottom: 8px; font-size: 1.2em" class="menu-icon skin-color-dark" :class="g3wtemplate.getFontClass('crop')"></span>
         <span class="item-text" v-t="'sdk.catalog.menu.download.geotiff_map_extent'"></span>
@@ -128,7 +142,7 @@
     <!-- Download as SHP -->
     <li v-if="canDownloadShp(layerMenu.layer.id)" v-download>
       <div @click.prevent.stop="downloadShp(layerMenu.layer.id)" >
-        <bar-loader :loading="layerMenu.loading.shp"></bar-loader>
+        <bar-loader :loading="layerMenu.loading.shp"/>
         <span class="menu-icon skin-color-dark" :class="g3wtemplate.getFontClass('shapefile')"></span>
         <span class="item-text" v-t="'sdk.catalog.menu.download.shp'"></span>
       </div>
@@ -137,7 +151,7 @@
     <!-- Download as GPX -->
     <li v-if="canDownloadGpx(layerMenu.layer.id)">
       <div @click.prevent.stop="downloadGpx(layerMenu.layer.id)" v-download>
-        <bar-loader :loading="layerMenu.loading.gpx"></bar-loader>
+        <bar-loader :loading="layerMenu.loading.gpx"/>
         <span class="menu-icon skin-color-dark" :class="g3wtemplate.getFontClass('gpx')"></span>
         <span class="item-text" v-t="'sdk.catalog.menu.download.gpx'"></span>
       </div>
@@ -146,7 +160,7 @@
     <!-- Download as Gpkg -->
     <li v-if="canDownloadGpkg(layerMenu.layer.id)">
       <div @click.prevent.stop="downloadGpkg(layerMenu.layer.id)" v-download>
-        <bar-loader :loading="layerMenu.loading.gpkg"></bar-loader>
+        <bar-loader :loading="layerMenu.loading.gpkg"/>
         <span class="menu-icon skin-color-dark" :class="g3wtemplate.getFontClass('gpkg')"></span>
         <span class="item-text" v-t="'sdk.catalog.menu.download.gpkg'"></span>
       </div>
@@ -155,7 +169,7 @@
     <!-- Download as CSV -->
     <li v-if="canDownloadCsv(layerMenu.layer.id)">
       <div @click.prevent.stop="downloadCsv(layerMenu.layer.id)" v-download>
-        <bar-loader :loading="layerMenu.loading.csv"></bar-loader>
+        <bar-loader :loading="layerMenu.loading.csv"/>
         <span class="menu-icon skin-color-dark" :class="g3wtemplate.getFontClass('csv')"></span>
         <span class="item-text" v-t="'sdk.catalog.menu.download.csv'"></span>
       </div>
@@ -164,7 +178,7 @@
     <!-- Download as XLS -->
     <li v-if="canDownloadXls(layerMenu.layer.id)" v-download>
       <div @click.prevent.stop="downloadXls(layerMenu.layer.id)">
-        <bar-loader :loading="layerMenu.loading.xls"></bar-loader>
+        <bar-loader :loading="layerMenu.loading.xls"/>
         <span class="menu-icon skin-color-dark" :class="g3wtemplate.getFontClass('xls')"></span>
         <span class="item-text" v-t="'sdk.catalog.menu.download.xls'"></span>
       </div>
@@ -214,6 +228,8 @@
   const { t } = require('core/i18n/i18n.service');
   const shpwrite = require('shp-write');
   const TableComponent = require('gui/table/vue/table');
+  const { downloadFile } = require('core/utils/utils');
+
 
   const OFFSETMENU = {
     top: 50,
@@ -319,6 +335,11 @@
         this.layerMenu.loading.gpkg = false;
         this.layerMenu.loading.xls = false;
         this.layerMenu.loading.geotiff = false;
+        /**
+         * @since 3.8.3
+         * @type {boolean}
+         */
+        this.layerMenu.loading.unknow = false;
       },
       closeLayerMenu(menu={}) {
         this._hideMenu();
@@ -526,6 +547,18 @@
         }
         geometryType = geometryType && geometryType !== 'NoGeometry' ? geometryType : '' ;
         return geometryType;
+      },
+
+      /**
+       * @since 3.8.3
+       * Download external Url
+       */
+      downloadExternal(url){
+        this.layerMenu.loading.unknow = true;
+        downloadFile({
+          url
+        })
+        this.layerMenu.loading.unknow = false;
       },
 
       /**

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -387,6 +387,7 @@ export default {
             copied: "Kopiert"
           },
           download: {
+            unknow: "Herunterladen",
             shp: 'Shapefile herunterladen',
             gpx: 'GPX herunterladen',
             gpkg: 'GPKG herunterladen',

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -387,6 +387,7 @@ export default {
             copied: "Copied"
           },
           download: {
+            unknow: 'Download',
             shp: 'Download Shapefile',
             gpx: 'Download GPX',
             gpkg: 'Download GPKG',

--- a/src/locales/fi.js
+++ b/src/locales/fi.js
@@ -387,6 +387,7 @@ export default {
             copied: "Kopioitu."
           },
           download: {
+            unknow: "Lataa",
             shp: 'Lataa SHP-tiedosto',
             gpx: 'Lataa GPX-tiedosto',
             gpkg: 'Lataa GPKG-tiedosto',

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -387,6 +387,7 @@ export default {
             copied: "Copié"
           },
           download: {
+            unknow: 'Télécharger',
             shp: 'Télécharger Shapefile',
             gpx: 'Télécharger GPX',
             gpkg: 'Télécharger GPKG',

--- a/src/locales/it.js
+++ b/src/locales/it.js
@@ -389,6 +389,7 @@ export default {
             copied: "Copiato"
           },
           download: {
+            unknow: "Scarica",
             shp: 'Scarica Shapefile',
             gpx: 'Scarica GPX',
             gpkg: 'Scarica GPKG',

--- a/src/locales/ro.js
+++ b/src/locales/ro.js
@@ -387,6 +387,7 @@ export default {
             copied: "Copiat"
           },
           download: {
+            unknow: 'Descarcă',
             shp: 'Descarcă Shapefile',
             gpx: 'Descarcă GPX',
             gpkg: 'Descarcă GPKG',

--- a/src/locales/se.js
+++ b/src/locales/se.js
@@ -388,6 +388,7 @@ export default {
             copied: "Kopierad."
           },
           download: {
+            unknow: 'Ladda',
             shp: 'Ladda SHP-fil',
             gpx: 'Ladda GPX-fil',
             gpkg: 'Ladda GPKG-fil',


### PR DESCRIPTION
Closes: #433 

Example of code use from external plugin:

```js
 GUI.getService('map').addExternalLayer(layer, {
  type: 'geojson',
  downloadUrl:  _<URL WHERE DOWNLOAD FILE>_
 });
```