### PR TITLE
Prevent datetimepicker widget from being occasionally clipped by surrounding container (editing mode)

### DIFF
--- a/src/assets/style/less/g3w-overwrite-extenal.less
+++ b/src/assets/style/less/g3w-overwrite-extenal.less
@@ -121,16 +121,6 @@ table.dataTable {
   }
 }
 
-// full screen date time picker (modal)
-.datimewidget_container > .bootstrap-datetimepicker-widget {
-  position: fixed !important;
-  top: 50% !important;
-  left: 50% !important;
-  transform: translateX(-50%) translateY(-50%) !important;
-  width: 70vw !important;
-  max-width: 500px !important;
-}
-
 .ql-tooltip[data-mode="link"] {
   left: 0 !important;
 }

--- a/src/assets/style/less/g3w-overwrite-extenal.less
+++ b/src/assets/style/less/g3w-overwrite-extenal.less
@@ -121,6 +121,16 @@ table.dataTable {
   }
 }
 
+// full screen date time picker (modal)
+.datimewidget_container > .bootstrap-datetimepicker-widget {
+  position: fixed !important;
+  top: 50% !important;
+  left: 50% !important;
+  transform: translateX(-50%) translateY(-50%) !important;
+  width: 70vw !important;
+  max-width: 500px !important;
+}
+
 .ql-tooltip[data-mode="link"] {
   left: 0 !important;
 }

--- a/src/components/InputDateTimePicker.vue
+++ b/src/components/InputDateTimePicker.vue
@@ -96,9 +96,11 @@ export default {
      */
     async onDatePickerShow(evt) {
       await this.$nextTick();
-      const { top, left, width } = this.$refs.datetimepicker_body.getBoundingClientRect();
-      this.widget_container.top = top;
-      this.widget_container.left = left - width;
+
+      const DOMContentPosition = document.getElementById('contents').getBoundingClientRect();
+      const { top, left, width, height } = this.$refs.datetimepicker_body.getBoundingClientRect();
+      this.widget_container.top = top  > 350 ? top : 350 ;
+      this.widget_container.left = left - (width > 220 ? width - 15 : 220);
       this.$emit('datetimepickershow');
     },
 
@@ -144,7 +146,8 @@ export default {
     } = formats[0];
 
     await this.$nextTick();
-    // set has widget input property instance
+
+      // set has widget input property instance
 
     this.datetimedisplayformat = this.service.convertQGISDateTimeFormatToMoment(displayformat);
     this.datetimefieldformat = this.service.convertQGISDateTimeFormatToMoment(fieldformat);

--- a/src/components/InputDateTimePicker.vue
+++ b/src/components/InputDateTimePicker.vue
@@ -104,7 +104,6 @@ export default {
         const modal                = document.querySelector('.bootstrap-datetimepicker-widget').getBoundingClientRect();
         this.widget_container.top  = container.top  + (container.top   < modal.height ? container.height + Math.abs(container.top - modal.height) + 20 : 0); // 20 = padding
         this.widget_container.left = container.left - (container.width < modal.width  ? modal.width : container.width);
-        console.log(widget, container);
         this.$emit('datetimepickershow');
       });
     },

--- a/src/components/InputDateTimePicker.vue
+++ b/src/components/InputDateTimePicker.vue
@@ -102,8 +102,8 @@ export default {
       setTimeout(() => {
         const container            = this.$refs.datetimepicker_body.getBoundingClientRect();
         const modal                = this.$refs.datimewidget_container.querySelector('.bootstrap-datetimepicker-widget').getBoundingClientRect();
-        this.widget_container.top  = container.top  + (container.top   < modal.height ? container.height + Math.abs(container.top - modal.height) + 20 : 0); // 20 = padding
-        this.widget_container.left = container.left - (container.width < modal.width  ? modal.width : container.width);
+        this.widget_container.top  = container.top  + (container.top < modal.height ? container.height + Math.abs(container.top - modal.height) + 20 : 0); // 20 = padding
+        this.widget_container.left = container.left - Math.max(container.width, modal.width);
         this.$emit('datetimepickershow');
       });
     },

--- a/src/components/InputDateTimePicker.vue
+++ b/src/components/InputDateTimePicker.vue
@@ -94,33 +94,19 @@ export default {
      * 
      * @since 3.8.0
      */
-    async onDatePickerShow(evt) {
-      //reset start position
-      this.widget_container = {
-        top: 0,
-        left: 0
-      };
-      let datetimeWidgetPosition;
-      //need to wait that dom widget is show
-      await new Promise((resolve) => {
-        setTimeout(() => {
-          datetimeWidgetPosition = document.getElementsByClassName('bootstrap-datetimepicker-widget')[0].getBoundingClientRect();
-          resolve()
-        })
+    onDatePickerShow(evt) {
+      // reset positions
+      this.widget_container.top  = 0;
+      this.widget_container.left = 0;
+      // wait until widget is present in DOM  
+      setTimeout(() => {
+        const container            = this.$refs.datetimepicker_body.getBoundingClientRect();
+        const modal                = document.querySelector('.bootstrap-datetimepicker-widget').getBoundingClientRect();
+        this.widget_container.top  = container.top  + (container.top   < modal.height ? container.height + Math.abs(container.top - modal.height) + 20 : 0); // 20 = padding
+        this.widget_container.left = container.left - (container.width < modal.width  ? modal.width : container.width);
+        console.log(widget, container);
+        this.$emit('datetimepickershow');
       });
-      //calculate
-      const { top, left, width, height } = this.$refs.datetimepicker_body.getBoundingClientRect();
-      //set widget top style position
-      this.widget_container.top = (top - datetimeWidgetPosition.height) < 0
-        ? Math.abs((top - datetimeWidgetPosition.height)) + top + height + 20 //padding
-        : top;
-
-      //set widget left style position
-      this.widget_container.left = left - ((width - datetimeWidgetPosition.width  < 0)
-        ? datetimeWidgetPosition.width
-        : width
-      );
-      this.$emit('datetimepickershow');
     },
 
     /**

--- a/src/components/InputDateTimePicker.vue
+++ b/src/components/InputDateTimePicker.vue
@@ -95,14 +95,31 @@ export default {
      * @since 3.8.0
      */
     async onDatePickerShow(evt) {
-      await this.$nextTick();
-      const { top, left, width } = this.$refs.datetimepicker_body.getBoundingClientRect();
+      //reset start position
+      this.widget_container = {
+        top: 0,
+        left: 0
+      };
+      let datetimeWidgetPosition;
+      //need to wait that dom widget is show
+      await new Promise((resolve) => {
+        setTimeout(() => {
+          datetimeWidgetPosition = document.getElementsByClassName('bootstrap-datetimepicker-widget')[0].getBoundingClientRect();
+          resolve()
+        })
+      });
+      //calculate
+      const { top, left, width, height } = this.$refs.datetimepicker_body.getBoundingClientRect();
       //set widget top style position
-      //350 are pixels height of datimepicker widget
-      this.widget_container.top = top  > 350 ? top : 350;
+      this.widget_container.top = (top - datetimeWidgetPosition.height) < 0
+        ? Math.abs((top - datetimeWidgetPosition.height)) + top + height + 20 //padding
+        : top;
+
       //set widget left style position
-      //220 are pixels width of datimepicker widget
-      this.widget_container.left = left - (width > 220 ? width : 220);
+      this.widget_container.left = left - ((width - datetimeWidgetPosition.width  < 0)
+        ? datetimeWidgetPosition.width
+        : width
+      );
       this.$emit('datetimepickershow');
     },
 

--- a/src/components/InputDateTimePicker.vue
+++ b/src/components/InputDateTimePicker.vue
@@ -96,11 +96,13 @@ export default {
      */
     async onDatePickerShow(evt) {
       await this.$nextTick();
-
-      const DOMContentPosition = document.getElementById('contents').getBoundingClientRect();
-      const { top, left, width, height } = this.$refs.datetimepicker_body.getBoundingClientRect();
-      this.widget_container.top = top  > 350 ? top : 350 ;
-      this.widget_container.left = left - (width > 220 ? width - 15 : 220);
+      const { top, left, width } = this.$refs.datetimepicker_body.getBoundingClientRect();
+      //set widget top style position
+      //350 are pixels height of datimepicker widget
+      this.widget_container.top = top  > 350 ? top : 350;
+      //set widget left style position
+      //220 are pixels width of datimepicker widget
+      this.widget_container.left = left - (width > 220 ? width : 220);
       this.$emit('datetimepickershow');
     },
 

--- a/src/components/InputDateTimePicker.vue
+++ b/src/components/InputDateTimePicker.vue
@@ -7,16 +7,6 @@
   <baseinput :state="state">
     <div slot="body" ref="datetimepicker_body">
 
-      <div
-        ref="datimewidget_container"
-        :style="{
-          top: widget_container.top + 'px',
-          left: widget_container.left + 'px',
-          position: 'fixed',
-          zIndex: 10000
-        }"
-      ></div>
-
       <div class='input-group date' :id='iddatetimepicker' v-disabled="!editable">
         <input
           type='text'
@@ -96,13 +86,6 @@ export default {
      */
     async onDatePickerShow(evt) {
       await this.$nextTick();
-      const { top, left, width } = this.$refs.datetimepicker_body.getBoundingClientRect();
-      //set widget top style position
-      //350 are pixels height of datimepicker widget
-      this.widget_container.top = top  > 350 ? top : 350;
-      //set widget left style position
-      //220 are pixels width of datimepicker widget
-      this.widget_container.left = left - (width > 220 ? width : 220);
       this.$emit('datetimepickershow');
     },
 
@@ -131,10 +114,10 @@ export default {
   async mounted() {
     const {
       formats = [],
-      layout = {
-        vertical: "top",
-        horizontal: "left"
-      }
+      // layout = {
+      //   vertical: "top",
+      //   horizontal: "left"
+      // }
     } = this.state.input.options;
 
     const {
@@ -162,6 +145,14 @@ export default {
         ? moment(this.state.value, this.datetimefieldformat).toDate()
         : null;
 
+    // since 3.9.0 (shared container)
+    let container = document.querySelector('.datimewidget_container');
+    if (!container) {
+      container    = document.createElement('div');
+      container.classList.add('datimewidget_container');
+      container.style.position = 'relative';
+      document.body.appendChild(container);
+    }
 
     $(`#${this.iddatetimepicker}`).datetimepicker({
       defaultDate: date,
@@ -174,11 +165,11 @@ export default {
       toolbarPlacement: 'top',
       minDate,
       maxDate,
-      widgetParent: $(this.$refs.datimewidget_container),
-      widgetPositioning: {
-        vertical: layout.vertical || 'top',
-        horizontal: layout.horizontal || 'left'
-      },
+      widgetParent: '.datimewidget_container',
+      // widgetPositioning: {
+      //   vertical: layout.vertical || 'top',
+      //   horizontal: layout.horizontal || 'left'
+      // },
       showClose: true,
       locale: this.service.getLocale()
     });

--- a/src/components/InputDateTimePicker.vue
+++ b/src/components/InputDateTimePicker.vue
@@ -13,7 +13,7 @@
           top: widget_container.top + 'px',
           left: widget_container.left + 'px',
           position: 'fixed',
-          zIndex: 10000
+          zIndex: 10000,
         }"
       ></div>
 
@@ -101,7 +101,7 @@ export default {
       // wait until widget is present in DOM  
       setTimeout(() => {
         const container            = this.$refs.datetimepicker_body.getBoundingClientRect();
-        const modal                = document.querySelector('.bootstrap-datetimepicker-widget').getBoundingClientRect();
+        const modal                = this.$refs.datimewidget_container.querySelector('.bootstrap-datetimepicker-widget').getBoundingClientRect();
         this.widget_container.top  = container.top  + (container.top   < modal.height ? container.height + Math.abs(container.top - modal.height) + 20 : 0); // 20 = padding
         this.widget_container.left = container.left - (container.width < modal.width  ? modal.width : container.width);
         this.$emit('datetimepickershow');

--- a/src/components/InputDateTimePicker.vue
+++ b/src/components/InputDateTimePicker.vue
@@ -7,6 +7,16 @@
   <baseinput :state="state">
     <div slot="body" ref="datetimepicker_body">
 
+      <div
+        ref="datimewidget_container"
+        :style="{
+          top: widget_container.top + 'px',
+          left: widget_container.left + 'px',
+          position: 'fixed',
+          zIndex: 10000
+        }"
+      ></div>
+
       <div class='input-group date' :id='iddatetimepicker' v-disabled="!editable">
         <input
           type='text'
@@ -86,6 +96,13 @@ export default {
      */
     async onDatePickerShow(evt) {
       await this.$nextTick();
+      const { top, left, width } = this.$refs.datetimepicker_body.getBoundingClientRect();
+      //set widget top style position
+      //350 are pixels height of datimepicker widget
+      this.widget_container.top = top  > 350 ? top : 350;
+      //set widget left style position
+      //220 are pixels width of datimepicker widget
+      this.widget_container.left = left - (width > 220 ? width : 220);
       this.$emit('datetimepickershow');
     },
 
@@ -114,10 +131,10 @@ export default {
   async mounted() {
     const {
       formats = [],
-      // layout = {
-      //   vertical: "top",
-      //   horizontal: "left"
-      // }
+      layout = {
+        vertical: "top",
+        horizontal: "left"
+      }
     } = this.state.input.options;
 
     const {
@@ -145,14 +162,6 @@ export default {
         ? moment(this.state.value, this.datetimefieldformat).toDate()
         : null;
 
-    // since 3.9.0 (shared container)
-    let container = document.querySelector('.datimewidget_container');
-    if (!container) {
-      container    = document.createElement('div');
-      container.classList.add('datimewidget_container');
-      container.style.position = 'relative';
-      document.body.appendChild(container);
-    }
 
     $(`#${this.iddatetimepicker}`).datetimepicker({
       defaultDate: date,
@@ -165,11 +174,11 @@ export default {
       toolbarPlacement: 'top',
       minDate,
       maxDate,
-      widgetParent: '.datimewidget_container',
-      // widgetPositioning: {
-      //   vertical: layout.vertical || 'top',
-      //   horizontal: layout.horizontal || 'left'
-      // },
+      widgetParent: $(this.$refs.datimewidget_container),
+      widgetPositioning: {
+        vertical: layout.vertical || 'top',
+        horizontal: layout.horizontal || 'left'
+      },
       showClose: true,
       locale: this.service.getLocale()
     });


### PR DESCRIPTION
Closes: #494 

## Before

![Screenshot from 2023-10-06 09-29-14](https://github.com/g3w-suite/g3w-client/assets/1051694/d130ffef-e2a6-4f3a-a92e-4b444f33c2d6)


## After

![Screenshot from 2023-10-06 09-46-12](https://github.com/g3w-suite/g3w-client/assets/1051694/a7dcfa53-b0b9-474b-9e44-644fa28070e4)
