### PR TITLE
Allow to customize close tooltip text (sidebar panel)

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -235,7 +235,7 @@
                   <i :class = "$fa('arrow-left')" class = "fa-stack-1x panel-icon"></i>
                 </span>
                 <span
-                  @click.stop            = "sidebar.buttons.close.enabled && closeAllPanels()"
+                  @click.stop            = "$gui.sidebar.buttons.close.enabled && closeAllPanels()"
                   data-toggle            = "tooltip"
                   data-container         = "body"
                   v-t-tooltip:top.create = "$gui.sidebar.buttons.close.tooltip"

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -235,16 +235,16 @@
                   <i :class = "$fa('arrow-left')" class = "fa-stack-1x panel-icon"></i>
                 </span>
                 <span
-                  @click.stop            = "$gui.sidebar.buttons.close.enabled && closeAllPanels()"
-                  data-toggle            = "tooltip"
-                  data-container         = "body"
-                  v-t-tooltip:top.create = "$gui.sidebar.buttons.close.tooltip"
-                  :current-tooltip       = "$gui.sidebar.buttons.close.tooltip"
-                  class                  = "skin-tooltip-left g3w-span-button close-pane-button fa-stack"
+                  @click.stop              = "app.sidebar.btn_close && closeAllPanels()"
+                  data-toggle              = "tooltip"
+                  data-container           = "body"
+                  v-t-tooltip:right.create = "app.sidebar.tooltip_close || 'close'"
+                  :current-tooltip         = "app.sidebar.tooltip_close || 'close'"
+                  class                    = "skin-tooltip-left g3w-span-button close-pane-button fa-stack"
                 >
                   <i :class = "$fa('circle')" class = "fa-stack-1x panel-button"></i>
                   <i
-                    :style = "{ opacity: $gui.sidebar.buttons.close.enabled ? '1' : '0.7', cursor: $gui.sidebar.buttons.close.enabled ? 'pointer' : 'not-allowed' }"
+                    :style = "{ opacity: app.sidebar.btn_close ? '1' : '0.7', cursor: app.sidebar.btn_close ? 'pointer' : 'not-allowed' }"
                     :class = "$fa('close')"
                     class  = "fa-stack-1x panel-icon">
                   </i>

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -235,7 +235,7 @@
                   <i :class = "$fa('arrow-left')" class = "fa-stack-1x panel-icon"></i>
                 </span>
                 <span
-                  @click.stop            = "sidebar.buttons.close.enabled && closeAllPanels"
+                  @click.stop            = "sidebar.buttons.close.enabled && closeAllPanels()"
                   data-toggle            = "tooltip"
                   data-container         = "body"
                   v-t-tooltip:top.create = "sidebar.buttons.close.tooltip"

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -235,15 +235,19 @@
                   <i :class = "$fa('arrow-left')" class = "fa-stack-1x panel-icon"></i>
                 </span>
                 <span
-                  @click.stop        = "closeAllPanels"
-                  data-placement     = "left"
-                  data-toggle        = "tooltip"
-                  data-container     = "body"
-                  v-t-tooltip.create = "'close'"
-                  class              = "skin-tooltip-left g3w-span-button close-pane-button fa-stack"
+                  @click.stop            = "sidebar.buttons.close.enabled && closeAllPanels"
+                  data-toggle            = "tooltip"
+                  data-container         = "body"
+                  v-t-tooltip:top.create = "sidebar.buttons.close.tooltip"
+                  :current-tooltip       = "sidebar.buttons.close.tooltip"
+                  class                  = "skin-tooltip-left g3w-span-button close-pane-button fa-stack"
                 >
                   <i :class = "$fa('circle')" class = "fa-stack-1x panel-button"></i>
-                  <i :class = "$fa('close')"  class = "fa-stack-1x panel-icon"></i>
+                  <i
+                    :style = "{ opacity: sidebar.buttons.close.enabled ? '1' : '0.7', cursor: sidebar.buttons.close.enabled ? 'pointer' : 'not-allowed' }"
+                    :class = "$fa('close')"
+                    class  = "fa-stack-1x panel-icon">
+                  </i>
                 </span>
               </div>
 
@@ -563,6 +567,7 @@ export default {
       updatePreviousTitle:   false,
       header:                t('main navigation'),
       custom_links,
+      sidebar:               ApplicationState.gui.sidebar,
     }
   },
 

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -211,7 +211,7 @@
         >
           <div id="g3w-sidebarpanel-header-placeholder">
             <div
-              style  = "display: flex;"
+              style  = "display: flex; margin-bottom: 5px;"
               :style = "{ justifyContent: app.sidebar.title ? 'space-between' : 'flex-end' }"
             >
 
@@ -238,13 +238,13 @@
                   @click.stop            = "sidebar.buttons.close.enabled && closeAllPanels()"
                   data-toggle            = "tooltip"
                   data-container         = "body"
-                  v-t-tooltip:top.create = "sidebar.buttons.close.tooltip"
-                  :current-tooltip       = "sidebar.buttons.close.tooltip"
+                  v-t-tooltip:top.create = "$gui.sidebar.buttons.close.tooltip"
+                  :current-tooltip       = "$gui.sidebar.buttons.close.tooltip"
                   class                  = "skin-tooltip-left g3w-span-button close-pane-button fa-stack"
                 >
                   <i :class = "$fa('circle')" class = "fa-stack-1x panel-button"></i>
                   <i
-                    :style = "{ opacity: sidebar.buttons.close.enabled ? '1' : '0.7', cursor: sidebar.buttons.close.enabled ? 'pointer' : 'not-allowed' }"
+                    :style = "{ opacity: $gui.sidebar.buttons.close.enabled ? '1' : '0.7', cursor: $gui.sidebar.buttons.close.enabled ? 'pointer' : 'not-allowed' }"
                     :class = "$fa('close')"
                     class  = "fa-stack-1x panel-icon">
                   </i>
@@ -567,7 +567,6 @@ export default {
       updatePreviousTitle:   false,
       header:                t('main navigation'),
       custom_links,
-      sidebar:               ApplicationState.gui.sidebar,
     }
   },
 

--- a/src/components/QueryBuilder.vue
+++ b/src/components/QueryBuilder.vue
@@ -375,7 +375,6 @@ export default {
 
 <style scoped>
 #query_builder {
-  font-family: monospace;
   margin-bottom: 0;
   height: 100%;
   display: flex;

--- a/src/index.prod.js
+++ b/src/index.prod.js
@@ -127,31 +127,6 @@ Vue.use(require('vue-cookie'));
  */
 Vue.use({
   install(Vue) {
-    /**
-     * @since 3.11.3 Sidebar
-     */
-    Vue.prototype.$gui = {
-      updateSidebarButton({ type, opts = {}} = {}) {
-        if (undefined === this.sidebar.buttons[type]) {
-          return;
-        }
-        Object.keys(opts).forEach(k => this.sidebar.buttons[type][k] = opts[k] );
-      },
-      sidebar: Vue.observable({
-        /**
-         *
-         * @param type
-         * @param opts
-         */
-        buttons : {
-          close: {
-            enabled: true,
-            tooltip: 'close'
-          }
-        }
-      })
-    };
-
     /** @since 3.11.0 */
     Vue.prototype.$t = t;
     // hold a list of registered fontawsome classes for current project

--- a/src/index.prod.js
+++ b/src/index.prod.js
@@ -127,6 +127,31 @@ Vue.use(require('vue-cookie'));
  */
 Vue.use({
   install(Vue) {
+    /**
+     * @since 3.11.3 Sidebar
+     */
+    Vue.prototype.$gui = {
+      updateSidebarButton({ type, opts = {}} = {}) {
+        if (undefined === this.sidebar.buttons[type]) {
+          return;
+        }
+        Object.keys(opts).forEach(k => this.sidebar.buttons[type][k] = opts[k] );
+      },
+      sidebar: Vue.observable({
+        /**
+         *
+         * @param type
+         * @param opts
+         */
+        buttons : {
+          close: {
+            enabled: true,
+            tooltip: 'close'
+          }
+        }
+      })
+    };
+
     /** @since 3.11.0 */
     Vue.prototype.$t = t;
     // hold a list of registered fontawsome classes for current project

--- a/src/store/application.js
+++ b/src/store/application.js
@@ -104,15 +104,6 @@ const STATE = Vue.observable({
        * true open, false hide - icons only
        */
       open    : true,
-      /**
-       * @since 3.11.3
-       */
-      buttons : {
-        close: {
-          enabled: true,
-          tooltip: 'close'
-        }
-      }
     },
 
     layout: {

--- a/src/store/application.js
+++ b/src/store/application.js
@@ -160,7 +160,11 @@ const STATE = Vue.observable({
     /** DOM element where insert the component/panel  */
     parent:     null,
     /** barstack state. It stores the panel array */
-    contentsdata: [], // Array<{ content, options }> 
+    contentsdata: [], // Array<{ content, options }>
+    /** @since 3.11.3 - whether to enable close button  */
+    btn_close: true,
+    /** @since 3.11.3 - custom tooltip for close button */
+    tooltip_close: 'close',
   },
 
   contentsdata: [],

--- a/src/store/application.js
+++ b/src/store/application.js
@@ -103,7 +103,16 @@ const STATE = Vue.observable({
        * @since v3.11.0
        * true open, false hide - icons only
        */
-      open    : true
+      open    : true,
+      /**
+       * @since 3.11.3
+       */
+      buttons : {
+        close: {
+          enabled: true,
+          tooltip: 'close'
+        }
+      }
     },
 
     layout: {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/76acb957-2511-400f-92ea-12ca8f2f9db3)

![image](https://github.com/user-attachments/assets/8f66137b-c458-42b8-998e-ee09b3e1e0a4)


## New properties:

- `g3wsdk.core.ApplicationState.sidebar.btn_close` (true / false)
- `g3wsdk.core.ApplicationState.sidebar.tooltip_close` (string)
