### PR TITLE
Restore `listenChangeInput` guard after calling `FormService::saveDefaultExpressionFieldsNotDependencies()`

### DIFF
--- a/src/app/gui/form/formservice.js
+++ b/src/app/gui/form/formservice.js
@@ -212,11 +212,8 @@ proto.setUpdate = function(bool=false, options={}) {
   this.force.update = force;
   this.state.update = this.force.update || bool;
   if (false === this.state.update) {
-    // need to set original value of field _value
-    // equal to current value to get changes
-    this.state.fields.forEach(field => {
-      field._value = field.value;
-    })
+    // set original `field._value` equal to current value to get changes
+    this.state.fields.forEach(field => { field._value = field.value; })
   }
 };
 
@@ -333,7 +330,7 @@ proto._handleFieldWithDefaultExpression = function(field, default_expression) {
     ].forEach(dependency_field => dependency_fields.add(dependency_field));
 
 
-    //Only in apply update listen changeInput
+    // Only in apply update listen changeInput
     if (apply_on_update) {
 
       this.default_expression_fields_on_update.push(field);
@@ -661,7 +658,7 @@ proto.saveDefaultExpressionFieldsNotDependencies = async function() {
     console.warn(err);
   }
 
-  // enable listen changeInput again
+  // enable listen changeInput
   this.listenChangeInput = true;
 
 };

--- a/src/app/gui/form/formservice.js
+++ b/src/app/gui/form/formservice.js
@@ -211,6 +211,13 @@ proto.setUpdate = function(bool=false, options={}) {
   const { force = false } = options;
   this.force.update = force;
   this.state.update = this.force.update || bool;
+  if (false === this.state.update) {
+    // need to set original value of field _value
+    // equal to current value to get changes
+    this.state.fields.forEach(field => {
+      field._value = field.value;
+    })
+  }
 };
 
 /**
@@ -653,6 +660,9 @@ proto.saveDefaultExpressionFieldsNotDependencies = async function() {
   } catch(err) {
     console.warn(err);
   }
+
+  // enable listen changeInput again
+  this.listenChangeInput = true;
 
 };
 

--- a/src/components/FormHeader.vue
+++ b/src/components/FormHeader.vue
@@ -42,8 +42,13 @@ export default Vue.extend({
   },
   methods: {
     click(id) {
-      if (this.currentid !== id)
+      /**
+       * @deprecated since 3.6.2
+       * This was used when form headers has more than one (case relation)
+       */
+      if (this.currentid !== id && this.headers.length > 1) {
         this.$emit('clickheader', id);
+      }
     },
     resizeForm(perc){
       this.$emit('resize-form', perc);


### PR DESCRIPTION
Closes: #435 
