### PR TITLE
Restore query results data for layers having multiple download formats

### DIFF
--- a/src/components/QueryResultsActionDownloadFormats.vue
+++ b/src/components/QueryResultsActionDownloadFormats.vue
@@ -20,8 +20,8 @@
 <script>
 export default {
 
-  /** @since 3.8.6 */
-  name: "queryresults-downloadformats",
+  /** @since 3.8.7 */
+  name: "downloadformats",
 
   data(){
     const download_format = this.config.downloads[0].format;


### PR DESCRIPTION
Fixes a regression introduced by: https://github.com/g3w-suite/g3w-client/pull/446, closes: #463 

## Before

![Screenshot from 2023-08-03 08-28-31](https://github.com/g3w-suite/g3w-client/assets/1051694/16131c39-420c-46f2-8a65-512e11c0f777)

![img](https://user-images.githubusercontent.com/1051694/258021012-513b9cb2-4feb-4d1e-8167-1e13ad634b70.png)

## After

![Screenshot from 2023-08-03 08-43-09](https://github.com/g3w-suite/g3w-client/assets/1051694/5cba064c-10a2-42ce-a928-ed0c1fc108d8)

