### PR TITLE
Remove trailing slash in Nominatim Search API endpoint: `https://nominatim.openstreetmap.org/search`

### DIFF
--- a/src/app/g3w-ol/controls/geocodingcontrol.js
+++ b/src/app/g3w-ol/controls/geocodingcontrol.js
@@ -252,7 +252,7 @@ class Nominatim {
     this.active = true;
     const extent = ol.proj.transformExtent(options.viewbox, options.mapCrs, 'EPSG:4326');
     this.settings = {
-      url: 'https://nominatim.openstreetmap.org/search/',
+      url: 'https://nominatim.openstreetmap.org/search',
       params: {
         q: '',
         format: 'json',


### PR DESCRIPTION
Related to: https://github.com/osm-search/Nominatim/issues/3134, closes: #465 

![image](https://github.com/g3w-suite/g3w-client/assets/9614886/e2ba95ce-7197-4c34-bd41-9cf2b0bd2095)

Due to changes in Nominatim api, need to remove Trailing Slash to geocoding control Search API:

## Before

- `https://nominatim.openstreetmap.org/search/`

## After

- `https://nominatim.openstreetmap.org/search`