### PR TITLE
Strick check `undefined !== filter` for attributes within `QGISProvider::getFeatures()` (editing plugin)

### DIFF
--- a/src/app/core/layers/providersfactory.js
+++ b/src/app/core/layers/providersfactory.js
@@ -23,6 +23,9 @@ const Filter                       = require('core/layers/filter/filter');
 const GETFEATUREINFO_IMAGE_SIZE = [101, 101];
 const DPI = geoutils.getDPI();
 
+const is_defined = d => undefined !== d;
+
+
 /**
  * ORIGINAL SOURCE: src/app/core/layers/providers/provider.js@3.8.6
  */
@@ -390,7 +393,7 @@ const Providers = {
           url,
           contentType: 'application/json',
         });
-      } else if (filter.bbox) { // bbox filter
+      } else if (is_defined(filter.bbox)) { // bbox filter
         promise = XHR.post({
           url,
           data: JSON.stringify({
@@ -399,7 +402,7 @@ const Providers = {
           }),
           contentType: 'application/json',
         })
-      } else if (filter.fid) { // fid filter
+      } else if (is_defined(filter.fid)) { // fid filter
         promise = RelationsService.getRelations(filter.fid);
       } else if (filter.field) {
         promise = XHR.post({
@@ -407,12 +410,12 @@ const Providers = {
           data: JSON.stringify(filter),
           contentType: 'application/json',
         })
-      } else if (filter.fids) {
+      } else if (is_defined(filter.fids)) {
         promise = XHR.get({
           url,
           params: filter
         })
-      } else if (filter.nofeatures) {
+      } else if (is_defined(filter.nofeatures)) {
         promise = XHR.post({
           url,
           data: JSON.stringify({


### PR DESCRIPTION
Closes: #480

## Before

![Screenshot from 2023-09-01 12-36-17](https://github.com/g3w-suite/g3w-client/assets/1051694/45fecba9-91f8-4235-a0d8-8b09b3b3b250)

![Screenshot from 2023-09-01 12-42-54](https://github.com/g3w-suite/g3w-client/assets/1051694/0954053f-581c-4a55-99d3-9627783177de)

## After

Check if filter attribute is defined before create appropriate provider.

![Screenshot from 2023-09-01 12-50-23](https://github.com/g3w-suite/g3w-client/assets/1051694/b7e77844-b33c-4750-8061-50b11e014ed3)