### PR TITLE
Adjust tooltip color of `Enlarge / Reduce` icon + wrong `Default size` on vertical viewports (ref: `components/GlobalResizeIcon.vue`)

### DIFF
--- a/src/components/GlobalResizeIcon.vue
+++ b/src/components/GlobalResizeIcon.vue
@@ -5,8 +5,21 @@
 
 <template>
   <div style="display: flex; justify-content: space-between">
-    <i v-if="show" :class="g3wtemplate.getFontClass(`resize-${this.type}`)" v-t-tooltip:bottom.create="'enlange_reduce'" style="cursor: pointer; margin-right: 3px;" class="action-button skin-color-dark" @click="toggleFull"></i>
-    <i :class="g3wtemplate.getFontClass(`resize-default`)" v-t-tooltip:left.create="'reset_default'" style="cursor: pointer" class="action-button skin-color-dark" @click="resetToDefault"></i>
+    <i
+      v-if                      = "show"
+      :class                    = "g3wtemplate.getFontClass(`resize-${this.type}`)"
+      v-t-tooltip:bottom.create = "'enlange_reduce'"
+      style                     = "cursor: pointer; margin-right: 3px;"
+      class                     = "action-button skin-color-dark"
+      @click                    = "toggleFull"
+    ></i>
+    <i
+      :class                    = "g3wtemplate.getFontClass(`resize-default`)"
+      v-t-tooltip:left.create   = "'reset_default'"
+      style                     = "cursor: pointer"
+      class                     = "action-button skin-color-dark"
+      @click                    = "resetToDefault"
+    ></i>
   </div>
 </template>
 
@@ -14,35 +27,47 @@
   import GUI from 'services/gui';
 
   export default {
+
     name: 'resize-icon',
+
     props: {
+
       type: {
-        type: String,
-        default: 'h'
-      }
+        type:    String,
+        default: 'h',
+      },
+
     },
-    data(){
+
+    data() {
       return {
-        show: "undefined" !== typeof this.type
-      }
+        show: "undefined" !== typeof this.type,
+      };
     },
+
     watch: {
+
       async type() {
         this.show = false;
         await this.$nextTick();
         this.show = true;
-      }
+      },
+
     },
 
     methods:{
-      toggleFull(){
+
+      toggleFull() {
         GUI.toggleFullViewContent();
         GUI.emit('resize');
       },
-      resetToDefault(){
+
+      resetToDefault() {
         GUI.resetToDefaultContentPercentage();
         GUI.emit('resize');
-      }
-    }
+      },
+
+    },
+
   };
 </script>

--- a/src/components/GlobalResizeIcon.vue
+++ b/src/components/GlobalResizeIcon.vue
@@ -5,8 +5,8 @@
 
 <template>
   <div style="display: flex; justify-content: space-between">
-      <i :class="g3wtemplate.getFontClass(`resize-${type}`)" v-t-tooltip:bottom.create="'enlange_reduce'" style="cursor: pointer; margin-right: 3px;" class="action-button skin-color-dark" @click="toggleFull"></i>
-      <i :class="g3wtemplate.getFontClass(`resize-default`)" v-t-tooltip:left.create="'reset_default'" style="cursor: pointer" class="action-button skin-color-dark" @click="resetToDefault"></i>
+    <i v-if="show" :class="g3wtemplate.getFontClass(`resize-${this.type}`)" v-t-tooltip:bottom.create="'enlange_reduce'" style="cursor: pointer; margin-right: 3px;" class="action-button skin-color-dark" @click="toggleFull"></i>
+    <i :class="g3wtemplate.getFontClass(`resize-default`)" v-t-tooltip:left.create="'reset_default'" style="cursor: pointer" class="action-button skin-color-dark" @click="resetToDefault"></i>
   </div>
 </template>
 
@@ -14,23 +14,35 @@
   import GUI from 'services/gui';
 
   export default {
-      name: 'resize-icon',
-      props: {
-        type: {
-            type: String,
-            default: 'h'
-        }
-      },
-      computed:{},
-      methods:{
-          toggleFull(){
-              GUI.toggleFullViewContent();
-              GUI.emit('resize');
-          },
-          resetToDefault(){
-              GUI.resetToDefaultContentPercentage();
-              GUI.emit('resize');
-          }
+    name: 'resize-icon',
+    props: {
+      type: {
+        type: String,
+        default: 'h'
       }
+    },
+    data(){
+      return {
+        show: "undefined" !== typeof this.type
+      }
+    },
+    watch: {
+      async type() {
+        this.show = false;
+        await this.$nextTick();
+        this.show = true;
+      }
+    },
+
+    methods:{
+      toggleFull(){
+        GUI.toggleFullViewContent();
+        GUI.emit('resize');
+      },
+      resetToDefault(){
+        GUI.resetToDefaultContentPercentage();
+        GUI.emit('resize');
+      }
+    }
   };
 </script>

--- a/src/locales/de.js
+++ b/src/locales/de.js
@@ -450,8 +450,8 @@ export default {
      * @since 3.8.0
      */
     dont_show_again: "Diese Meldung nicht mehr anzeigen",
-    enlange_reduce:"Vergrößern/Verkleinern",
-    reset_default:"Standardgröße",
+    enlange_reduce: "Vergrößern / Verkleinern",
+    reset_default: "Standardgröße",
     add: "Hinzufügen",
     exitnosave: "Beenden ohne Speichern",
     annul: "Abbrechen",

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -450,8 +450,8 @@ export default {
      * @since 3.8.0
      */
     dont_show_again: "Don't show again",
-    enlange_reduce:"Enlarge/Reduce",
-    reset_default:"Default size",
+    enlange_reduce: "Enlarge / Reduce",
+    reset_default: "Default size",
     add: "Add",
     exitnosave: "Exit without save",
     annul: "Cancel",

--- a/src/locales/fi.js
+++ b/src/locales/fi.js
@@ -450,8 +450,8 @@ export default {
      * @since 3.8.0
      */
     dont_show_again: "Älä näytä viestiä uudelleen",
-    enlange_reduce:"Enlarge/Reduce",
-    reset_default:"Default size",
+    enlange_reduce: "Suurenna / Pienennä",
+    reset_default: "Oletuskoko",
     add: "Lisää",
     exitnosave: "Poistu tallentamatta",
     annul: "Peruuta",

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -449,8 +449,8 @@ export default {
      * @since 3.8.0
      */
     dont_show_again: "Ne plus afficher ce message",
-    enlange_reduce:"Enlarge/Reduce",
-    reset_default:"Default size",
+    enlange_reduce: "Agrandir / Réduire",
+    reset_default: "Taille par défaut",
     add: "Ajouter",
     exitnosave: "Quitter sans sauvegarder",
     annul: "Annuler",

--- a/src/locales/it.js
+++ b/src/locales/it.js
@@ -452,8 +452,8 @@ export default {
      * @since 3.8.0
      */
     dont_show_again: "Non mostrare più",
-    enlange_reduce: "Allarga/Riduci",
-    reset_default: "Dimensione Partenza",
+    enlange_reduce: "Allarga / Riduci",
+    reset_default: "Dimensione predefinita",
     add: "Aggiungi",
     exitnosave: "Esci senza salvare",
     annul: "Annulla",

--- a/src/locales/ro.js
+++ b/src/locales/ro.js
@@ -450,8 +450,8 @@ export default {
      * @since 3.8.0
      */
     dont_show_again: "Nu mai afișa mesajul",
-    enlange_reduce:"Mărește/Micșorează",
-    reset_default:"Mărimea implicită",
+    enlange_reduce: "Mărește / Micșorează",
+    reset_default: "Mărimea implicită",
     add: "Adaugă",
     exitnosave: "Ieșire fără salvare",
     annul: "Anulează",

--- a/src/locales/se.js
+++ b/src/locales/se.js
@@ -451,8 +451,8 @@ export default {
      * @since 3.8.0
      */
     dont_show_again: "Visa inte det här meddelandet igen",
-    enlange_reduce:"Enlarge/Reduce",
-    reset_default:"Default size",
+    enlange_reduce: "Förstora / Förminska",
+    reset_default: "Standardstorlek",
     add: "Lägg till",
     exitnosave: "Lämna programmet utan att spara",
     annul: "Ångra",

--- a/src/services/application.js
+++ b/src/services/application.js
@@ -752,39 +752,34 @@ const ApplicationService = function() {
     return d.promise();
   };
 
+  /**
+   * Updates panels sizes when showing content (eg. bottom "Attribute Table" panel, right "Query Results" table)
+   */
   this.setLayout = function(who='app', config={}) {
-    /**
-     * Set default height percentage of height when show
-     * vertical content (for example show table attribute)
-     */
-    if (config.rightpanel) {
-      /**
-       * @since 3.6.7
-       * Configuration values coming from server if set.
-       * Basically, referred to right panel is consider width default percentage.
-       * So height value (ex. show attribute table of a layer show vertically) is get the same percentage of with
-       */
-      const default_width_height = config.rightpanel.width ||  config.rightpanel.width || 50;
-      Object.assign(config.rightpanel, {
-          width: config.rightpanel.width || default_width_height,
-          height: config.rightpanel.height || default_width_height,
-          width_default: config.rightpanel.width || default_width_height, // used eventually to reset starting values
-          height_default: config.rightpanel.height || default_width_height ,
-          width_100: false,
-          height_100: false,
-        }
-      );
-    } else {
-      config.rightpanel = {
-        width: 50,
-        height: 50,
-        width_default: 50,
-        height_default: 50,
-        width_100: false,
-        height_100: false
-      };
-    }
+
+    const default_config = config.rightpanel || {
+      width:          50, // ie. width == 50%  
+      height:         50, // ie. height == 50%
+      width_default:  50,
+      height_default: 50,
+      width_100:      false,
+      height_100:     false,
+    };
+
+    config.rightpanel = Object.assign(
+      default_config,
+      {
+        width:          config.rightpanel.width  || default_config.width,
+        height:         config.rightpanel.height || default_config.width,
+        width_default:  config.rightpanel.width  || default_config.width,
+        height_default: config.rightpanel.height || default_config.width,
+        width_100:      false,
+        height_100:     false,
+      }
+    );
+
     ApplicationState.gui.layout[who] = config;
+
   };
 
   this.removeLayout = function(who) {

--- a/src/services/application.js
+++ b/src/services/application.js
@@ -758,11 +758,18 @@ const ApplicationService = function() {
      * vertical content (for example show table attribute)
      */
     if (config.rightpanel) {
+      /**
+       * @since 3.6.7
+       * Configuration values coming from server if set.
+       * Basically, referred to right panel is consider width default percentage.
+       * So height value (ex. show attribute table of a layer show vertically) is get the same percentage of with
+       */
+      const default_width_height = config.rightpanel.width ||  config.rightpanel.width || 50;
       Object.assign(config.rightpanel, {
-          width: config.rightpanel.width || 50,
-          height: config.rightpanel.height || 50,
-          width_default: config.rightpanel.width, // used eventually to reset starting values
-          height_default: config.rightpanel.height,
+          width: config.rightpanel.width || default_width_height,
+          height: config.rightpanel.height || default_width_height,
+          width_default: config.rightpanel.width || default_width_height, // used eventually to reset starting values
+          height_default: config.rightpanel.height || default_width_height ,
           width_100: false,
           height_100: false,
         }


### PR DESCRIPTION
Closes: #447 

![Screenshot from 2023-07-13 17-07-23](https://github.com/g3w-suite/g3w-client/assets/1051694/fe284017-1a91-49f2-b56a-7a4b393e44b3)

