### PR TITLE
Allow to define which layers to hide to end user within Table of Contents

### DIFF
--- a/src/app/core/layers/layer.js
+++ b/src/app/core/layers/layer.js
@@ -79,7 +79,7 @@ function Layer(config={}, options={}) {
     this.config.urls.featurecount = project.getUrl('featurecount');
     
     /**
-     * Custom parameters based on project qgis version
+     * Custom parameters based on a project qgis version
      */
     this.config.searchParams = { I: 0, J: 0 };
   }
@@ -89,55 +89,53 @@ function Layer(config={}, options={}) {
 
   this.state = {
 
-    id: config.id,
+    id:                 config.id,
 
-    title: config.title,
+    title:              config.title,
 
-    selected: config.selected || false,
+    selected:           config.selected || false,
 
-    disabled: config.disabled || false,
+    disabled:           config.disabled || false,
 
-    metadata: config.metadata,
+    metadata:           config.metadata,
 
-    metadata_querable: this.isBaseLayer() ? false: this.isQueryable({onMap:false}),
+    metadata_querable:  this.isBaseLayer() ? false: this.isQueryable({onMap:false}),
 
     openattributetable: this.isBaseLayer() ? false: this.canShowTable(),
 
-    removable: config.removable || false,
+    removable:          config.removable || false,
 
-    downloadable: this.isDownloadable(),
+    downloadable:       this.isDownloadable(),
 
-    source: config.source,
+    source:             config.source,
 
-    styles: config.styles,
+    styles:             config.styles,
 
     defaultstyle,
 
     /**
      * state of if is in editing (setted by editing plugin)
      */
-    inediting: false,
+    inediting:          false,
 
-    infoformat: this.getInfoFormat(),
+    infoformat:         this.getInfoFormat(),
 
-    infoformats: this.config.infoformats || [],
+    infoformats:        this.config.infoformats || [],
 
-    projectLayer: true,
+    projectLayer:       true,
 
-    geolayer: false,
+    geolayer:           false,
 
     /**
      * Reactive selection attribute 
      */
-    selection: {
-      active: false
-    },
+    selection:          { active: false },
 
     /**
      * Reactive filter attribute 
      */
     filter: {
-      active: false,
+      active:  false,
 
       /**
        * @since 3.9.0 whether filter is set from a previously saved filter
@@ -150,34 +148,31 @@ function Layer(config={}, options={}) {
      *
      * @since 3.9.0
      */
-    filters: config.filters || [],
+    filters:            config.filters || [],
 
-    attributetable: {
-      pageLength: null
-    },
+    attributetable:     { pageLength: null },
 
 
-    visible: config.visible || false,
+    visible:            config.visible || false,
 
-    tochighlightable: false,
+    tochighlightable:   false,
 
     /**
      * @type {number}
      * 
      * @since 3.8.0
      */
-    featurecount: config.featurecount,
+    featurecount:       config.featurecount,
 
     /**
      * @type { boolean | Object<number, number> }
      * 
      * @since 3.8.0
      */
-    stylesfeaturecount: config.featurecount && defaultstyle && {
-      [defaultstyle]: config.featurecount
-    },
-    name: config.name, /** since 3.10.0 **/
-    expanded: config.expanded,  /** since 3.10.0 **/
+    stylesfeaturecount: config.featurecount && defaultstyle && { [defaultstyle]: config.featurecount },
+    name:               config.name, /** since 3.10.0 **/
+    expanded:           config.expanded,  /** since 3.10.0 **/
+    toc:                'boolean' === typeof config.toc ? config.toc: true, /** @since 3.10.0 true: show layer on TOC; false hide layer on TOC */
 
   };
 
@@ -1016,7 +1011,7 @@ proto.getUrl = function(type) {
  * @param url.type
  * @param url.url
  */
-proto.setUrl = function({type, url}={}) {
+proto.setUrl = function({ type, url } = {}) {
   this.config.urls[type] = url;
 };
 

--- a/src/app/core/layers/layer.js
+++ b/src/app/core/layers/layer.js
@@ -87,6 +87,9 @@ function Layer(config={}, options={}) {
   // dinamic layer values useful for layerstree
   const defaultstyle = config.styles && config.styles.find(style => style.current).name;
 
+  /**
+   * @TODO make it simpler, `this.config` and `this.state` are essentially duplicated data
+   */
   this.state = {
 
     id:                 config.id,
@@ -170,9 +173,27 @@ function Layer(config={}, options={}) {
      * @since 3.8.0
      */
     stylesfeaturecount: config.featurecount && defaultstyle && { [defaultstyle]: config.featurecount },
-    name:               config.name, /** since 3.10.0 **/
-    expanded:           config.expanded,  /** since 3.10.0 **/
-    toc:                'boolean' === typeof config.toc ? config.toc: true, /** @since 3.10.0 true: show layer on TOC; false hide layer on TOC */
+
+    /**
+     * @type { string }
+     * 
+     * @since 3.10.0
+     */
+    name:               config.name,
+
+    /**
+     * @type { boolean }
+     * 
+     * @since 3.10.0
+     */
+    expanded:           config.expanded,
+
+    /**
+     * @type { boolean } whether to show layer on TOC (default: true)
+     * 
+     * @since 3.10.0
+     */
+    toc:                'boolean' === typeof config.toc ? config.toc: true,
 
   };
 

--- a/src/app/gui/queryresults/queryresultsservice.js
+++ b/src/app/gui/queryresults/queryresultsservice.js
@@ -519,7 +519,7 @@ class QueryResultsService extends G3WObject {
       }
 
       // Lookup for layer selection status (active).
-      if (undefined !== layer.selection.active) {
+      if (layer.toc && undefined !== layer.selection.active) {
         this._setActionSelection(layer);
       }
 
@@ -1028,6 +1028,7 @@ class QueryResultsService extends G3WObject {
       atlas:                  this.getAtlasByLayerId(id),
       rawdata:                rawdata ? rawdata : null,
       error:                  error   ? error   : '',
+      toc:                    external || layer.state.toc, //@since v3.10.0
     };
 
     return layerObj;

--- a/src/components/CatalogTristateTree.vue
+++ b/src/components/CatalogTristateTree.vue
@@ -6,6 +6,7 @@
 <template>
 
   <li
+    v-if                      = "isGroup || !layerstree.projectLayer || layerstree.toc"
     class                     = "tree-item"
     @contextmenu.prevent.stop = "showContextMenu"
     @click.stop               = "onTreeItemClick"

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -118,6 +118,7 @@
                   </span>
                   <span
                     v-if                    = "
+                      layer.toc &&
                       layer.id !== '__g3w_marker' &&
                       layer.features.length > 1 &&
                       (layer.external || (layer.source && layer.source.type !== 'wms'))


### PR DESCRIPTION
# Depend on https://github.com/g3w-suite/g3w-admin/pull/841

Closes: #624 

layerstree layer configuration has new attribute set from server:

```jsonc
{
    "name": "buildings",
    "expanded": true,
    "id": "buildings_2f43dc1d_6725_42d2_a09b_dd446220104a",
    "visible": true,
    "showfeaturecount": true
    "toc": <true or false>
}
```

true -> show layer on TOC
false -> hide layer on TOC
