### PR TITLE
Remove unnecessary branch name suffix for stable version releases

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -64,7 +64,7 @@ function setNODE_ENV() {
   outputFolder         = production ? g3w.admin_plugins_folder + '/client' : g3w.admin_overrides_folder;
   console.log('[G3W-CLIENT] environment:',    process.env.NODE_ENV);
   console.log('[G3W-CLIENT] output folder:',  outputFolder);
-  console.log(`[G3W-CLIENT] loaded plugins: {\n  ${Object.entries(loaded_plugins).map(([pluginName, p]) => (GREEN__ + pluginName + __RESET + ': '+ p.version())).join('\n  ')}\n}\n`);
+  console.log(`[G3W-CLIENT] loaded plugins: {\n  ${dev_plugins.map(pluginName => (GREEN__ + pluginName + __RESET + ': '+ get_version(pluginName))).join('\n  ')}\n}\n`);
 }
 
 // Retrieve project dependencies ("g3w-client")
@@ -82,12 +82,6 @@ const default_plugins = [
 const dev_plugins = Array.from(
   new Set(default_plugins.concat(g3w.plugins instanceof Array ? plugins : Object.keys(g3w.plugins)))
 );
-
-// Helper info about locally developed client plugins (Object<pluginName, pluginInfo>)
-const loaded_plugins = Object.fromEntries(dev_plugins.map(pluginName => { return [pluginName, { version: get_version.bind(null, pluginName), hash: get_hash.bind(null, pluginName), branch: get_branch.bind(null, pluginName) }]}));
-
-// List all plugins within the `g3w.pluginsFolder`
-const local_plugins = fs.readdirSync(g3w.pluginsFolder).filter(file => file !== 'client' && file.indexOf('_templates') === -1 && fs.statSync(`${g3w.pluginsFolder}/${file}`).isDirectory() && fs.statSync(`${g3w.pluginsFolder}/${file}/plugin.js`).isFile());
 
 /**
  * @param { string } pluginName
@@ -154,7 +148,18 @@ function set_version(pluginName) {
     data.splice(0, 1, pluginName ? `# g3w-client-plugin-${pluginName} v${version}` : `# G3W-CLIENT v${version}`);
     fs.writeFile(`${src}/README.md`, data.join("\n"), 'utf8', (err) => { if (err) return console.log(err); });
   });
-};
+}
+
+/**
+ * @param { string } branchName
+ * 
+ * @returns { boolean } whether is a stable branch (eg. v3.9.x)
+ * 
+ * @since 3.10.0
+ */
+function is_prod_branch(branchName) {
+  return production || ['dev', 'main', 'master'].includes(branchName) || /^v\d+\.\d+\.x$/.test(branchName);
+}
 
 setNODE_ENV();
 
@@ -196,9 +201,9 @@ const browserify_plugin = (pluginName, watch = true) => {
   del([`${src}/plugin.js.map`]);
 
   const rebundle = () => {
-    const version = loaded_plugins[pluginName].version();
-    const hash    = loaded_plugins[pluginName].hash();
-    const branch  = loaded_plugins[pluginName].branch();
+    const version = get_version(pluginName);
+    const hash    = get_hash(pluginName);
+    const branch  = get_branch(pluginName);
 
     return merge(
         gulp
@@ -212,7 +217,7 @@ const browserify_plugin = (pluginName, watch = true) => {
       )
       .pipe(concat('plugin.js'))
       .pipe(replace('process.env.g3w_plugin_name', `"${pluginName}"`))
-      .pipe(replace('process.env.g3w_plugin_version', `"${production ? version : version.split('-')[0] + '-' + branch }"`))
+      .pipe(replace('process.env.g3w_plugin_version', `"${is_prod_branch(branch) ? version : version.split('-')[0] + '-' + branch }"`))
       .pipe(replace('process.env.g3w_plugin_hash', `"${hash}"`))
       .pipe(replace('process.env.g3w_plugin_branch', `"${branch}"`))
       .pipe(gulpif(production, sourcemaps.init()))
@@ -355,7 +360,11 @@ gulp.task('browserify:app', function() {
   .on('update', ()  => !production && rebundle())
   .on('log', (info) => !production && gutil.log(GREEN__ + '[client]' + __RESET + ' → ', info));
 
-  const rebundle = () => bundler.bundle()
+  const rebundle = () => {
+    const version = get_version();
+    const branch  = get_branch();
+
+    return bundler.bundle()
     .on('error', err => {
       console.log('ERROR: running gulp task "browserify:app"', err);
       this.emit('end');
@@ -366,7 +375,7 @@ gulp.task('browserify:app', function() {
       // ]).then(() => process.exit());
     })
     .pipe(source('build.js'))
-    .pipe(replace('process.env.g3w_client_rev', `"${ production ? get_version() : get_version().split('-')[0] + '-' + get_branch() }"`))
+    .pipe(replace('process.env.g3w_client_rev', `"${ is_prod_branch(branch) ? version : version.split('-')[0] + '-' + branch }"`))
     .pipe(buffer())
     .pipe(gulpif(production, sourcemaps.init()))
     .pipe(gulpif(production, uglify({ compress: { drop_console: true } }).on('error', gutil.log)))
@@ -374,6 +383,7 @@ gulp.task('browserify:app', function() {
     .pipe(gulpif(production, sourcemaps.write('.')))
     .pipe(gulp.dest(outputFolder + '/static/client/js/'))
     .pipe(gulpif(!production, browserSync.reload({ stream: true }))); // refresh browser after changing local files (dev mode)
+  };
 
   return rebundle();
 });
@@ -653,7 +663,7 @@ gulp.task('test', function() {
  */
 gulp.task('version', function() {
   set_version();                                                                     // client
-  Object.entries(loaded_plugins).forEach(([pluginName]) => set_version(pluginName)); // plugins
+  dev_plugins.forEach(pluginName => set_version(pluginName)); // plugins
 });
 
 /**

--- a/src/app/core/plugin/pluginservice.js
+++ b/src/app/core/plugin/pluginservice.js
@@ -1,8 +1,8 @@
-import ApplicationState from 'store/application-state';
+import ApplicationState   from 'store/application-state';
 import ApplicationService from 'services/application';
 
 const { base, inherit } = require('utils');
-const G3WObject = require('core/g3wobject');
+const G3WObject         = require('core/g3wobject');
 
 function PluginService(options={}) {
   base(this, options);
@@ -16,8 +16,7 @@ function PluginService(options={}) {
   this.currentLayout = ApplicationService.getCurrentLayoutName();
   this.vm = new Vue();
   this.unwatch = this.vm.$watch(()=> ApplicationState.gui.layout.__current,
-      currentLayoutName => this.currentLayout = currentLayoutName !== this.getPlugin().getName() ? currentLayoutName : this.currentLayout);
-
+    currentLayoutName => this.currentLayout = currentLayoutName !== this.getPlugin().getName() ? currentLayoutName : this.currentLayout);
 }
 
 inherit(PluginService, G3WObject);
@@ -32,21 +31,21 @@ proto.init = function(config={}) {
   this.config = config;
 };
 
-proto.setCurrentLayout = function(){
+proto.setCurrentLayout = function() {
   ApplicationService.setCurrentLayout(this.getPlugin().getName());
 };
 
-proto.resetCurrentLayout = function(){
+proto.resetCurrentLayout = function() {
   ApplicationService.setCurrentLayout(this.currentLayout);
 };
 
 // set owner plugin of the service
-proto.setPlugin = function(plugin){
+proto.setPlugin = function(plugin) {
   this.plugin = plugin;
 };
 
 // return the instance of the plugin owner of the service
-proto.getPlugin = function(){
+proto.getPlugin = function() {
   return this.plugin;
 };
 
@@ -57,12 +56,12 @@ proto.isIframe = function() {
 /**
  * Get Current Project
  */
-proto.getCurrentProject = function(){
+proto.getCurrentProject = function() {
   return ApplicationService.getCurrentProject();
 };
 
-proto.getGid = function(){
-  const {gid} = this.config;
+proto.getGid = function() {
+  const { gid } = this.config;
   return gid && gid.split(':')[1];
 };
 
@@ -135,12 +134,12 @@ proto.clearAllEvents = function() {
 };
 
 // to owerwrite if we need some condition to load or not the plugin
-proto.loadPlugin = function(){
+proto.loadPlugin = function() {
   return true
 };
 
 //Called when plugin is removed to clear events and memory
-proto.clear = function(){
+proto.clear = function() {
   // to overwrite
 };
 

--- a/src/plugins/_version.js
+++ b/src/plugins/_version.js
@@ -1,10 +1,13 @@
 /** START: g3w-client/src/plugins/_version.js */
 (function() {
   const plugins = window && window.initConfig && window.initConfig.group && window.initConfig.group.plugins;
-  if (plugins) plugins[process.env.g3w_plugin_name] = Object.assign(plugins[process.env.g3w_plugin_name] || {}, {
-    version: process.env.g3w_plugin_version,
-    hash: process.env.g3w_plugin_hash,
-    branch: process.env.g3w_plugin_branch,
-  });
+  if (plugins) {
+    plugins[process.env.g3w_plugin_name] = Object.assign(plugins[process.env.g3w_plugin_name] || {},
+      {
+        version : process.env.g3w_plugin_version,
+        hash    : process.env.g3w_plugin_hash,
+        branch  : process.env.g3w_plugin_branch,
+      });
+  }
 })();
 /** END: g3w-client/src/plugins/_version.js */

--- a/src/store/plugins.js
+++ b/src/store/plugins.js
@@ -3,11 +3,11 @@
  * @since v3.6
  */
 
-import ProjectsRegistry from 'store/projects';
+import ProjectsRegistry   from 'store/projects';
 import ApplicationService from 'services/application';
 
 const { base, inherit } = require('utils');
-const G3WObject = require('core/g3wobject');
+const G3WObject         = require('core/g3wobject');
 
 /**
  * 'law' project configuration on project is handle as plugin


### PR DESCRIPTION
Improves https://github.com/g3w-suite/g3w-client/pull/485 on release branches by removing useful suffix for stable/tagged plugin versions, ie:

- `-dev`
- `-main`
- `-master`
- `-v3.9.x`
- `-v3.10.x`
- ...

## Before

 [g3wsdk.info]

- g3w-admin: __3.7.dev-20240214084236__
- g3w-client: __3.10.0-dev__
    - openrouteservice: __3.7.0-remove-panel.js__
    - qtimeseries: __3.7.0-dev__
- browser: __Firefox 122.0__
- operating system: __Windows 10 64-bit__

## After

 [g3wsdk.info]

- g3w-admin: __3.7.dev-20240214084236__
- g3w-client: __3.10.0-alpha.0__ <-- CHANGED
    - openrouteservice: __3.7.0-remove-panel.js__
    - qtimeseries: __3.7.0__  <-- CHANGED
- browser: __Firefox 122.0__
- operating system: __Windows 10 64-bit__

