### PR TITLE
Ensure unique IDs for modal galleries

### DIFF
--- a/src/components/FieldImage.vue
+++ b/src/components/FieldImage.vue
@@ -70,10 +70,10 @@
 </template>
 
 <script>
-import { toRawType } from 'utils/toRawType';
-
-import Field         from 'components/Field.vue';
-import Teleport      from 'vue2-teleport';
+import Teleport           from 'vue2-teleport';
+import Field              from 'components/Field.vue';
+import { toRawType }      from 'utils/toRawType';
+import { getUniqueDomId } from 'utils/getUniqueDomId';
 
 export default {
 
@@ -83,7 +83,7 @@ export default {
   props: ['state'],
   data() {
     return {
-      id:     Date.now(),
+      id:     getUniqueDomId(),
       active: null,
       value:  undefined !== this.state.value.mime_type ? this.state.value.value : this.state.value,
     }


### PR DESCRIPTION
Make use of `getUniqueDomId()` instead of `Date.now()` for generating gallery ids.

Closes: https://github.com/g3w-suite/g3w-client/issues/703
