### PR TITLE
Missing form autocompletion when default print template is "Atlas"

### DIFF
--- a/src/components/Print.vue
+++ b/src/components/Print.vue
@@ -749,6 +749,17 @@ export default {
 
   },
 
+  /**
+   * @since 3.10.2
+   */
+  async mounted() {
+    await this.$nextTick();
+    // when default print template is "atlas" → initialize select2
+    if (this.state.atlas) {
+      this.initSelect2Field();
+    }
+  }
+
 };
 </script>
 


### PR DESCRIPTION
Closes: #650 

## Before

![Screenshot from 2024-08-07 11-11-19](https://github.com/user-attachments/assets/aa4c5980-d613-4cdd-b388-6b4029be4624)

## After

![Screenshot from 2024-08-07 11-36-51](https://github.com/user-attachments/assets/9f1449f8-55a2-45b8-99a2-dee68e49c2f3)
