### PR TITLE
🔙 from #725 - Always emit `plugin.js` into plugin repository

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -232,6 +232,7 @@ const browserify_plugin = (pluginName, watch = true) => {
     .pipe(gulpif(production, sourcemaps.write('.')))
     .pipe(gulp.dest(src))           // put plugin.js to plugin folder (git source)
     .pipe(gulp.dest(outputFolder)) // put plugin.js to static folder (PROD | DEV env)
+    .pipe(gulp.dest(`${g3w.pluginsFolder}/${pluginName}`)) // put plugin.js to plugin code folder
     .pipe(gulpif(!production, browserSync.reload({ stream: true }))); // refresh browser after changing local files (dev mode)
   };
 


### PR DESCRIPTION
Referred to https://github.com/g3w-suite/g3w-client/pull/725
