### PR TITLE
Check for empty for geocoding providers: `initConfig.group.mapcontrols.geocoding`

### DIFF
--- a/src/components/MapControlGeocoding.vue
+++ b/src/components/MapControlGeocoding.vue
@@ -212,7 +212,7 @@ const Projections                   = require('g3w-ol/projection/projections');
  * VENDOR_KEYS['my_custom_provider'] = 'super.secret.key'
  * ```
  */
-const PROVIDERS = window.initConfig.group.mapcontrols.geocoding.providers;
+const PROVIDERS = window.initConfig.group.mapcontrols.geocoding ? window.initConfig.group.mapcontrols.geocoding.providers : {};
 Object
   .keys(PROVIDERS)
   .forEach(function(p) {


### PR DESCRIPTION
Closes: https://github.com/g3w-suite/g3w-client/issues/524
