### PR TITLE
Add search support for `Relation Reference` widget (1:N relations)

### DIFF
--- a/src/app/core/layers/filter/expression.js
+++ b/src/app/core/layers/filter/expression.js
@@ -10,11 +10,11 @@ function Expression(options={}) {
 const proto = Expression.prototype;
 
 proto.and = function(field, value) {
-    this._expression = this._expression ? this._expression + ' AND ': this._expression;
-    if (field && value) {
-      this.eq(field, value);
-    }
-    return this;
+  this._expression = this._expression ? this._expression + ' AND ': this._expression;
+  if (field && value) {
+    this.eq(field, value);
+  }
+  return this;
 };
 
 proto.or = function() {
@@ -88,20 +88,23 @@ proto.createSingleExpressionElement = function({value, attribute, operator, logi
     const _value = Array.isArray(value) ? value : [value];
     const filterValue = `( ${_value.map(value => `'${value}'`).join(',').replace(/,/g, ' , ')} )`;
     filterElement = `"${attribute}" ${filterOp} ${filterValue}${filterLogicOperator}`;
-  } else if ((value !== null && value !== undefined) && !(Number.isNaN(value) || !value.toString().trim())) {
-    const singolequote = typeof value !== 'number' ? value.split("'") : [];
+  } else if (
+    (value !== null && value !== undefined)
+    && !(Number.isNaN(value) || !value.toString().trim()) //check if a valid number (not a NaN and not an empty string)
+  ) {
+    const singolequote = Array.isArray(value) ? value :
+      typeof value !== 'number' ? value.split("'") : [];
     if (singolequote.length > 1) {
       const _filterElements = [];
       for (let i = 0; i < singolequote.length; i++) {
         const value = singolequote[i];
         if (!value)
           continue;
-        const filterOp = 'ILIKE';
         const filterValue = `%${value}%`.trim();
         const filterElement = `"${attribute}" ${filterOp} '${filterValue}'`;
         _filterElements.push(filterElement)
       }
-      filterElement =  `${_filterElements.join(' AND ')}${filterLogicOperator}`;
+      filterElement =  `${_filterElements.join(` ${logicop} `)}${filterLogicOperator}`;
     } else filterElement = `"${attribute}" ${filterOp} '${valueExtra}${value}${valueExtra}'${filterLogicOperator}`;
   }
   return filterElement;

--- a/src/app/core/layers/layer.js
+++ b/src/app/core/layers/layer.js
@@ -705,6 +705,7 @@ proto.searchFeatures = function(options = {}, params = {}) {
  * @param opts.suggest (mandatory): object with key is a field of layer and value is value of the field to filter
  * @param opts.field   Array of object with type of suggest (see above)
  * @param opts.unique
+ * @param opts.fformatter
  * @param opts.queryUrl
  * @param opts.ordering
  * @param { boolean } opts.raw
@@ -715,9 +716,10 @@ proto.getFilterData = async function({
   raw = false,
   suggest = {},
   unique,
+  fformatter, //@since v3.9
   formatter = 1,
   queryUrl,
-  ordering
+  ordering,
 } = {}) {
   return await this
     .getProvider('data')
@@ -729,6 +731,7 @@ proto.getFilterData = async function({
       suggest,
       formatter,
       unique,
+      fformatter,
     });
 };
 

--- a/src/app/core/layers/layer.js
+++ b/src/app/core/layers/layer.js
@@ -501,7 +501,7 @@ proto.searchFeatures = function(options = {}, params = {}) {
               ordering:  options.ordering,
               unique:    options.unique,
               raw:       undefined !== options.raw       ? options.raw       : false,
-              suggest:   undefined !== options.suggest   ? options.suggest   : {},
+              suggest:   options.suggest,
               /** @since 3.9.0 */
               formatter: undefined !== options.formatter ? options.formatter : 1,
             })
@@ -530,7 +530,7 @@ proto.searchFeatures = function(options = {}, params = {}) {
  */
 proto.getFilterData = async function({
   raw       = false,
-  suggest   = {},
+  suggest,
   field,
   unique,
   fformatter, //@since v3.9

--- a/src/app/core/layers/providersfactory.js
+++ b/src/app/core/layers/providersfactory.js
@@ -183,15 +183,16 @@ const Providers = {
     }
 
     /**
-     *
-     * @param field
-     * @param raw
-     * @param suggest
-     * @param unique
-     * @param formatter
-     * @param queryUrl
-     * @param ordering
-     * @param fformatter
+     * @param { Object } opts
+     * @param opts.field
+     * @param opts.raw
+     * @param opts.suggest
+     * @param opts.unique
+     * @param opts.formatter
+     * @param opts.queryUrl
+     * @param opts.ordering
+     * @param opts.fformatter since 3.9.0
+     * 
      * @returns {Promise<unknown>}
      */
     async getFilterData({
@@ -202,7 +203,7 @@ const Providers = {
       formatter = 1,
       queryUrl,
       ordering,
-      fformatter, //@since v3.9
+      fformatter,
     } = {}) {
       try {
         let response = await XHR.get({
@@ -223,19 +224,18 @@ const Providers = {
           this.setProjections();
         }
 
-        if (raw)                       return response;
-        if (unique && response.result) return response.data;
+        if (raw)                           return response;
+        if (unique && response.result)     return response.data;
+        if (fformatter && response.result) return response;
+
         if (response.result) {
-          if (fformatter) {
-            return response;
-          } else {
-            return {
-              data: Parsers.response.get('application/json')({
-                layers: [this._layer],
-                response: response.vector.data,
-                projections: this._projections
-              }) };
-          }
+          return {
+            data: Parsers.response.get('application/json')({
+              layers: [this._layer],
+              response: response.vector.data,
+              projections: this._projections,
+            })
+          };
         }
 
       } catch(e) {

--- a/src/app/core/layers/providersfactory.js
+++ b/src/app/core/layers/providersfactory.js
@@ -198,25 +198,36 @@ const Providers = {
     async getFilterData({
       field,
       raw = false,
-      suggest = {},
+      suggest,
       unique,
       formatter = 1,
       queryUrl,
       ordering,
       fformatter,
     } = {}) {
+      const params =  {
+        field,
+        suggest,
+        ordering,
+        formatter,
+        unique,
+        fformatter,
+        filtertoken: ApplicationState.tokens.filtertoken
+      };
       try {
-        let response = await XHR.get({
-          url: `${queryUrl ? queryUrl : this._layer.getUrl('data')}`,
-          params: {
-            field,
-            suggest,
-            ordering,
-            formatter,
-            unique,
-            fformatter,
-            filtertoken: ApplicationState.tokens.filtertoken
-          },
+        /**
+         * @TODO
+         * Need to check only if field parameter is set because g3w-suite <= v3.7 doesn't handle
+         * POST request for unique, ordering parameter
+         * @type {*}
+         */
+        const response = field ? await XHR.post({
+          url: `${queryUrl ?  queryUrl : dataUrl}`,
+          data: JSON.stringify(params),
+          contentType: 'application/json',
+        }) : await XHR.get({
+          url: `${queryUrl ?  queryUrl : dataUrl}`,
+          params
         });
 
         // vector layer

--- a/src/app/core/layers/providersfactory.js
+++ b/src/app/core/layers/providersfactory.js
@@ -215,20 +215,10 @@ const Providers = {
         filtertoken: ApplicationState.tokens.filtertoken
       };
       try {
-        /**
-         * @TODO
-         * Need to check only if field parameter is set because g3w-suite <= v3.7 doesn't handle
-         * POST request for unique, ordering parameter
-         * @type {*}
-         */
-        const response = field ? await XHR.post({
-          url: `${queryUrl ?  queryUrl : dataUrl}`,
-          data: JSON.stringify(params),
-          contentType: 'application/json',
-        }) : await XHR.get({
-          url: `${queryUrl ?  queryUrl : dataUrl}`,
-          params
-        });
+        const url = queryUrl ? queryUrl : this._layer.getUrl('data');
+        const response = field                                                                    // check `field` parameter
+          ? await XHR.post({ url, contentType: 'application/json', data: JSON.stringify(params)}) // since g3w-admin@v3.7
+          : await XHR.get({ url, params });                                                       // BACKCOMP (`unique` and `ordering` were only GET parameters)
 
         // vector layer
         if ('table' !== this._layer.getType()) {

--- a/src/app/core/layers/providersfactory.js
+++ b/src/app/core/layers/providersfactory.js
@@ -189,6 +189,18 @@ const Providers = {
       }
     }
 
+    /**
+     *
+     * @param field
+     * @param raw
+     * @param suggest
+     * @param unique
+     * @param formatter
+     * @param queryUrl
+     * @param ordering
+     * @param fformatter
+     * @returns {Promise<unknown>}
+     */
     async getFilterData({
       field,
       raw = false,
@@ -197,6 +209,7 @@ const Providers = {
       formatter = 1,
       queryUrl,
       ordering,
+      fformatter, //@since v3.9
     } = {}) {
       try {
         let response = await XHR.get({
@@ -207,6 +220,7 @@ const Providers = {
             ordering,
             formatter,
             unique,
+            fformatter,
             filtertoken: ApplicationState.tokens.filtertoken
           },
         });
@@ -218,7 +232,18 @@ const Providers = {
 
         if (raw)                       return response;
         if (unique && response.result) return response.data;
-        if (response.result)           return { data: Parsers.response.get('application/json')({ layers: [this._layer], response: response.vector.data, projections: this._projections }) };
+        if (response.result) {
+          if (fformatter) {
+            return response;
+          } else {
+            return {
+              data: Parsers.response.get('application/json')({
+                layers: [this._layer],
+                response: response.vector.data,
+                projections: this._projections
+              }) };
+          }
+        }
 
         return Promise.reject();
 

--- a/src/app/gui/search/vue/panel/searchservice.js
+++ b/src/app/gui/search/vue/panel/searchservice.js
@@ -100,6 +100,10 @@ function SearchService(config = {}) {
    * Create the form search structure
    */
   this.createInputsFormFromFilter({ filter: (options.filter || []) });
+
+  /**
+   * @TODO Handle https://github.com/g3w-suite/g3w-admin/pull/631
+   */
 }
 
 inherit(SearchService, G3WObject);

--- a/src/app/gui/search/vue/panel/searchservice.js
+++ b/src/app/gui/search/vue/panel/searchservice.js
@@ -39,61 +39,59 @@ function SearchService(config = {}) {
   base(this);
 
   // reactivity data
-  this.state = {
-    title: null,
-    forminputs: [],
-    loading: {},
-    searching: false
-  };
+  this.state             = {
+                            title: null,
+                            forminputs: [],
+                            loading: {},
+                            searching: false,
+                           };
 
-  this.config = config;
+  this.config            = config;
 
   const { options = {} } = this.config;
   const layerid          = options.querylayerid || options.layerid || null;
 
-  this.inputdependance = {};
+  this.inputdependance   = {};
 
   this.inputdependencies = {};
 
   this.cachedependencies = {};
 
-  this.project = ProjectsRegistry.getCurrentProject();
+  this.project           = ProjectsRegistry.getCurrentProject();
 
-  this.mapService = GUI.getService('map');
+  this.mapService        = GUI.getService('map');
 
-  this.searchLayer = null;
+  this.searchLayer       = null;
 
-  this.filter = null;
+  this.filter            = null;
 
-  this.inputs = [];
+  this.inputs            = [];
 
-  this.state.title = config.name;
+  this.state.title       = config.name;
 
-  this.search_endpoint = config.search_endpoint;
+  this.search_endpoint   = config.search_endpoint;
 
-  this.url = options.queryurl;
+  this.url               = options.queryurl;
 
-  this.filter = options.filter;
+  this.filter            = options.filter;
 
   /**
    * @type { 'search' | 'search_1n' }
    */
-  this.type = this.config.type || 'search';
+  this.type              = this.config.type || 'search';
 
-  this.return = options.return || 'data';
+  this.return            = options.return || 'data';
 
-  this.show = this.return === 'data' && this.type === 'search';
+  this.show              = this.return === 'data' && this.type === 'search';
 
-  this.searchLayer = CatalogLayersStoresRegistry.getLayerById(layerid);
+  this.searchLayer       = CatalogLayersStoresRegistry.getLayerById(layerid);
 
   /**
    * Store layers that will be searchable for that search form.
    * First one is layer owner of the search setted on admin.
    */
-  this.searchLayers = [
-    layerid,
-    ...(options.otherquerylayerids || [])
-  ].map(layerid => CatalogLayersStoresRegistry.getLayerById(layerid));
+  this.searchLayers      = [ layerid, ...(options.otherquerylayerids || []) ]
+                            .map(layerid => CatalogLayersStoresRegistry.getLayerById(layerid));
 
 
   /**
@@ -135,7 +133,7 @@ proto.createInputsFormFromFilter = async function({filter=[]}={}) {
       loading: false,
       widget: null
     };
-    //check if has a dependance
+    //check if it has a dependance
     const {options:{ dependance, dependance_strict } } = forminput;
     if (forminput.type === 'selectfield' || forminput.type === 'autocompletefield') {
       // to be sure set values options to empty array if undefined
@@ -160,7 +158,6 @@ proto.createInputsFormFromFilter = async function({filter=[]}={}) {
             resolve();
           }
         } else {
-
           // no dependence
           this.getValuesFromField(forminput)
             .then(values => { // return array of values
@@ -232,6 +229,11 @@ proto.setReturnType = function(returnType='data') {
   this.show   = ('data' === returnType);
 };
 
+/**
+ *
+ * @param field
+ * @returns {*}
+ */
 proto.getAutoFieldDependeciesParamField = function(field) {
   const fieldDependency = this.getCurrentFieldDependance(field);
   if (fieldDependency) {
@@ -240,8 +242,20 @@ proto.getAutoFieldDependeciesParamField = function(field) {
   }
 };
 
-proto.createFieldsDependenciesAutocompleteParameter = function({ fields = [], field, value }={}) {
+/**
+ *
+ * @param opts.fields
+ * @param opts.field
+ * @param opts.value
+ * @returns {string|undefined|*}
+ */
+proto.createFieldsDependenciesAutocompleteParameter = function({
+  fields = [],
+  field,
+  value
+} = {}) {
   const dependendency = this.getCurrentFieldDependance(field);
+
   if (undefined !== value) {
     fields.push(createSingleFieldParameter({ field, value, operator: this.getFilterInputFromField(field).op }));
   }
@@ -283,9 +297,16 @@ proto.getValuesFromField = async function(field) {
   if (field.options.values.length) {
     return this.getValueMapValues(field);
   }
+
   return this.getUniqueValuesFromField({ field:field.attribute })
 };
 
+/**
+ *
+ * @param field
+ * @param filter
+ * @returns {Promise<*[]>}
+ */
 proto.getValueRelationValues = async function(field, filter) {
   try {
     const { data = [] } = await DataRouterService.getData('search:features', {
@@ -301,7 +322,7 @@ proto.getValueRelationValues = async function(field, filter) {
     (data && data[0] && data[0].features || [])
       .forEach(feature => {
         values.push({ key: feature.get(field.options.key), value: feature.get(field.options.value) })
-    });
+      });
     return values;
   } catch(err) {
     return [];
@@ -333,7 +354,8 @@ proto.getValueMapValues = async function(field) {
 proto.getLayersFilterData = async function(layers, options = {}) {
   const { field, suggest, unique, ordering } = options;
   // get unique value from each layers
-  const promisesData = await Promise.allSettled(layers.map(layer => layer.getFilterData({ field, suggest, unique, ordering })));
+  const promisesData = await Promise
+    .allSettled(layers.map(layer => layer.getFilterData({ field, suggest, unique, ordering })));
 
   const data = Array.from(
     promisesData
@@ -445,7 +467,9 @@ proto.doSearch = async function({
  * @returns {*[]}
  */
 proto.filterValidFormInputs = function() {
-  return this.state.forminputs.filter(input => -1 === NONVALIDVALUES.indexOf(input.value) && '' !== input.value.toString().trim());
+  return this.state
+    .forminputs
+    .filter(input => -1 === NONVALIDVALUES.indexOf(input.value) && '' !== input.value.toString().trim());
 };
 
 /**
@@ -463,6 +487,10 @@ proto.createFilter = function(search_endpoint = this.getSearchEndPoint()) {
   return createFilterFormInputs({ layer: this.searchLayers, inputs: this.filterValidFormInputs(), search_endpoint });
 };
 
+/**
+ *
+ * @private
+ */
 proto._run = function() {
   this.doSearch();
 };
@@ -476,6 +504,11 @@ proto.changeInput = function({id, value} = {}) {
   this.state.forminputs.find(input => id == input.id).value = value;
 };
 
+/**
+ *
+ * @param filter
+ * @returns {{}}
+ */
 proto.createQueryFilterFromConfig = function({filter}) {
   let queryFilter;
   for (const operator in filter) {
@@ -484,10 +517,21 @@ proto.createQueryFilterFromConfig = function({filter}) {
   return queryFilter;
 };
 
+/**
+ *
+ * @param field
+ * @returns {*}
+ */
 proto.getFilterInputFromField = function(field) {
   return this.filter.find(input =>  input.attribute === field);
 };
 
+/**
+ *
+ * @param field
+ * @returns {*|null}
+ * @private
+ */
 proto._getExpressionOperatorFromInput = function(field) {
   const dependanceCascadeField = this.getFilterInputFromField(field);
   return dependanceCascadeField ? dependanceCascadeField.op : null;
@@ -521,7 +565,9 @@ proto.getCurrentFieldDependance = function(field) {
  * Check the current value of dependance
  */
 proto.getDependanceCurrentValue = function(field) {
-  return this.inputdependance[field] ? this.cachedependencies[this.inputdependance[field]]._currentValue : this.state.forminputs.find(forminput => forminput.attribute === field).value;
+  return this.inputdependance[field] ?
+    this.cachedependencies[this.inputdependance[field]]._currentValue :
+    this.state.forminputs.find(forminput => forminput.attribute === field).value;
 };
 
 /**
@@ -537,20 +583,25 @@ proto.fillDependencyInputs = function({field, subscribers=[], value=ALLVALUE}={}
     //loop over dependencies fields inputs
     subscribers.forEach(subscribe => {
       // in case of autocomplete reset values to empty array
-      if (subscribe.type === 'autocompletefield') subscribe.options.values.splice(0);
-      else {
+      if (subscribe.type === 'autocompletefield') {
+        subscribe.options.values.splice(0);
+      } else {
         //set starting all values
-        if (subscribe.options._allvalues === undefined) subscribe.options._allvalues = [...subscribe.options.values];
+        if (subscribe.options._allvalues === undefined) {
+          subscribe.options._allvalues = [...subscribe.options.values];
+        }
         //case of father is set an empty invalid value (all value example)
         if (invalidValue) {
           //subscribe has to set all valaues
           subscribe.options.values.splice(0);
           setTimeout(()=>subscribe.options.values = [...subscribe.options._allvalues]);
-        } else subscribe.options.values.splice(1); //otherwise has to get first __ALL_VALUE
+        } else {
+          subscribe.options.values.splice(1);
+        } //otherwise has to get first __ALL_VALUE
       }
       subscribe.value =  subscribe.type !== 'selectfield' ? ALLVALUE : null;
     });
-    // check i cache field values are set
+    // check if cache field values are set
     this.cachedependencies[field] = this.cachedependencies[field] || {};
     this.cachedependencies[field]._currentValue = value;
     const notAutocompleteSubscribers = subscribers.filter(subscribe => subscribe.type !== 'autocompletefield');
@@ -584,8 +635,9 @@ proto.fillDependencyInputs = function({field, subscribers=[], value=ALLVALUE}={}
         }
       } else {
         this.state.loading[field] = true;
-        if (isRoot) this.cachedependencies[field][value] = this.cachedependencies[field][value] || {};
-        else {
+        if (isRoot) {
+          this.cachedependencies[field][value] = this.cachedependencies[field][value] || {};
+        } else {
           const dependenceValue =  this.getDependanceCurrentValue(field);
           this.cachedependencies[field][dependenceValue] = this.cachedependencies[field][dependenceValue] || {};
           this.cachedependencies[field][dependenceValue][value] = this.cachedependencies[field][dependenceValue][value] || {}
@@ -600,54 +652,57 @@ proto.fillDependencyInputs = function({field, subscribers=[], value=ALLVALUE}={}
           // filter data from relation layer
           this.searchLayer.getFilterData({
             field: fieldParams
-          }).then(async data => {
-            const parentData = data.data[0].features || [];
-            for (let i = 0; i < notAutocompleteSubscribers.length; i++) {
-              const subscribe = notAutocompleteSubscribers[i];
-              const { attribute, widget } = subscribe;
-              const uniqueValues = new Set();
-              // case value map
-              if (widget === 'valuemap') {
-                let values = [...subscribe.options._values];
-                parentData.forEach(feature => {
-                  const value = feature.get(attribute);
-                  value && uniqueValues.add(value);
-                });
-                const data = [...uniqueValues];
-                values = values.filter(({key}) => data.indexOf(key) !== -1);
-                values.forEach(value => subscribe.options.values.push(value));
-              }
-              else if (widget === 'valuerelation') {
-                parentData.forEach(feature =>{
+          })
+            .then(async data => {
+              const parentData = data.data[0].features || [];
+              for (let i = 0; i < notAutocompleteSubscribers.length; i++) {
+                const subscribe = notAutocompleteSubscribers[i];
+                const { attribute, widget } = subscribe;
+                const uniqueValues = new Set();
+                // case value map
+                if (widget === 'valuemap') {
+                  let values = [...subscribe.options._values];
+                  parentData.forEach(feature => {
                     const value = feature.get(attribute);
                     value && uniqueValues.add(value);
                   });
-                  if (uniqueValues.size > 0) {
-                    const filter = createSingleFieldParameter({
-                      field: subscribe.options.key,
-                      value: [...uniqueValues]
-                    });
-                    try {
-                      const values = await this.getValueRelationValues(subscribe, filter);
-                      values.forEach(value =>  subscribe.options.values.push(value));
-                    } catch(err) {console.log(err)}
-                  }
+                  const data = [...uniqueValues];
+                  values = values.filter(({key}) => data.indexOf(key) !== -1);
+                  values.forEach(value => subscribe.options.values.push(value));
                 }
-              else {
-                parentData.forEach(feature => {
-                  const value = feature.get(attribute);
-                  value && uniqueValues.add(value);
-                });
-                this.valuesToKeysValues([...uniqueValues].sort()).forEach(value => subscribe.options.values.push(value));
+                else if (widget === 'valuerelation') {
+                  parentData.forEach(feature => {
+                      const value = feature.get(attribute);
+                      value && uniqueValues.add(value);
+                    });
+                    if (uniqueValues.size > 0) {
+                      const filter = createSingleFieldParameter({
+                        field: subscribe.options.key,
+                        value: [...uniqueValues]
+                      });
+                      try {
+                        const values = await this.getValueRelationValues(subscribe, filter);
+                        values.forEach(value =>  subscribe.options.values.push(value));
+                      } catch(err) {console.log(err)}
+                    }
+                  }
+                else {
+                  parentData.forEach(feature => {
+                    const value = feature.get(attribute);
+                    value && uniqueValues.add(value);
+                  });
+                  this.valuesToKeysValues([...uniqueValues].sort()).forEach(value => subscribe.options.values.push(value));
+                }
+                if (isRoot) {
+                  this.cachedependencies[field][value][subscribe.attribute] = subscribe.options.values.slice(1);
+                } else {
+                  const dependenceValue = this.getDependanceCurrentValue(field);
+                  this.cachedependencies[field][dependenceValue][value][subscribe.attribute] = subscribe.options.values.slice(1);
+                }
+                subscribe.options.disabled = false;
               }
-              if (isRoot) this.cachedependencies[field][value][subscribe.attribute] = subscribe.options.values.slice(1);
-              else {
-                const dependenceValue = this.getDependanceCurrentValue(field);
-                this.cachedependencies[field][dependenceValue][value][subscribe.attribute] = subscribe.options.values.slice(1);
-              }
-              subscribe.options.disabled = false;
-            }
-          }).catch(error => reject(error))
+            })
+            .catch(error => reject(error))
             .finally(() => {
             this.state.loading[field] = false;
             resolve();
@@ -655,23 +710,36 @@ proto.fillDependencyInputs = function({field, subscribers=[], value=ALLVALUE}={}
         } else {
           //set disable
           subscribers.forEach(subscribe => {
-            if (subscribe.options.dependance_strict) subscribe.options.disabled = false;
+            if (subscribe.options.dependance_strict) {
+              subscribe.options.disabled = false;
+            }
           });
           this.state.loading[field] = false;
           resolve();
         }
       }
     } else {
-      subscribers.forEach(subscribe => subscribe.options.disabled = subscribe.options.dependance_strict);
+      subscribers
+        .forEach(subscribe => subscribe.options.disabled = subscribe.options.dependance_strict);
       resolve();
     }
   })
 };
 
+/**
+ *
+ * @param field
+ * @returns {*|*[]}
+ */
 proto.getDependencies = function(field) {
   return this.inputdependencies[field] || [];
 };
 
+/**
+ *
+ * @param master
+ * @param slave
+ */
 proto.setInputDependencies = function({ master, slave }={}) {
   this.inputdependencies[master] = (undefined !== this.inputdependencies[master] ? this.inputdependencies[master] : []);
   this.inputdependencies[master].push(slave);
@@ -679,13 +747,26 @@ proto.setInputDependencies = function({ master, slave }={}) {
 
 //set key value for select
 proto.valuesToKeysValues = function(values) {
-  return values.length ? ('Object' !== toRawType(values[0]) ? values.map(value => ({ key: value, value })) : values) : values;
+  return values.length ?
+    ('Object' !== toRawType(values[0]) ? values.map(value => ({ key: value, value })) : values) :
+    values;
 };
 
+/**
+ *
+ * @param ogcService
+ * @param filter
+ * @returns {{infoFormat: *, crs: *, serverType, layers: *[], url: *} & {filter: {}, ogcService: string}}
+ */
 proto.createQueryFilterObject = function({ogcService='wms', filter={}}={}) {
   return Object.assign(this.getInfoFromLayer(ogcService), { ogcService, filter });
 };
 
+/**
+ *
+ * @param ogcService
+ * @returns {{infoFormat: *, crs: *, serverType, layers: *[], url: *}}
+ */
 proto.getInfoFromLayer = function(ogcService) {
   return {
     url: ('wfs' === ogcService ? this.searchLayer.getProject().getWmsUrl() : this.searchLayer.getQueryUrl()),
@@ -696,14 +777,25 @@ proto.getInfoFromLayer = function(ogcService) {
   };
 };
 
+/**
+ *
+ * @param layer
+ */
 proto.setSearchLayer = function(layer) {
   this.searchLayer = layer;
 };
 
+/**
+ *
+ * @returns {null|*}
+ */
 proto.getSearchLayer = function() {
   return this.searchLayer
 };
 
+/**
+ *
+ */
 proto.clear = function() {
   this.state = null;
 };
@@ -713,18 +805,18 @@ proto.clear = function() {
  */
 function create_boolean_filter(operator, inputs = []) {
   const boolean = { [operator]: [] };
-  inputs.forEach((input) => {
-    for (const operator in input) {
-      if (Array.isArray(input[operator])) {
-        create_boolean_filter(operator, input[operator]); // recursion step.
-        break;
+  inputs
+    .forEach((input) => {
+      for (const operator in input) {
+        if (Array.isArray(input[operator])) {
+          create_boolean_filter(operator, input[operator]); // recursion step.
+          break;
+        }
       }
-    }
-    boolean[operator].push({
-      [input.op] : {
+      boolean[operator].push({
+        [input.op] : {
         [input.attribute]: null
-      }
-    });
+      }});
   });
   return boolean;
 }

--- a/src/app/gui/search/vue/panel/searchservice.js
+++ b/src/app/gui/search/vue/panel/searchservice.js
@@ -38,70 +38,115 @@ function SearchService(config = {}) {
 
   base(this);
 
-  // reactivity data
-  this.state             = {
-                            title: null,
-                            forminputs: [],
-                            loading: {},
-                            searching: false,
-                           };
+  /**
+   * reactivity data
+   */
+  this.state = {
+    title: null,
+    forminputs: [],
+    loading: {},
+    searching: false,
+  };
 
+  /**
+   * @FIXME add description
+   */
   this.config            = config;
 
   const { options = {} } = this.config;
   const layerid          = options.querylayerid || options.layerid || null;
 
-  this.inputdependance   = {};
+  /**
+   * @FIXME add description
+   */
+  this.inputdependance = {};
 
+  /**
+   * @FIXME add description
+   */
   this.inputdependencies = {};
 
+  /**
+   * @FIXME add description
+   */
   this.cachedependencies = {};
 
-  this.project           = ProjectsRegistry.getCurrentProject();
+  /**
+   * @FIXME add description
+   */
+  this.project = ProjectsRegistry.getCurrentProject();
 
-  this.mapService        = GUI.getService('map');
+  /**
+   * @FIXME add description
+   */
+  this.mapService = GUI.getService('map');
 
-  this.searchLayer       = null;
+  /**
+   * @FIXME add description
+   */
+  this.searchLayer = null;
 
-  this.filter            = null;
+  /**
+   * @FIXME add description
+   */
+  this.filter = null;
 
-  this.inputs            = [];
+  /**
+   * @FIXME add description
+   */
+  this.inputs = [];
 
-  this.state.title       = config.name;
+  /**
+   * @FIXME add description
+   */
+  this.state.title = config.name;
 
-  this.search_endpoint   = config.search_endpoint;
+  /**
+   * @FIXME add description
+   */
+  this.search_endpoint = config.search_endpoint;
 
-  this.url               = options.queryurl;
+  /**
+   * @FIXME add description
+   */
+  this.url = options.queryurl;
 
-  this.filter            = options.filter;
+  /**
+   * @FIXME add description
+   */
+  this.filter = options.filter;
 
   /**
    * @type { 'search' | 'search_1n' }
    */
-  this.type              = this.config.type || 'search';
+  this.type = this.config.type || 'search';
 
-  this.return            = options.return || 'data';
+  /**
+   * @FIXME add description
+   */
+  this.return = options.return || 'data';
 
-  this.show              = this.return === 'data' && this.type === 'search';
+  /**
+   * @FIXME add description
+   */
+  this.show = 'data' === this.return && 'search' === this.type;
 
-  this.searchLayer       = CatalogLayersStoresRegistry.getLayerById(layerid);
+  /**
+   * @FIXME add description
+   */
+  this.searchLayer = CatalogLayersStoresRegistry.getLayerById(layerid);
 
   /**
    * Store layers that will be searchable for that search form.
    * First one is layer owner of the search setted on admin.
    */
-  this.searchLayers      = [ layerid, ...(options.otherquerylayerids || []) ]
-                            .map(layerid => CatalogLayersStoresRegistry.getLayerById(layerid));
-
+  this.searchLayers = [ layerid, ...(options.otherquerylayerids || []) ].map(id => CatalogLayersStoresRegistry.getLayerById(id));
 
   /**
    * Create the form search structure
    */
   this.createInputsFormFromFilter({ filter: (options.filter || []) });
 
-  /**
-   * @TODO Handle https://github.com/g3w-suite/g3w-admin/pull/631
-   */
 }
 
 inherit(SearchService, G3WObject);

--- a/src/components/Relation.vue
+++ b/src/components/Relation.vue
@@ -4,63 +4,186 @@
 -->
 
 <template>
-  <div class="query-relation" ref="query_relation" :class="isMobile() ? 'mobile' : null" style="margin-top: 3px;" v-if="table">
-    <div class="header skin-background-color lighten" ref="relation-header" style="padding: 3px; display: flex; justify-content: space-between; align-items: center; width: 100%;">
-      <div style="border-radius: 3px;" :style="{fontSize: isMobile() ? '1em' : '1.3em'}" class="g3w-long-text">
-        <span v-if="showrelationslist" style="font-size: 0.8em;" v-t-tooltip:right.create="'sdk.relations.back_to_relations'" class="action-button-icon action-button" :class="g3wtemplate.getFontClass('exit')" @click.stop="back"></span>
-        <span style="font-weight: bold" class="relation-tile skin-color"> {{ relation.name }}</span>
+  <div
+    v-if="table"
+    class="query-relation"
+    ref="query_relation"
+    :class="isMobile() ? 'mobile' : null"
+    style="margin-top: 3px;"
+  >
+    <div
+      class="header skin-background-color lighten"
+      ref="relation-header"
+      style="padding: 3px; display: flex; justify-content: space-between; align-items: center; width: 100%;"
+    >
+      <div
+        style="border-radius: 3px;"
+        :style="{fontSize: isMobile() ? '1em' : '1.3em'}"
+        class="g3w-long-text"
+      >
+        <span
+          v-if="showrelationslist"
+          style="font-size: 0.8em;"
+          v-t-tooltip:right.create="'sdk.relations.back_to_relations'"
+          class="action-button-icon action-button"
+          :class="g3wtemplate.getFontClass('exit')"
+          @click.stop="back">
+        </span>
+
+        <span
+          style="font-weight: bold"
+          class="relation-tile skin-color"
+        > {{ relation.name }}</span>
+
       </div>
-      <div class="relations-table-tools" v-if="table.rows.length" style="font-size: 1.1em; margin-bottom: 3px">
-          <span v-if="downloadButton" style="padding: 5px;" v-download class="action-button-icon action-button"
-            :class="[g3wtemplate.getFontClass('download'), {'toggled-white': downloadButton.toggled}]" @click="downloadButton.handler" v-t-tooltip:left.create="downloadButton.tooltip"></span>
-          <span v-if="showChartButton" style="padding: 5px;" class="action-button-icon action-button"
-            :class="[g3wtemplate.getFontClass('chart'), chart ? 'toggled-white' : '']" @click.stop="showChart" v-t-tooltip:bottom.create="'sdk.tooltips.show_chart'"></span>
-        </div>
+
+      <div
+        v-if="table.rows.length"
+        class="relations-table-tools"
+        style="font-size: 1.1em; margin-bottom: 3px"
+      >
+        <span
+          v-if="downloadButton"
+          style="padding: 5px;"
+          v-download
+          class="action-button-icon action-button"
+          :class="[
+            g3wtemplate.getFontClass('download'),
+            {'toggled-white': downloadButton.toggled}
+          ]"
+          @click.stop="downloadButton.handler"
+          v-t-tooltip:left.create="downloadButton.tooltip">
+        </span>
+        <span
+          v-if="showChartButton"
+          style="padding: 5px;"
+          class="action-button-icon action-button"
+          :class="[
+            g3wtemplate.getFontClass('chart'),
+            chart ? 'toggled-white' : ''
+           ]"
+          @click.stop="showChart"
+          v-t-tooltip:bottom.create="'sdk.tooltips.show_chart'"
+        ></span>
+
+      </div>
+
     </div>
-    <div v-if="table.rows.length" style="display: flex; justify-content: space-between; margin-bottom: 5px; margin-top: 3px; height: 95%;"  ref="relationwrapper">
-      <div id="table_content" :style="{width: chart ? '70%' : '100%', marginRight: chart ? '8px' : '3px', position: 'relative' }" ref="tablecontent">
+
+    <div
+      v-if="table.rows.length"
+      style="display: flex; justify-content: space-between; margin-bottom: 5px; margin-top: 3px; height: 95%;"
+      ref="relationwrapper"
+    >
+      <div
+        id="table_content"
+        :style="{width: chart ? '70%' : '100%', marginRight: chart ? '8px' : '3px', position: 'relative' }"
+        ref="tablecontent"
+      >
         <template v-if="headercomponent">
           <div style="width: 100%; display: flex; margin-left: auto; margin-bottom: 5px; margin-right: 4px;">
-            <component :is="headercomponent" :layer="downloadLayer.state" :config="downloadLayer.config"/>
+            <component
+              :is="headercomponent"
+              :layer="downloadLayer.state"
+              :config="downloadLayer.config"/>
           </div>
         </template>
-        <table ref="relationtable" class="hover relationtable table table-striped row-border" style="width:100%">
+        <table
+          ref="relationtable"
+          class="hover relationtable table table-striped row-border"
+          style="width:100%"
+        >
           <thead>
             <tr style="height: 0! important">
-              <th v-if="table.formStructure || isEditable" :style="{minWidth: `${((1*!!table.formStructure) + (1*isEditable))*30}px`, padding: '0 !important' }"></th>
-              <th v-for="column in table.columns">{{ column }}</th>
+              <th
+                v-if="table.formStructure || isEditable"
+                :style="{minWidth: `${((1*!!table.formStructure) + (1*isEditable))*30}px`, padding: '0 !important' }">
+              </th>
+              <th
+                v-for="column in table.columns">{{ column }}
+              </th>
             </tr>
           </thead>
+
           <tbody>
-          <tr v-for="(row, index) in table.rows" :key="table.rows_fid[index]" :class="{'selected': table.rowFormStructure === row}">
+
+          <tr
+            v-for="(row, index) in table.rows"
+            :key="table.rows_fid[index]"
+            :class="{'selected': table.rowFormStructure === row}"
+          >
             <td v-if="table.formStructure || isEditable">
-              <span v-if="table.formStructure" @click.stop="showFormStructureRow($event, row)" style="cursor: pointer" :current-tooltip="table.rowFormStructure === row ? 'sdk.tooltips.relations.form_to_row': 'sdk.tooltips.relations.row_to_form'"
-                class="action-button row-form skin-color" v-t-tooltip:right.create="table.rowFormStructure === row ? 'sdk.tooltips.relations.form_to_row': 'sdk.tooltips.relations.row_to_form'"
-                :class="[table.rowFormStructure === row ? g3wtemplate.getFontClass('minus') :  g3wtemplate.getFontClass('table')]"></span>
-              <span v-if="isEditable" @click.stop="editFeature(index)" class="action-button row-form skin-color" v-t-tooltip:right.create="'Edit'"
-                :class="g3wtemplate.getFontClass('pencil')"></span>
+              <span
+                v-if="table.formStructure"
+                @click.stop="showFormStructureRow($event, row)"
+                style="cursor: pointer"
+                :current-tooltip="table.rowFormStructure === row ? 'sdk.tooltips.relations.form_to_row': 'sdk.tooltips.relations.row_to_form'"
+                class="action-button row-form skin-color"
+                v-t-tooltip:right.create="table.rowFormStructure === row ? 'sdk.tooltips.relations.form_to_row': 'sdk.tooltips.relations.row_to_form'"
+                :class="[table.rowFormStructure === row ? g3wtemplate.getFontClass('minus') :  g3wtemplate.getFontClass('table')]">
+              </span>
+              <span
+                v-if="isEditable"
+                @click.stop="editFeature(index)"
+                class="action-button row-form skin-color"
+                v-t-tooltip:right.create="'Edit'"
+                :class="g3wtemplate.getFontClass('pencil')">
+              </span>
             </td>
+
             <template v-if="table.formStructure && table.rowFormStructure === row">
-              <td :colspan="table.columns.length" class="row-wrap-tabs">
-                <tabs :layerid="table.layerId" :feature="table.features[index]" :fields="fields" :tabs="table.formStructure"/>
+              <td
+                :colspan="table.columns.length"
+                class="row-wrap-tabs"
+              >
+                <tabs
+                  :layerid="table.layerId"
+                  :feature="table.features[index]"
+                  :fields="fields"
+                  :tabs="table.formStructure"/>
               </td>
             </template>
+
             <template v-else>
               <td v-for="value in row">
                 <field :state="{value:value}"/>
               </td>
             </template>
+
           </tr>
+
           </tbody>
+
         </table>
+
       </div>
-      <g3w-resize :show="chart" :moveFnc="moveFnc" :where="'content'" class="skin-border-color lighten" style="border-style: solid; border-width: 0 1px 0 1px"/>
-      <div v-show="chart" id="chart_content" :style="{width: chart ? '30%' : '0', paddingBottom: '5px', marginBottom: '5px', marginLeft: '8px' }" ref="chartcontent"></div>
+
+      <g3w-resize
+        :show="chart"
+        :moveFnc="moveFnc"
+        :where="'content'"
+        class="skin-border-color lighten"
+        style="border-style: solid; border-width: 0 1px 0 1px"/>
+
+      <div
+        v-show="chart"
+        id="chart_content"
+        :style="{width: chart ? '30%' : '0', paddingBottom: '5px', marginBottom: '5px', marginLeft: '8px' }"
+        ref="chartcontent">
+      </div>
+
     </div>
-    <div v-else class="dataTables_scrollBody" style="font-weight: bold; margin-top: 10px; font-size: 1.1em; display: flex; justify-content: space-between;">
+
+    <div
+      v-else
+      class="dataTables_scrollBody"
+      style="font-weight: bold; margin-top: 10px; font-size: 1.1em; display: flex; justify-content: space-between;"
+    >
       <span v-t="'sdk.relations.no_relations_found'"></span>
     </div>
+
   </div>
+
 </template>
 
 <script>
@@ -119,7 +242,11 @@ export default {
     }
   },
   methods: {
-    async createTable(){
+    /**
+     *
+     * @returns {Promise<void>}
+     */
+    async createTable() {
       const layer = CatalogLayersStoresRegistry.getLayerById(this.table.layerId);
       this.isEditable =  layer.isEditable() && !layer.isInEditing();
       const downloadformats = layer.isDownloadable() ? layer.getDownloadableFormats() : [];
@@ -149,7 +276,7 @@ export default {
       VM.$on('reload', () => {
         this.reloadLayout();
       });
-      this.showChart = throttle(async ()=> {
+      this.showChart = throttle(async () => {
         this.chart = !this.chart;
         await this.$nextTick();
         this.chartContainer = this.chartContainer ||  $('#chart_content');
@@ -180,7 +307,11 @@ export default {
       //In case of pop child relation need to resize
       GUI.on('pop-content', this.resize);
     },
-    async resize(){
+    /**
+     *
+     * @returns {Promise<void>}
+     */
+    async resize() {
       // in case of waiting table
       if (this.$refs.query_relation && this.$refs.query_relation.parentNode.style.display !== 'none') {
         const tableHeight = $(".content").height();
@@ -201,18 +332,32 @@ export default {
         this.reloadLayout();
       }
     },
-    saveRelation(type){
+    /**
+     *
+     * @param type
+     */
+    saveRelation(type) {
       this.$emit('save-relation', type);
       this.downloadButton.toggled = false;
     },
-    async showFormStructureRow(event, row){
+    /**
+     *
+     * @param event
+     * @param row
+     * @returns {Promise<void>}
+     */
+    async showFormStructureRow(event, row) {
       this.table.rowFormStructure = this.table.rowFormStructure === row ? null : row;
       this.fields = this.getRowFields(row);
       await this.$nextTick();
       $('#relationtable_wrapper div.dataTables_scrollBody').css('overflow-x', this.table.rowFormStructure  ? 'hidden' : 'auto');
       this.resize();
     },
-    editFeature(index){
+    /**
+     *
+     * @param index
+     */
+    editFeature(index) {
       const queryResultsService = GUI.getService('queryresults');
       queryResultsService.editFeature({
         layer: {
@@ -222,6 +367,11 @@ export default {
         feature: this.table.features[index]
       });
     },
+    /**
+     *
+     * @param row
+     * @returns {*}
+     */
     getRowFields(row){
       return this.table.fields.map((field, index)=> {
         field.value = row[index];
@@ -232,22 +382,44 @@ export default {
         return field;
       });
     },
+    /**
+     *
+     */
     reloadLayout() {
       this.relationDataTable && this.relationDataTable.columns.adjust();
     },
+    /**
+     *
+     */
     back() {
       this.$parent.setRelationsList();
     },
+    /**
+     *
+     * @param type
+     * @param value
+     * @returns {boolean}
+     */
     fieldIs(type, value) {
       const fieldType = this.getFieldType(value);
       return fieldType === type;
     },
+    /**
+     *
+     * @param type
+     * @param value
+     * @returns {boolean}
+     */
     is(type,value) {
       return this.fieldIs(type, value);
     },
+    /**
+     *
+     * @param evt
+     */
     moveFnc(evt){
-      const sidebarHeaderSize =  $('.sidebar-collapse').length ? 0 : SIDEBARWIDTH;
-      const size = evt.pageX+2 - sidebarHeaderSize;
+      const sidebarHeaderSize             =  $('.sidebar-collapse').length ? 0 : SIDEBARWIDTH;
+      const size                          = evt.pageX+2 - sidebarHeaderSize;
       this.$refs.tablecontent.style.width = `${size}px`;
       this.$refs.chartcontent.style.width = `${$(this.$refs.relationwrapper).width() - size - 10}px`;
     }
@@ -260,11 +432,11 @@ export default {
         table && table.rows.length && this.createTable();
       }
     },
-    async chart(){
+    async chart() {
       await this.$nextTick();
       this.resize();
     },
-    async headercomponent(){
+    async headercomponent() {
       await this.$nextTick();
       this.resize();
     }
@@ -272,7 +444,7 @@ export default {
   beforeCreate() {
     this.delayType = 'debounce';
   },
-  async beforeDestroy(){
+  async beforeDestroy() {
     if (this.relationDataTable){
       this.relationDataTable.destroy();
       this.relationDataTable = null;

--- a/src/components/Relation.vue
+++ b/src/components/Relation.vue
@@ -5,65 +5,65 @@
 
 <template>
   <div
-    v-if="table"
-    class="query-relation"
-    ref="query_relation"
-    :class="isMobile() ? 'mobile' : null"
-    style="margin-top: 3px;"
+    v-if   = "table"
+    class  = "query-relation"
+    ref    = "query_relation"
+    :class = "isMobile() ? 'mobile' : null"
+    style  = "margin-top: 3px;"
   >
     <div
-      class="header skin-background-color lighten"
-      ref="relation-header"
-      style="padding: 3px; display: flex; justify-content: space-between; align-items: center; width: 100%;"
+      class = "header skin-background-color lighten"
+      ref   = "relation-header"
+      style = "padding: 3px; display: flex; justify-content: space-between; align-items: center; width: 100%;"
     >
       <div
-        style="border-radius: 3px;"
-        :style="{fontSize: isMobile() ? '1em' : '1.3em'}"
-        class="g3w-long-text"
+        style  = "border-radius: 3px;"
+        :style = "{fontSize: isMobile() ? '1em' : '1.3em'}"
+        class  = "g3w-long-text"
       >
         <span
-          v-if="showrelationslist"
-          style="font-size: 0.8em;"
-          v-t-tooltip:right.create="'sdk.relations.back_to_relations'"
-          class="action-button-icon action-button"
-          :class="g3wtemplate.getFontClass('exit')"
-          @click.stop="back">
+          v-if                     = "showrelationslist"
+          style                    = "font-size: 0.8em;"
+          v-t-tooltip:right.create = "'sdk.relations.back_to_relations'"
+          class                    = "action-button-icon action-button"
+          :class                   = "g3wtemplate.getFontClass('exit')"
+          @click.stop              = "back">
         </span>
 
         <span
-          style="font-weight: bold"
-          class="relation-tile skin-color"
+          style = "font-weight: bold"
+          class = "relation-tile skin-color"
         > {{ relation.name }}</span>
 
       </div>
 
       <div
-        v-if="table.rows.length"
-        class="relations-table-tools"
-        style="font-size: 1.1em; margin-bottom: 3px"
+        v-if  = "table.rows.length"
+        class = "relations-table-tools"
+        style = "font-size: 1.1em; margin-bottom: 3px"
       >
         <span
-          v-if="downloadButton"
-          style="padding: 5px;"
+          v-if                    = "downloadButton"
+          style                   = "padding: 5px;"
           v-download
-          class="action-button-icon action-button"
-          :class="[
+          :class                  = "[
+            'action-button-icon action-button',
             g3wtemplate.getFontClass('download'),
-            {'toggled-white': downloadButton.toggled}
+            { 'toggled-white': downloadButton.toggled },
           ]"
-          @click.stop="downloadButton.handler"
-          v-t-tooltip:left.create="downloadButton.tooltip">
+          @click.stop             = "downloadButton.handler"
+          v-t-tooltip:left.create = "downloadButton.tooltip">
         </span>
         <span
-          v-if="showChartButton"
-          style="padding: 5px;"
-          class="action-button-icon action-button"
-          :class="[
+          v-if                      = "showChartButton"
+          style                     = "padding: 5px;"
+          :class                    = "[
+            'action-button-icon action-button',
             g3wtemplate.getFontClass('chart'),
-            chart ? 'toggled-white' : ''
+            { 'toggled-white': chart },
            ]"
-          @click.stop="showChart"
-          v-t-tooltip:bottom.create="'sdk.tooltips.show_chart'"
+          @click.stop               = "showChart"
+          v-t-tooltip:bottom.create = "'sdk.tooltips.show_chart'"
         ></span>
 
       </div>
@@ -71,83 +71,89 @@
     </div>
 
     <div
-      v-if="table.rows.length"
-      style="display: flex; justify-content: space-between; margin-bottom: 5px; margin-top: 3px; height: 95%;"
-      ref="relationwrapper"
+      v-if  = "table.rows.length"
+      style = "display: flex; justify-content: space-between; margin-bottom: 5px; margin-top: 3px; height: 95%;"
+      ref   = "relationwrapper"
     >
       <div
-        id="table_content"
-        :style="{width: chart ? '70%' : '100%', marginRight: chart ? '8px' : '3px', position: 'relative' }"
-        ref="tablecontent"
+        id     = "table_content"
+        :style = "{
+          width: chart ? '70%' : '100%',
+          marginRight: chart ? '8px' : '3px',
+          position: 'relative',
+        }"
+        ref    = "tablecontent"
       >
-        <template v-if="headercomponent">
-          <div style="width: 100%; display: flex; margin-left: auto; margin-bottom: 5px; margin-right: 4px;">
-            <component
-              :is="headercomponent"
-              :layer="downloadLayer.state"
-              :config="downloadLayer.config"/>
-          </div>
-        </template>
+        <div
+          v-if  = "headercomponent"
+          style = "width: 100%; display: flex; margin-left: auto; margin-bottom: 5px; margin-right: 4px;"
+        >
+          <component
+            :is     = "headercomponent"
+            :layer  = "downloadLayer.state"
+            :config = "downloadLayer.config"
+          />
+        </div>
         <table
-          ref="relationtable"
-          class="hover relationtable table table-striped row-border"
-          style="width:100%"
+          ref   = "relationtable"
+          class = "hover relationtable table table-striped row-border"
+          style = "width:100%"
         >
           <thead>
             <tr style="height: 0! important">
               <th
-                v-if="table.formStructure || isEditable"
-                :style="{minWidth: `${((1*!!table.formStructure) + (1*isEditable))*30}px`, padding: '0 !important' }">
-              </th>
-              <th
-                v-for="column in table.columns">{{ column }}
-              </th>
+                v-if   = "table.formStructure || isEditable"
+                :style = "{
+                  minWidth: `${((1*!!table.formStructure) + (1*isEditable))*30}px`,
+                  padding:  '0 !important',
+                }"
+              ></th>
+              <th v-for="column in table.columns">{{ column }}</th>
             </tr>
           </thead>
 
           <tbody>
 
           <tr
-            v-for="(row, index) in table.rows"
-            :key="table.rows_fid[index]"
-            :class="{'selected': table.rowFormStructure === row}"
+            v-for  = "(row, index) in table.rows"
+            :key   = "table.rows_fid[index]"
+            :class = "{'selected': table.rowFormStructure === row}"
           >
             <td v-if="table.formStructure || isEditable">
               <span
-                v-if="table.formStructure"
-                @click.stop="showFormStructureRow($event, row)"
-                style="cursor: pointer"
-                :current-tooltip="table.rowFormStructure === row ? 'sdk.tooltips.relations.form_to_row': 'sdk.tooltips.relations.row_to_form'"
-                class="action-button row-form skin-color"
-                v-t-tooltip:right.create="table.rowFormStructure === row ? 'sdk.tooltips.relations.form_to_row': 'sdk.tooltips.relations.row_to_form'"
-                :class="[table.rowFormStructure === row ? g3wtemplate.getFontClass('minus') :  g3wtemplate.getFontClass('table')]">
-              </span>
+                v-if                     = "table.formStructure"
+                @click.stop              = "showFormStructureRow($event, row)"
+                style                    = "cursor: pointer"
+                :current-tooltip         = "table.rowFormStructure === row ? 'sdk.tooltips.relations.form_to_row': 'sdk.tooltips.relations.row_to_form'"
+                v-t-tooltip:right.create = "table.rowFormStructure === row ? 'sdk.tooltips.relations.form_to_row': 'sdk.tooltips.relations.row_to_form'"
+                :class                   = "[
+                  'action-button row-form skin-color',
+                  g3wtemplate.getFontClass(table.rowFormStructure === row ? 'minus' : 'table')
+                  ]"
+                ></span>
               <span
-                v-if="isEditable"
-                @click.stop="editFeature(index)"
-                class="action-button row-form skin-color"
-                v-t-tooltip:right.create="'Edit'"
-                :class="g3wtemplate.getFontClass('pencil')">
+                v-if                     = "isEditable"
+                @click.stop              = "editFeature(index)"
+                class                    = "action-button row-form skin-color"
+                v-t-tooltip:right.create = "'Edit'"
+                :class                   = "g3wtemplate.getFontClass('pencil')">
               </span>
             </td>
 
-            <template v-if="table.formStructure && table.rowFormStructure === row">
-              <td
-                :colspan="table.columns.length"
-                class="row-wrap-tabs"
-              >
-                <tabs
-                  :layerid="table.layerId"
-                  :feature="table.features[index]"
-                  :fields="fields"
-                  :tabs="table.formStructure"/>
-              </td>
-            </template>
-
+            <td
+              v-if     = "table.formStructure && table.rowFormStructure === row"
+              :colspan = "table.columns.length"
+              class    = "row-wrap-tabs"
+            >
+              <tabs
+                :layerid = "table.layerId"
+                :feature = "table.features[index]"
+                :fields  = "fields"
+                :tabs    = "table.formStructure"
+              />
+            </td>
             <template v-else>
-              <td v-for="value in row">
-                <field :state="{value:value}"/>
-              </td>
+              <td v-for="value in row"><field :state="{value:value}"/></td>
             </template>
 
           </tr>
@@ -159,25 +165,30 @@
       </div>
 
       <g3w-resize
-        :show="chart"
-        :moveFnc="moveFnc"
-        :where="'content'"
-        class="skin-border-color lighten"
-        style="border-style: solid; border-width: 0 1px 0 1px"/>
+        :show    = "chart"
+        :moveFnc = "moveFnc"
+        :where   = "'content'"
+        class    = "skin-border-color lighten"
+        style    = "border-style: solid; border-width: 0 1px 0 1px"
+      />
 
       <div
-        v-show="chart"
-        id="chart_content"
-        :style="{width: chart ? '30%' : '0', paddingBottom: '5px', marginBottom: '5px', marginLeft: '8px' }"
-        ref="chartcontent">
-      </div>
+        v-show   = "chart"
+        id       = "chart_content"
+        :style   = "{
+          width: chart ? '30%' : '0',
+          paddingBottom: '5px',
+          marginBottom: '5px',
+          marginLeft: '8px',
+        }"
+        ref      = "chartcontent"
+      ></div>
 
     </div>
 
-    <div
-      v-else
-      class="dataTables_scrollBody"
-      style="font-weight: bold; margin-top: 10px; font-size: 1.1em; display: flex; justify-content: space-between;"
+    <div v-else
+      class = "dataTables_scrollBody"
+      style = "font-weight: bold; margin-top: 10px; font-size: 1.1em; display: flex; justify-content: space-between;"
     >
       <span v-t="'sdk.relations.no_relations_found'"></span>
     </div>
@@ -187,15 +198,14 @@
 </template>
 
 <script>
-import { G3W_FID } from 'app/constant';
-import Field from 'components/FieldG3W.vue';
-import DownloadFormats from 'components/QueryResultsActionDownloadFormats.vue';
-import CatalogLayersStoresRegistry from 'store/catalog-layers';
-import GUI from 'services/gui';
+import { G3W_FID }                  from 'app/constant';
+import Field                        from 'components/FieldG3W.vue';
+import DownloadFormats              from 'components/QueryResultsActionDownloadFormats.vue';
+import CatalogLayersStoresRegistry  from 'store/catalog-layers';
+import GUI                          from 'services/gui';
 import { fieldsMixin, resizeMixin } from 'mixins';
-import { RelationEventBus as VM } from 'app/eventbus';
-
-const { throttle } = require('utils');
+import { RelationEventBus as VM }   from 'app/eventbus';
+import { throttle }                 from 'utils';
 
 let SIDEBARWIDTH;
 
@@ -205,21 +215,23 @@ export default {
   name: 'relation',
 
   props: {
-    table: {},
-    feature: {
-      default: null
-    },
-    relation: {},
-    previousview: {},
+    table:           {},
+    feature:         { default: null },
+    relation:        {},
+    previousview:    {},
     showChartButton: {},
-    cardinality:{},
+    cardinality:     {},
   },
+
   inject: ['relationnoback'],
+
   mixins: [fieldsMixin, resizeMixin],
+
   components: {
-    Field
+    Field,
   },
-  data(){
+
+  data() {
     return {
       fields: null,
       chart: false,
@@ -228,23 +240,28 @@ export default {
       downloadLayer: {
         state: null,
         config: {
-          downloads:[]
-        }
-      }
-    }
+          downloads: [],
+        },
+      },
+    };
   },
+
   computed: {
+
     showrelationslist() {
-      return this.previousview === 'relations' && !this.relationnoback;
+      return 'relations' === this.previousview  && !this.relationnoback;
     },
+
     one() {
-      return this.relation.type === 'ONE';
-    }
+      return 'ONE' === this.relation.type;
+    },
+
   },
+
   methods: {
+
     /**
-     *
-     * @returns {Promise<void>}
+     * @returns { Promise<void> }
      */
     async createTable() {
       const layer = CatalogLayersStoresRegistry.getLayerById(this.table.layerId);
@@ -307,9 +324,9 @@ export default {
       //In case of pop child relation need to resize
       GUI.on('pop-content', this.resize);
     },
+
     /**
-     *
-     * @returns {Promise<void>}
+     * @returns { Promise<void> }
      */
     async resize() {
       // in case of waiting table
@@ -332,19 +349,20 @@ export default {
         this.reloadLayout();
       }
     },
+
     /**
-     *
      * @param type
      */
     saveRelation(type) {
       this.$emit('save-relation', type);
       this.downloadButton.toggled = false;
     },
+
     /**
-     *
      * @param event
      * @param row
-     * @returns {Promise<void>}
+     * 
+     * @returns { Promise<void> }
      */
     async showFormStructureRow(event, row) {
       this.table.rowFormStructure = this.table.rowFormStructure === row ? null : row;
@@ -353,8 +371,8 @@ export default {
       $('#relationtable_wrapper div.dataTables_scrollBody').css('overflow-x', this.table.rowFormStructure  ? 'hidden' : 'auto');
       this.resize();
     },
+
     /**
-     *
      * @param index
      */
     editFeature(index) {
@@ -367,12 +385,13 @@ export default {
         feature: this.table.features[index]
       });
     },
+
     /**
-     *
      * @param row
+     * 
      * @returns {*}
      */
-    getRowFields(row){
+    getRowFields(row) {
       return this.table.fields.map((field, index)=> {
         field.value = row[index];
         field.query = true;
@@ -382,77 +401,94 @@ export default {
         return field;
       });
     },
+
     /**
-     *
+     * @FIXME add description
      */
     reloadLayout() {
       this.relationDataTable && this.relationDataTable.columns.adjust();
     },
+
     /**
-     *
+     * @FIXME add description
      */
     back() {
       this.$parent.setRelationsList();
     },
+
     /**
-     *
      * @param type
      * @param value
-     * @returns {boolean}
+     * 
+     * @returns { boolean }
      */
     fieldIs(type, value) {
       const fieldType = this.getFieldType(value);
       return fieldType === type;
     },
+
     /**
-     *
      * @param type
      * @param value
-     * @returns {boolean}
+     * 
+     * @returns { boolean }
      */
-    is(type,value) {
+    is(type, value) {
       return this.fieldIs(type, value);
     },
+
     /**
-     *
      * @param evt
      */
-    moveFnc(evt){
+    moveFnc(evt) {
       const sidebarHeaderSize             =  $('.sidebar-collapse').length ? 0 : SIDEBARWIDTH;
       const size                          = evt.pageX+2 - sidebarHeaderSize;
       this.$refs.tablecontent.style.width = `${size}px`;
       this.$refs.chartcontent.style.width = `${$(this.$refs.relationwrapper).width() - size - 10}px`;
-    }
+    },
+
   },
+
   watch: {
-    // in case of show relation directly
+
+    /**
+     * in case of show relation directly
+     */
     table: {
       immediate: true,
       handler(table) {
         table && table.rows.length && this.createTable();
       }
     },
+
     async chart() {
       await this.$nextTick();
       this.resize();
     },
+
     async headercomponent() {
       await this.$nextTick();
       this.resize();
-    }
+    },
+
   },
+
   beforeCreate() {
     this.delayType = 'debounce';
   },
+
   async beforeDestroy() {
-    if (this.relationDataTable){
-      this.relationDataTable.destroy();
-      this.relationDataTable = null;
-      this.chartContainer && this.$emit('hide-chart', this.chartContainer);
-      this.chartContainer = null;
-      this.tableHeaderHeight = null;
-      GUI.off('pop-content', this.resize);
+    // skip when ..
+    if (!this.relationDataTable) {
+      return;
     }
-  }
+    this.relationDataTable.destroy();
+    this.relationDataTable = null;
+    this.chartContainer && this.$emit('hide-chart', this.chartContainer);
+    this.chartContainer = null;
+    this.tableHeaderHeight = null;
+    GUI.off('pop-content', this.resize);
+  },
+
 };
 </script>

--- a/src/utils/createSingleFieldParameter.js
+++ b/src/utils/createSingleFieldParameter.js
@@ -1,6 +1,10 @@
 import { FILTER_EXPRESSION_OPERATORS } from 'app/constant';
+import {
+  createFilterFromString
+} from "./createFilterFromString";
 
 /**
+ * @param layer
  * @param field
  * @param value
  * @param operator
@@ -12,6 +16,7 @@ import { FILTER_EXPRESSION_OPERATORS } from 'app/constant';
  * @since 3.8.7
  */
 export function createSingleFieldParameter({
+  layer,
   field,
   value,
   operator        = 'eq',
@@ -34,16 +39,25 @@ export function createSingleFieldParameter({
     return `${field}|${operator.toLowerCase()}|${encodeURIComponent(value)}${logicop ? `|${logicop}` : ''}`;
   }
 
-  /** @TODO add description */
+  //store string filter
+  let filter = '';
+
+  /**If value is array of values */
   if (Array.isArray(value)) {
-    let filter = '';
+
     const valueLenght = value.length;
     value.forEach((value, index) => {
-      filter+=`"${field}" ${FILTER_EXPRESSION_OPERATORS[operator]} '${encodeURIComponent(value)}' ${index < valueLenght - 1 ? `${logicop} ` : ''}`
+      filter += `"${field}" ${FILTER_EXPRESSION_OPERATORS[operator]} '${encodeURIComponent(value)}' ${index < valueLenght - 1 ? `${logicop} ` : ''}`
     });
-    return filter
+  } else {
+    //single value
+    filter = `"${field}" ${FILTER_EXPRESSION_OPERATORS[operator]} '${encodeURIComponent(value)}'`;
   }
 
-  /** @TODO add description */
-  return `"${field}" ${FILTER_EXPRESSION_OPERATORS[operator]} '${encodeURIComponent(value)}'`;
+  return createFilterFromString({
+    layer,
+    search_endpoint,
+    filter
+  })
+
 };

--- a/src/utils/createSingleFieldParameter.js
+++ b/src/utils/createSingleFieldParameter.js
@@ -1,15 +1,14 @@
 import { FILTER_EXPRESSION_OPERATORS } from 'app/constant';
-import {
-  createFilterFromString
-} from "./createFilterFromString";
+import { createFilterFromString } from './createFilterFromString';
 
 /**
- * @param layer
- * @param field
- * @param value
- * @param operator
- * @param logicop // set OR as default
- * @param search_endpoint
+ * @param { Object } opts
+ * @param opts.layer
+ * @param opts.field
+ * @param opts.value
+ * @param { string } [opts.operator='eq']         'eq' as default
+ * @param { string } [opts.logicop='OR']          'OR' as default
+ * @param { string } [opts.search_endpoint='api'] 'api' as default
  * 
  * @returns {string}
  * 
@@ -39,12 +38,11 @@ export function createSingleFieldParameter({
     return `${field}|${operator.toLowerCase()}|${encodeURIComponent(value)}${logicop ? `|${logicop}` : ''}`;
   }
 
-  //store string filter
+  // store filter string 
   let filter = '';
 
-  /**If value is array of values */
+  // value is array of values
   if (Array.isArray(value)) {
-
     const valueLenght = value.length;
     value.forEach((value, index) => {
       filter += `"${field}" ${FILTER_EXPRESSION_OPERATORS[operator]} '${encodeURIComponent(value)}' ${index < valueLenght - 1 ? `${logicop} ` : ''}`
@@ -57,7 +55,7 @@ export function createSingleFieldParameter({
   return createFilterFromString({
     layer,
     search_endpoint,
-    filter
-  })
+    filter,
+  });
 
 };


### PR DESCRIPTION
## Depends on:

- https://github.com/g3w-suite/g3w-admin/pull/631
- https://github.com/g3w-suite/g3w-client-plugin-editing/pull/73

## Summary

Add support for **search** and **editing** capabilities on Relation Reference widget (1:N relations).

Ref: https://github.com/g3w-suite/g3w-admin/issues/616

## Demo project --> [demo-buildings.zip](https://github.com/g3w-suite/g3w-client/files/13306073/demo-buildings.zip)

## Before

![image](https://github.com/g3w-suite/g3w-client/assets/9614886/43efaea2-2bcc-40ef-b3e5-cc7b056c800f)

## After

![image](https://github.com/g3w-suite/g3w-client/assets/9614886/1180cb69-c11d-4082-8b35-2084887b0fd9)

## G3W-ADMIN configuration

![image](https://github.com/g3w-suite/g3w-client/assets/9614886/8c29d55e-f5f7-49a4-a13a-0ba1d50b1d17)

![image](https://github.com/g3w-suite/g3w-client/assets/9614886/cf63da52-8357-4348-b9c1-f36c5aa4a077)

## QGIS configuration --> [16.1.9.2 Edit widgets > Relation Reference](https://docs.qgis.org/3.28/en/docs/user_manual/working_with_vector/vector_properties.html?highlight=relation%20widget#edit-widgets)

![Screenshot from 2023-10-27 14-58-07](https://github.com/g3w-suite/g3w-client/assets/1051694/cf80be1c-d72d-4972-a446-6bd5c970fb8c)

