### PR TITLE
Fix invalid geocoding response for `"X,Y,EPSG"` searches, i.e. those with a different CRS than the current map

### DIFF
--- a/src/components/MapControlGeocoding.vue
+++ b/src/components/MapControlGeocoding.vue
@@ -467,8 +467,7 @@ export default {
         let transform      = false;
         const [x, y, epsg] = (q || '').split(',');
         // get projection of coordinates is pass as third value
-        const projection    = epsg && Projections.get({ epsg: `EPSG:${epsg.trim()}` });
-
+        const projection    = epsg && await Projections.registerProjection(`EPSG:${epsg.trim()}`);
         // extract xCoord and yCoord
         if (isNumber(1 * x) && isNumber(1 * y)) {
           coordinates = [1 * x, 1 * y];


### PR DESCRIPTION
Closes: #554 

## Before

![Screenshot from 2024-01-31 12-16-50](https://github.com/g3w-suite/g3w-client/assets/1051694/2061c5af-eded-4a07-a615-2770ca2f0339)


## After

![Screenshot from 2024-01-31 12-23-16](https://github.com/g3w-suite/g3w-client/assets/1051694/0e022834-9f08-490d-99d5-59f71f885bd5)

