### PR TITLE
In case of just one project inside a group, show "No more project for this group" 

### DIFF
--- a/src/components/ChangeMapMenu.vue
+++ b/src/components/ChangeMapMenu.vue
@@ -359,11 +359,6 @@ export default {
     Object
       .entries({ 'project': this.items, 'magrocroup': this.macrogroups, 'group': this.groups })
       .forEach(([type, d]) => d.forEach(item => this.setItemImageSrc({ item, type })))
-
-    if (0 === this.items.length) {
-      this.back();
-    }
-
   },
 
 };


### PR DESCRIPTION
Instead of skip and show parent group/macrogroup, when click on _Change Map_ button, show **No more project for this group**

**Before:**

![Screenshot from 2024-03-01 15-12-48](https://github.com/g3w-suite/g3w-client/assets/1051694/9b7e6b3a-80b3-4e8f-bc9c-5a5d039b6574)


**After**:

![Screenshot from 2024-03-01 15-12-05](https://github.com/g3w-suite/g3w-client/assets/1051694/7d3d91b4-35fc-40f8-8f43-bb023840b48f)

and after click on back arrow 

![Screenshot from 2024-03-01 15-12-48](https://github.com/g3w-suite/g3w-client/assets/1051694/989cd4f0-8e87-4121-83f9-ec856c7a96fc)
