### PR TITLE
Fix icons path for DataTables images (`vendor.min.css`)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -241,7 +241,7 @@ gulp.task('images', function () {
  gulp.task('datatable-images', function () {
   return gulp.src(`${g3w.assetsFolder}/vendors/datatables/DataTables-1.10.16/images/*`)
     .pipe(flatten())
-    .pipe(gulp.dest(outputFolder + '/static/client/css/DataTables-1.10.16/images/'));
+    .pipe(gulp.dest(outputFolder + '/static/client/images/'));
 });
 
 /**


### PR DESCRIPTION
## Before

Icons not found:

![Screenshot from 2023-07-04 17-51-12](https://github.com/g3w-suite/g3w-client/assets/1051694/57dec089-af37-4459-9fd0-f724594b90dd)


- `/static/client/css/DataTables-1.10.16/images/sort_asc.png`
- `/static/client/css/DataTables-1.10.16/images/sort_asc_disabled.png`
- `/static/client/css/DataTables-1.10.16/images/sort_desc_disabled.png`
- `/static/client/css/DataTables-1.10.16/images/sort_desc_disabled.png`
- `/static/client/css/DataTables-1.10.16/images/sort_both.png`


## After

![Screenshot from 2023-07-04 17-56-15](https://github.com/g3w-suite/g3w-client/assets/1051694/bd0b3399-38a3-4d5b-99d8-542de7af8b60)

- `/static/client/images/sort_asc.png`
- `/static/client/images/sort_asc_disabled.png`
- `/static/client/images/sort_desc_disabled.png`
- `/static/client/images/sort_desc_disabled.png`
- `/static/client/images/sort_both.png`

Closes: #443 