### PR TITLE
Fix overwrite behaviour of query map control from iframe

### DIFF
--- a/src/app/g3w-ol/controls/querybboxcontrol.js
+++ b/src/app/g3w-ol/controls/querybboxcontrol.js
@@ -1,4 +1,3 @@
-import { SPATIAL_LMETHODS } from 'app/constant';
 import GUI from 'services/gui';
 import DataRouterService from 'services/data';
 import ProjectsRegistry from 'store/projects';

--- a/src/app/g3w-ol/controls/querybboxcontrol.js
+++ b/src/app/g3w-ol/controls/querybboxcontrol.js
@@ -114,6 +114,11 @@ proto.checkVisible = function() {
  */
 proto.setMap = function(map) {
 
+  this.setEventKey({
+    eventType: 'bboxend',
+    eventKey:   this.on('bboxend', this.runSpatialQuery)
+  });
+
   InteractionControl.prototype.setMap.call(this, map);
 
   this._interaction
@@ -133,12 +138,6 @@ proto.setMap = function(map) {
       }
 
     }));
-
-    this.setEventKey({
-      eventType: 'bboxend',
-      eventKey: this.on('bboxend', this.runSpatialQuery)
-    });
-
 };
 
 /**

--- a/src/app/g3w-ol/controls/querybypolygoncontrol.js
+++ b/src/app/g3w-ol/controls/querybypolygoncontrol.js
@@ -94,6 +94,11 @@ proto.checkVisibile = function(layers) {
  */
 proto.setMap = function(map) {
 
+  this.setEventKey({
+    eventType: 'picked',
+    eventKey:  this.on('picked', this.getPolygonFeatureFromCoordinates)
+  });
+
   BaseQueryPolygonControl.prototype.setMap.call(this, map);
   
   this._interaction
@@ -107,11 +112,6 @@ proto.setMap = function(map) {
       }
 
     }));
-
-  this.setEventKey({
-    eventType: 'picked',
-    eventKey: this.on('picked', this.getPolygonFeatureFromCoordinates)
-  });
 
   this.setEnable(false);
 };

--- a/src/app/g3w-ol/controls/querycontrol.js
+++ b/src/app/g3w-ol/controls/querycontrol.js
@@ -33,23 +33,20 @@ const proto = QueryControl.prototype;
  * @listens InteractionControl~toggled
  */
 proto.setMap = function(map) {
- let key = null;
-
-  this.on('toggled', ({ toggled }) => {
-    if (true !== toggled) {
-      ol.Observable.unByKey(key);
-      key = null;
-    } else if (null === key && map) {
-      key = this.getInteraction().on('picked', throttle(evt => this.runQuery({coordinates: evt.coordinate })));
-    }
-  });
 
   this.setEventKey({
     eventType: 'picked',
-    eventKey: this.on('picked', this.runQuery)
+    eventKey:   this.on('picked', this.runQuery)
   });
-
+  
   InteractionControl.prototype.setMap.call(this, map);
+
+  this._interaction
+    .on('picked', throttle(async evt => {
+      this.dispatchEvent({ type: 'picked', coordinates: evt.coordinate });
+    }));
+
+
 };
 
 /**


### PR DESCRIPTION
When click on map to query layers, parent window of iframe need to redirect results to main windows application without show query result content.