### PR TITLE
Fix not empty results for 1:N relations (search widget)

### DIFF
--- a/src/app/core/layers/filter/expression.js
+++ b/src/app/core/layers/filter/expression.js
@@ -88,8 +88,12 @@ proto.createSingleExpressionElement = function({value, attribute, operator, logi
     const _value = Array.isArray(value) ? value : [value];
     const filterValue = `( ${_value.map(value => `'${value}'`).join(',').replace(/,/g, ' , ')} )`;
     filterElement = `"${attribute}" ${filterOp} ${filterValue}${filterLogicOperator}`;
-  } else if ((value !== null && value !== undefined) && !(Number.isNaN(value) || !value.toString().trim())) {
-    const singolequote = typeof value !== 'number' ? value.split("'") : [];
+  } else if (
+      (value !== null && value !== undefined)
+      && !(Number.isNaN(value) || !value.toString().trim()) //check if a valid number (not a NaN and not an empty string)
+    ) {
+    const singolequote = Array.isArray(value) ? value :
+      typeof value !== 'number' ? value.split("'") : [];
     if (singolequote.length > 1) {
       const _filterElements = [];
       for (let i = 0; i < singolequote.length; i++) {

--- a/src/app/gui/search/vue/panel/searchservice.js
+++ b/src/app/gui/search/vue/panel/searchservice.js
@@ -740,6 +740,7 @@ async function parse_search_1n(data, options) {
   if (!features.length) {
     //show empty result output
     DataRouterService.showEmptyOutputs();
+    return [];
   }
 
   //get relation


### PR DESCRIPTION
Closes: #514 

## How to test

1. Create a search on 1:n relation

![Screenshot from 2023-11-02 11-26-15](https://github.com/g3w-suite/g3w-client/assets/1051694/8124fe0d-5021-4d01-a015-b57f8de90651)


2. Do a search that return no feature (eg. search a `fid` that not exist)

![Screenshot from 2023-11-02 11-28-02](https://github.com/g3w-suite/g3w-client/assets/1051694/31f30809-d6ad-4a95-ac1d-d97b65e7ce98)

## Before

Shows all relation layer feature results

![Screenshot from 2023-11-02 11-33-31](https://github.com/g3w-suite/g3w-client/assets/1051694/1e7afec1-e147-4a79-816b-b2cdd29f66d4)


## After:

No features

![Screenshot from 2023-11-02 11-29-26](https://github.com/g3w-suite/g3w-client/assets/1051694/90310fc9-8298-4012-8a6e-3216a1d4c1e9)


