### PR TITLE
Prevent "Uncaught TypeError: n.context[i.value][u] is undefined" when adding external WMS Layer

### DIFF
--- a/src/components/WMSLayersPanel.vue
+++ b/src/components/WMSLayersPanel.vue
@@ -23,7 +23,7 @@
     </label>
     <select
       id        = "g3w-wms-layers"
-      multiple  = "multiple"
+      :multiple  = "true"
       clear     = "true"
       v-select2 = "'selectedlayers'"
     >

--- a/src/directives/v-select2.js
+++ b/src/directives/v-select2.js
@@ -13,9 +13,9 @@ export default {
       select2_value,
       indexItem, /** @since 3.9.1 */
     } = vnode.data.attrs || {};
-    const isArrayWithIndex = binding.value
-      && Array.isArray(vnode.context[binding.value]) //check if is an array
-      && undefined !== indexItem //check if indexItem is defined /** @since 3.10.0 **/
+    const isArray = binding.value
+      && Array.isArray(vnode.context[binding.value]) // check if is an array
+      && undefined !== indexItem                     // check if indexItem is defined
     $(el)
       .select2({
         width: '100%',
@@ -30,17 +30,17 @@ export default {
           const value = e.params.data.id;
           //check is can have multiple value
           if (multiple && (
-            (isArrayWithIndex
+            (isArray
               ? vnode.context[binding.value][indexItem].value
               : vnode.context[binding.value]
             ).filter(d => value === d).length === 0)
           ) {
-            (isArrayWithIndex
+            (isArray
               ? vnode.context[binding.value][indexItem].value
               : vnode.context[binding.value]
             ).push(value);
           } else {
-            if (isArrayWithIndex) {
+            if (isArray) {
               vnode.context[binding.value][indexItem].value = value;
             } else {
               vnode.context[binding.value] = value;
@@ -50,7 +50,7 @@ export default {
       })
       .on('select2:unselect', (e) => {
         if (binding.value && multiple) {
-          if (isArrayWithIndex) {
+          if (isArray) {
             vnode.context[binding.value][indexItem].value = vnode.context[binding.value][indexItem].value.filter(d => e.params.data.id !== d);
           } else {
             vnode.context[binding.value] = vnode.context[binding.value].filter(d => e.params.data.id !== d);

--- a/src/directives/v-select2.js
+++ b/src/directives/v-select2.js
@@ -13,7 +13,9 @@ export default {
       select2_value,
       indexItem, /** @since 3.9.1 */
     } = vnode.data.attrs || {};
-    const isArray = binding.value && Array.isArray(vnode.context[binding.value]); //check if is an array
+    const isArrayWithIndex = binding.value
+      && Array.isArray(vnode.context[binding.value]) //check if is an array
+      && undefined !== indexItem //check if indexItem is defined /** @since 3.10.0 **/
     $(el)
       .select2({
         width: '100%',
@@ -24,19 +26,21 @@ export default {
       })
       .on('select2:select', (e) => {
         if (binding.value) {
+          //get value
           const value = e.params.data.id;
+          //check is can have multiple value
           if (multiple && (
-            (isArray
+            (isArrayWithIndex
               ? vnode.context[binding.value][indexItem].value
               : vnode.context[binding.value]
             ).filter(d => value === d).length === 0)
           ) {
-            (isArray
+            (isArrayWithIndex
               ? vnode.context[binding.value][indexItem].value
               : vnode.context[binding.value]
             ).push(value);
           } else {
-            if (isArray) {
+            if (isArrayWithIndex) {
               vnode.context[binding.value][indexItem].value = value;
             } else {
               vnode.context[binding.value] = value;
@@ -46,7 +50,7 @@ export default {
       })
       .on('select2:unselect', (e) => {
         if (binding.value && multiple) {
-          if (isArray) {
+          if (isArrayWithIndex) {
             vnode.context[binding.value][indexItem].value = vnode.context[binding.value][indexItem].value.filter(d => e.params.data.id !== d);
           } else {
             vnode.context[binding.value] = vnode.context[binding.value].filter(d => e.params.data.id !== d);


### PR DESCRIPTION
Closes: #582 
