### PR TITLE
Add support for `LAYERFONTSIZE`, `ITEMFONTSIZE` and `SHOWFEATURECOUNT` parameters (rif: `GetLegendGraphic`)

### DIFF
--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -218,7 +218,7 @@
         <!-- ORIGINAL SOURCE: src/components/CatalogLayersLegendItems.vue@v3.9.3 -->
         <!-- ORIGINAL SOURCE: src/components/CatalogLayersLegend.vue@v3.9.3 -->
         <div
-          v-if   = "'tab' === legend_position"
+          v-if   = "'tab' === legend_position && 'legend' === activeTab"
           v-for  = "tree in state.layerstrees"
           :key   = "tree.id"
           role   = "tabpanel"
@@ -523,8 +523,7 @@ export default {
           obj.loading = false;
         }
       }
-
-    return legendurls;
+      return legendurls;
     },
 
     /**

--- a/src/map/layers/imagelayer.js
+++ b/src/map/layers/imagelayer.js
@@ -845,9 +845,10 @@ class ImageLayer extends GeoLayerMixin(Layer) {
       layerfontfamily,
       layerfontbold,
       itemfontbold,
-      itemfontsize, //@since 3.11.3
+      itemfontsize,     //@since 3.11.3
       layerfontitalic,
-      layerfontsize, //@since 3.11.3
+      layerfontsize,    //@since 3.11.3
+      showfeaturecount, //@since 3.11.3
       itemfontitalic,
       rulelabel,
       crs,
@@ -889,36 +890,37 @@ class ImageLayer extends GeoLayerMixin(Layer) {
         'SERVICE=WMS',
         'VERSION=1.3.0',
         'REQUEST=GetLegendGraphic',
-        __('SLD_VERSION=',     sld_version),
-        __('WIDTH=',           width),
-        __('HEIGHT=',          height),
-        __('FORMAT=',          (undefined === opts.format ? 'image/png' : opts.format)),
-        __('TRANSPARENT=',     transparent),
-        __('ITEMFONTCOLOR=',   color),
-        __('LAYERFONTCOLOR=',  color),
-        __('LAYERTITLE=',      layertitle),
-        __('ITEMFONTSIZE=',    itemfontsize || fontsize),
-        __('CRS=',             crs),
-        __('BBOX=',            ((true === opts.all ? undefined : [false, undefined].includes(opts.all) && bbox && bbox.join(',')))),
-        __('BOXSPACE=',        boxspace),
-        __('LAYERSPACE=',      layerspace),
-        __('LAYERTITLESPACE=', layertitlespace),
-        __('SYMBOLSPACE=',     symbolspace),
-        __('ICONLABELSPACE=',  iconlabelspace),
-        __('SYMBOLWIDTH=',     (opts.categories && 'application/json' === opts.format ? 16 : symbolwidth)),
-        __('SYMBOLHEIGHT=',    (opts.categories && 'application/json' === opts.format ? 16 : symbolheight)),
-        __('LAYERFONTFAMILY=', layerfontfamily),
-        __('ITEMFONTFAMILY=',  itemfontfamily),
-        __('LAYERFONTBOLD=',   layerfontbold),
-        __('ITEMFONTBOLD=',    itemfontbold),
-        __('LAYERFONTITALIC=', layerfontitalic),
-        __('LAYERFONTSIZE=',   layerfontsize), //@since 3.11.3
-        __('ITEMFONTITALIC=',  itemfontitalic),
-        __('RULELABEL=',       rulelabel),
-        __('LEGEND_ON=',       ctx_legend && ctx_legend.LEGEND_ON),
-        __('LEGEND_OFF=',      ctx_legend && ctx_legend.LEGEND_OFF),
-        __('STYLES=',          (opts.categories && 'application/json' === opts.format ? encodeURIComponent(this.getCurrentStyle().name) : undefined)),
-        __('LAYER=',           this.getWMSLayerName({ type: 'legend' }))
+        __('SLD_VERSION=',      sld_version),
+        __('WIDTH=',            width),
+        __('HEIGHT=',           height),
+        __('FORMAT=',           (undefined === opts.format ? 'image/png' : opts.format)),
+        __('TRANSPARENT=',      transparent),
+        __('ITEMFONTCOLOR=',    color),
+        __('LAYERFONTCOLOR=',   color),
+        __('LAYERTITLE=',       layertitle),
+        __('ITEMFONTSIZE=',     itemfontsize || fontsize), //@since 3.11.3 check itemfontsize or fontsize
+        __('CRS=',              crs),
+        __('BBOX=',             ((true === opts.all ? undefined : [false, undefined].includes(opts.all) && bbox && bbox.join(',')))),
+        __('BOXSPACE=',         boxspace),
+        __('LAYERSPACE=',       layerspace),
+        __('LAYERTITLESPACE=',  layertitlespace),
+        __('SYMBOLSPACE=',      symbolspace),
+        __('ICONLABELSPACE=',   iconlabelspace),
+        __('SYMBOLWIDTH=',      (opts.categories && 'application/json' === opts.format ? 16 : symbolwidth)),
+        __('SYMBOLHEIGHT=',     (opts.categories && 'application/json' === opts.format ? 16 : symbolheight)),
+        __('LAYERFONTFAMILY=',  layerfontfamily),
+        __('ITEMFONTFAMILY=',   itemfontfamily),
+        __('LAYERFONTBOLD=',    layerfontbold),
+        __('ITEMFONTBOLD=',     itemfontbold),
+        __('LAYERFONTITALIC=',  layerfontitalic),
+        __('LAYERFONTSIZE=',    layerfontsize),    //@since 3.11.3
+        __('SHOWFEATURECOUNT=', showfeaturecount), //@since 3.11.3
+       __('ITEMFONTITALIC=',    itemfontitalic),
+        __('RULELABEL=',        rulelabel),
+        __('LEGEND_ON=',        ctx_legend && ctx_legend.LEGEND_ON),
+        __('LEGEND_OFF=',       ctx_legend && ctx_legend.LEGEND_OFF),
+        __('STYLES=',           (opts.categories && 'application/json' === opts.format ? encodeURIComponent(this.getCurrentStyle().name) : undefined)),
+        __('LAYER=',            this.getWMSLayerName({ type: 'legend' }))
       ]; 
     }
 

--- a/src/map/layers/imagelayer.js
+++ b/src/map/layers/imagelayer.js
@@ -915,7 +915,7 @@ class ImageLayer extends GeoLayerMixin(Layer) {
         __('LAYERFONTITALIC=',  layerfontitalic),
         __('LAYERFONTSIZE=',    layerfontsize),    //@since 3.11.3
         __('SHOWFEATURECOUNT=', showfeaturecount), //@since 3.11.3
-       __('ITEMFONTITALIC=',    itemfontitalic),
+        __('ITEMFONTITALIC=',   itemfontitalic),
         __('RULELABEL=',        rulelabel),
         __('LEGEND_ON=',        ctx_legend && ctx_legend.LEGEND_ON),
         __('LEGEND_OFF=',       ctx_legend && ctx_legend.LEGEND_OFF),

--- a/src/map/layers/imagelayer.js
+++ b/src/map/layers/imagelayer.js
@@ -20,7 +20,7 @@ import { get_legend_params }  from 'utils/get_legend_params';
  * @returns { string | null } a string if value is set or null
  */
 function __(name, value) {
-  return (value || 0 === value) ? `${name}${value}` : null;
+  return [null, undefined].includes(value) ? value : `${name}${value}`;
 }
 
 /**
@@ -823,7 +823,7 @@ class ImageLayer extends GeoLayerMixin(Layer) {
    * 
    * @see https://docs.qgis.org/3.28/en/docs/server_manual/services/wms.html#getlegendgraphics
    */
-  getLegendUrl(params = {}, opts = {categories:false,  all:false,format:'image/png',}) {
+  getLegendUrl(params = {}, opts = { categories:false,  all:false,format:'image/png',}) {
 
     let base_url, url_params;
 
@@ -845,7 +845,9 @@ class ImageLayer extends GeoLayerMixin(Layer) {
       layerfontfamily,
       layerfontbold,
       itemfontbold,
+      itemfontsize, //@since 3.11.3
       layerfontitalic,
+      layerfontsize, //@since 3.11.3
       itemfontitalic,
       rulelabel,
       crs,
@@ -895,9 +897,9 @@ class ImageLayer extends GeoLayerMixin(Layer) {
         __('ITEMFONTCOLOR=',   color),
         __('LAYERFONTCOLOR=',  color),
         __('LAYERTITLE=',      layertitle),
-        __('ITEMFONTSIZE=',    fontsize),
+        __('ITEMFONTSIZE=',    itemfontsize || fontsize),
         __('CRS=',             crs),
-        __('BBOX=',            ([false, undefined].includes(opts.all) && bbox && bbox.join(','))),
+        __('BBOX=',            ((true === opts.all ? undefined : [false, undefined].includes(opts.all) && bbox && bbox.join(',')))),
         __('BOXSPACE=',        boxspace),
         __('LAYERSPACE=',      layerspace),
         __('LAYERTITLESPACE=', layertitlespace),
@@ -910,6 +912,7 @@ class ImageLayer extends GeoLayerMixin(Layer) {
         __('LAYERFONTBOLD=',   layerfontbold),
         __('ITEMFONTBOLD=',    itemfontbold),
         __('LAYERFONTITALIC=', layerfontitalic),
+        __('LAYERFONTSIZE=',   layerfontsize), //@since 3.11.3
         __('ITEMFONTITALIC=',  itemfontitalic),
         __('RULELABEL=',       rulelabel),
         __('LEGEND_ON=',       ctx_legend && ctx_legend.LEGEND_ON),


### PR DESCRIPTION
### • LAYERFONTSIZE

This parameter specifies the font size for rendering **layer title in point**.

![wms_getlegendgraphic_layerfontsize](https://github.com/user-attachments/assets/3f69506d-2457-4f18-91d9-e949e5ce75b9)

```url
http://localhost/qgisserver?
SERVICE=WMS
&REQUEST=GetLegendGraphic
&LAYERS=airports,places
&BBOX=43.20,-2.93,49.35,8.32
&CRS=EPSG:4326
&TRANSPARENT=TRUE
&LAYERFONTSIZE=20
```

Rif: https://docs.qgis.org/3.34/en/docs/server_manual/services/wms.html#wms-getlegendgraphic-layerfontsize

### • ITEMFONTSIZE

This parameter specifies the font size for rendering **layer title in point**.

![wms_getlegendgraphic_itemfontsize](https://github.com/user-attachments/assets/9568dfbc-98a0-4deb-83bd-df06108b8f9e)

```url
http://localhost/qgisserver?
SERVICE=WMS
&REQUEST=GetLegendGraphic
&LAYERS=airports,places
&BBOX=43.20,-2.93,49.35,8.32
&CRS=EPSG:4326
&TRANSPARENT=TRUE
&ITEMFONTSIZE=20
```

Rif: https://docs.qgis.org/3.34/en/docs/server_manual/services/wms.html#wms-getlegendgraphic-itemfontsize

### • SHOWFEATURECOUNT

`True/False`: wether to activate feature count in the legend.

![getfeaturecount_legend](https://github.com/user-attachments/assets/e68abc78-836e-4f2a-9524-91d63c65ef60)

