### PR TITLE
Treat ArcGIS Rest Server connections as WMS image layers (ref: `src/app/core/layers/layerfactory.js`)

### DIFF
--- a/src/app/core/layers/layerfactory.js
+++ b/src/app/core/layers/layerfactory.js
@@ -42,6 +42,10 @@ function LayerFactory() {
             Layer.SourceTypes.VECTORTILE,
             Layer.SourceTypes["VECTOR-TILE"],
             Layer.SourceTypes.MDAL,
+            /**
+             * @since 3.8.7
+             */
+            Layer.SourceTypes.ARCGISMAPSERVER,
           ].find(sourcetype => sourcetype === config.source.type)) LayerClass = ImageLayer;
         }
         break;


### PR DESCRIPTION
Fixes a regression probably introduced in: [`73f4c5`](https://github.com/g3w-suite/g3w-client/commit/73f4c55a4e5152c645d80f845966189c500d94a9#diff-3c20c3ac070854f3f8d6048454351fe52253ffc2a8feaaa2a681e594e05462c7)

Closes: #453 
