### PR TITLE
:bug: Fix call to undefind method  `zoomToExtent` (BaseIframeService)

### DIFF
--- a/src/services/iframe.js
+++ b/src/services/iframe.js
@@ -386,7 +386,7 @@ class BaseIframeService extends G3WObject {
     }
     // in case of no response zoom to an initial extent
     if (!response.found) {
-      this.zoomToExtent(this.mapService.project.state.initextent)
+      this.mapService.zoomToExtent(this.mapService.project.state.initextent)
     }
     return response;
   }


### PR DESCRIPTION
Wrong method zoomToExtend related to iframe service instance. It is referred to mapservice method
