### PR TITLE
:bug: Editing panel doesn't open for more than one layer (edit in iframe)

### DIFF
--- a/config.template.js
+++ b/config.template.js
@@ -23,11 +23,17 @@ let conf = {
       initConfig.group.vendorkeys = Object.assign(initConfig.group.vendorkeys || {}, G3W_KEYS);
       initConfig.group.plugins    = Object.assign(initConfig.group.plugins || {}, G3W_PLUGINS.reduce((a, v) => ({ ...a, [v]: { ...initConfig.group.plugins[v], gid: initConfig.group.initproject, baseUrl: initConfig.staticurl }}), {}));
     });
-    g3wsdk.gui.GUI.once('iframe:message', (w, e) => { w.postMessage({ // test MESSAGE sent to "Open in iframe" map control
-      id: null,
-      action: 'app:getcenter',                                        // or 'app:getextent'
-      data: { epsg: 4326 }	
-    }, '*') });
+    //Every time a new iframe is created, listen for messages
+    g3wsdk.gui.GUI.on('iframe:message', (w, e) => { 
+      //Once app is ready, send a message to the iframe
+      if (e.data.action === 'app:ready') {
+        w.postMessage({ // test MESSAGE sent to "Open in iframe" map control
+          id: null,
+          action: 'app:getcenter',                                        // or 'app:getextent'
+          data: { epsg: 4326 }	
+        }, '*')
+      }
+    });
     g3wsdk.gui.GUI.once('ready', () => { console.log('ready'); });
   }
 };

--- a/src/index.dev.js
+++ b/src/index.dev.js
@@ -15,6 +15,7 @@ import 'g3w-globals';
 // print some debug info
 window.g3wsdk.info();
 
+
 // custom header links
 g3wsdk.core.ApplicationService.once('initconfig', () => {
   initConfig.header_custom_links = [
@@ -230,7 +231,34 @@ g3wsdk.gui.GUI.once('ready', () => {
         customClass: 'fa fa-window-restore',
         onclick() {
           const w = window.open('about:blank', '_blank', `fullscreen=yes`);
-          w.document.write(`<!doctype HTML><html><head><title>Test Iframe</title><style>html,body,iframe{width:100%;height:100%;margin:0;border:0;display:block;}</style></head><body><iframe src="${location.href}"></iframe></body></html>`);
+          w.document.write(`
+            <!doctype HTML>
+            <html>
+              <head>
+                <title>Test Iframe</title>
+                <style>html,body,iframe{width:100%;height:100%;margin:0;border:0;display:block;}</style>
+              </head>
+              <body>
+                <iframe src="${location.href}"></iframe>
+              </body>
+              <script>
+                window.addEventListener('message', e => {
+                  if (e.data.action === 'app:zoomtofeature') {
+                    document.querySelector('iframe').contentWindow.postMessage({
+                      id: null,
+                      action: 'editing:add',
+                      data: {
+                        qgs_layer_id: ['buildings_2f43dc1d_6725_42d2_a09b_dd446220104a', 'roads_ea006d6f_bd87_4635_aae0_4e9e7842b3f4'],
+                        properties: {
+                          name : 'Pollo'
+                        }
+                      }
+                    }, '*');
+                  }
+                }) 
+
+              </script>
+            </html>`);
           // send message to iframe when app is ready
           w.addEventListener('message', e => {
             if (e.data.action === 'app:ready') {

--- a/src/index.dev.js
+++ b/src/index.dev.js
@@ -4,7 +4,6 @@
  */
 import localforage from 'localforage';
 import { waitFor } from 'utils/waitFor';
-import { VM }      from 'g3w-eventbus';
 import shpwrite    from '@mapbox/shp-write';
 
 // expose global variables
@@ -221,45 +220,37 @@ C,"POINT (11.2474811 43.7910709)"`],
  * 
  * @see https://github.com/g3w-suite/g3w-client/pull/736
  */
-g3wsdk.core.plugin.PluginsRegistry.onafter('registerPlugin', plugin => {
-  if (!plugin && 'editing' !== plugin.name) {
-    return;
-  }
-  VM.$watch(
+g3wsdk.gui.GUI.once('ready', () => {
+  (new Vue).$watch(
     () => g3wsdk.core.ApplicationState.sidebar.contentsdata,
-    (data = []) => data
-      .filter(d => 'editing-panel' === d.content.id)
-      .forEach(d => {
-        const tolboxes = d.content.internalPanel.$el.querySelector('#toolboxes');
-        let iframe_btn = document.querySelector('#edit_in_iframe');
-        if (!tolboxes || iframe_btn) {
-          return;
-        }
-        tolboxes.insertAdjacentHTML('afterend', `<p><a href="#" id="edit_in_iframe">&#x270f; Edit in iframe</a></p>`);
-        iframe_btn = document.querySelector('#edit_in_iframe');
-        iframe_btn.addEventListener('click', () => {
-          const w = window.open('about:blank', '_blank', `fullscreen=yes`);
-          w.document.write(`<!doctype HTML><html><head><title>Test Iframe</title><style>html,body,iframe{width:100%;height:100%;margin:0;border:0;display:block;}</style></head><body><iframe src="${location.href}"></iframe></body></html>`);
-          //Listen message from application
-          w.addEventListener('message', e => {
-            if ('app:ready' === e.data.action) {
-              // send message to iframe every time iframe send a message con contentWindow
-              w.document.querySelector('iframe').contentWindow.postMessage({
-                id:      null,
-                action: 'editing:add',
-                data: {
-                  // only visible toolboxes
-                  qgs_layer_id: Array.from(editing_tolboxes.children).filter(item => item.classList.contains('toolbox') && 'none' !== item.style.display).map(item => item.id.split('id_toolbox_')[1]),
-                  properties: { },
-                }
-              }, '*');
-            }
-          }, false);
-          // prevent page refresh (eg. CTRL+R)
-          w.onbeforeunload = () => w.close();
-        });
-      })
-  );
+    (data = []) => data.filter(d => 'editing-panel' === d.content.id).forEach(d => { //wait for editing panel
+      const tolboxes = d.content.internalPanel.$el.querySelector('#toolboxes');
+      let iframe_btn = document.querySelector('#edit_in_iframe');
+      if (!tolboxes || iframe_btn) {
+        return;
+      }
+      // append "edit in iframe" element immediately after toolboxes
+      tolboxes.insertAdjacentHTML('afterend', `<p><a href="#" id="edit_in_iframe">&#x270f; Edit in iframe</a></p>`);
+      iframe_btn = document.querySelector('#edit_in_iframe');
+      iframe_btn.addEventListener('click', () => {
+        const w = window.open('about:blank', '_blank', `fullscreen=yes`);
+        w.document.write(`<!doctype HTML><html><head><title>Test Iframe</title><style>html,body,iframe{width:100%;height:100%;margin:0;border:0;display:block;}</style></head><body><iframe src="${location.href}"></iframe></body></html>`);
+        w.addEventListener('message', e => {
+          if ('app:ready' === e.data.action) {
+            w.document.querySelector('iframe').contentWindow.postMessage({
+              id:      null,
+              action: 'editing:add',
+              data: {
+                qgs_layer_id: Array.from(editing_tolboxes.children).filter(item => item.classList.contains('toolbox') && 'none' !== item.style.display).map(item => item.id.split('id_toolbox_')[1]), // toolbox id = layer id
+                properties: { },
+              }
+            }, '*');
+          }
+        }, false);
+        // prevent page refresh (eg. CTRL+R)
+        w.onbeforeunload = () => w.close();
+      });
+    }));
 });
 
 /**

--- a/src/index.dev.js
+++ b/src/index.dev.js
@@ -15,7 +15,6 @@ import 'g3w-globals';
 // print some debug info
 window.g3wsdk.info();
 
-
 // custom header links
 g3wsdk.core.ApplicationService.once('initconfig', () => {
   initConfig.header_custom_links = [
@@ -231,34 +230,7 @@ g3wsdk.gui.GUI.once('ready', () => {
         customClass: 'fa fa-window-restore',
         onclick() {
           const w = window.open('about:blank', '_blank', `fullscreen=yes`);
-          w.document.write(`
-            <!doctype HTML>
-            <html>
-              <head>
-                <title>Test Iframe</title>
-                <style>html,body,iframe{width:100%;height:100%;margin:0;border:0;display:block;}</style>
-              </head>
-              <body>
-                <iframe src="${location.href}"></iframe>
-              </body>
-              <script>
-                window.addEventListener('message', e => {
-                  if (e.data.action === 'app:zoomtofeature') {
-                    document.querySelector('iframe').contentWindow.postMessage({
-                      id: null,
-                      action: 'editing:add',
-                      data: {
-                        qgs_layer_id: ['buildings_2f43dc1d_6725_42d2_a09b_dd446220104a', 'roads_ea006d6f_bd87_4635_aae0_4e9e7842b3f4'],
-                        properties: {
-                          name : 'Pollo'
-                        }
-                      }
-                    }, '*');
-                  }
-                }) 
-
-              </script>
-            </html>`);
+          w.document.write(`<!doctype HTML><html><head><title>Test Iframe</title><style>html,body,iframe{width:100%;height:100%;margin:0;border:0;display:block;}</style></head><body><iframe src="${location.href}"></iframe></body></html>`);
           // send message to iframe when app is ready
           w.addEventListener('message', e => {
             if (e.data.action === 'app:ready') {

--- a/src/index.dev.js
+++ b/src/index.dev.js
@@ -217,7 +217,7 @@ C,"POINT (11.2474811 43.7910709)"`],
 });
 
 /**
- * Edit in iframe
+ * Custom editing control: "Edit in iframe"
  * 
  * @see https://github.com/g3w-suite/g3w-client/pull/736
  */

--- a/src/index.dev.js
+++ b/src/index.dev.js
@@ -216,58 +216,56 @@ C,"POINT (11.2474811 43.7910709)"`],
 
 });
 
-// custom map control: "Open in iframe"
-g3wsdk.gui.GUI.once('ready', () => {
-
-  g3wsdk.core.plugin.PluginsRegistry.onafter('registerPlugin', plugin => {  
-    if (plugin && 'editing' === plugin.name) {
-      VM.$watch(
-        () => g3wsdk.core.ApplicationState.sidebar.contentsdata,
-        (data = []) => {
-          data
-          .filter(d => 'editing-panel' === d.content.id)
-          .forEach(d => {
-            const editing_tolboxes = d.content.internalPanel.$el.querySelector('#toolboxes');
-            let iframe_btn = document.querySelector('#edit_in_iframe');
-            if (editing_tolboxes && !iframe_btn) {
-                editing_tolboxes.insertAdjacentHTML('afterend', `<p><a href="#" id="edit_in_iframe">&#x270f; Edit in iframe</a></p>`);
-                iframe_btn = document.querySelector('#edit_in_iframe');
-                iframe_btn.addEventListener('click', () => {
-                  const qgs_layer_id = [];
-                  for (let item of editing_tolboxes.children) {
-                    //filter only visible toolbox
-                    if (item.classList.contains('toolbox') && 'none' !== item.style.display) {
-                      qgs_layer_id.push(item.id.split('id_toolbox_')[1]);
-                    }
-                  }
-                  const w = window.open('about:blank', '_blank', `fullscreen=yes`);
-                  w.document.write(`<!doctype HTML><html><head><title>Test Iframe</title><style>html,body,iframe{width:100%;height:100%;margin:0;border:0;display:block;}</style></head><body><iframe src="${location.href}"></iframe></body></html>`);
-                  //Listen message from application
-                  w.addEventListener('message', e => {
-                    if ('app:ready' === e.data.action) {
-                      // send message to iframe every time iframe send a message con contentWindow
-                      w.document.querySelector('iframe').contentWindow.postMessage({
-                        id:      null,
-                        action: 'editing:add',
-                        data: {
-                          qgs_layer_id,
-                          properties: { },
-                        }
-                      }, '*');
-                    }
-                  }, false);
-          
-                  // prevent page refresh (eg. CTRL+R)
-                  w.onbeforeunload = () => w.close();
-                });
-              }
-
-          })
+/**
+ * Edit in iframe
+ * 
+ * @see https://github.com/g3w-suite/g3w-client/pull/736
+ */
+g3wsdk.core.plugin.PluginsRegistry.onafter('registerPlugin', plugin => {
+  if (!plugin && 'editing' !== plugin.name) {
+    return;
+  }
+  VM.$watch(
+    () => g3wsdk.core.ApplicationState.sidebar.contentsdata,
+    (data = []) => data
+      .filter(d => 'editing-panel' === d.content.id)
+      .forEach(d => {
+        const tolboxes = d.content.internalPanel.$el.querySelector('#toolboxes');
+        let iframe_btn = document.querySelector('#edit_in_iframe');
+        if (!tolboxes || iframe_btn) {
+          return;
         }
-      )
-    }
-  })
+        tolboxes.insertAdjacentHTML('afterend', `<p><a href="#" id="edit_in_iframe">&#x270f; Edit in iframe</a></p>`);
+        iframe_btn = document.querySelector('#edit_in_iframe');
+        iframe_btn.addEventListener('click', () => {
+          const w = window.open('about:blank', '_blank', `fullscreen=yes`);
+          w.document.write(`<!doctype HTML><html><head><title>Test Iframe</title><style>html,body,iframe{width:100%;height:100%;margin:0;border:0;display:block;}</style></head><body><iframe src="${location.href}"></iframe></body></html>`);
+          //Listen message from application
+          w.addEventListener('message', e => {
+            if ('app:ready' === e.data.action) {
+              // send message to iframe every time iframe send a message con contentWindow
+              w.document.querySelector('iframe').contentWindow.postMessage({
+                id:      null,
+                action: 'editing:add',
+                data: {
+                  // only visible toolboxes
+                  qgs_layer_id: Array.from(editing_tolboxes.children).filter(item => item.classList.contains('toolbox') && 'none' !== item.style.display).map(item => item.id.split('id_toolbox_')[1]),
+                  properties: { },
+                }
+              }, '*');
+            }
+          }, false);
+          // prevent page refresh (eg. CTRL+R)
+          w.onbeforeunload = () => w.close();
+        });
+      })
+  );
+});
 
+/**
+ * Custom map control: "Open in iframe"
+ */
+g3wsdk.gui.GUI.once('ready', () => {
   g3wsdk.gui.GUI.getService('map').once('ready', function() {
     this.createMapControl('onclick',
     {

--- a/src/index.dev.js
+++ b/src/index.dev.js
@@ -233,19 +233,19 @@ g3wsdk.gui.GUI.once('ready', () => {
                 editing_tolboxes.insertAdjacentHTML('afterend', `<p><a href="#" id="edit_in_iframe">&#x270f; Edit in iframe</a></p>`);
                 iframe_btn = document.querySelector('#edit_in_iframe');
                 iframe_btn.addEventListener('click', () => {
+                  const qgs_layer_id = [];
+                  for (let item of editing_tolboxes.children) {
+                    //filter only visible toolbox
+                    if (item.classList.contains('toolbox') && 'none' !== item.style.display) {
+                      qgs_layer_id.push(item.id.split('id_toolbox_')[1]);
+                    }
+                  }
                   const w = window.open('about:blank', '_blank', `fullscreen=yes`);
                   w.document.write(`<!doctype HTML><html><head><title>Test Iframe</title><style>html,body,iframe{width:100%;height:100%;margin:0;border:0;display:block;}</style></head><body><iframe src="${location.href}"></iframe></body></html>`);
                   //Listen message from application
                   w.addEventListener('message', e => {
                     if ('app:ready' === e.data.action) {
-                      const qgs_layer_id = [];
-                      for (let item of editing_tolboxes.children) {
-                        if (item.classList.contains('toolbox')) {
-                          qgs_layer_id.push(item.id.split('id_toolbox_')[1]);
-                        }
-                      }
-                      
-                      // send message to iframe every time ifrema send a message con contentWindow
+                      // send message to iframe every time iframe send a message con contentWindow
                       w.document.querySelector('iframe').contentWindow.postMessage({
                         id:      null,
                         action: 'editing:add',

--- a/src/index.dev.js
+++ b/src/index.dev.js
@@ -4,6 +4,7 @@
  */
 import localforage from 'localforage';
 import { waitFor } from 'utils/waitFor';
+import { VM }      from 'g3w-eventbus';
 import shpwrite    from '@mapbox/shp-write';
 
 // expose global variables
@@ -217,6 +218,55 @@ C,"POINT (11.2474811 43.7910709)"`],
 
 // custom map control: "Open in iframe"
 g3wsdk.gui.GUI.once('ready', () => {
+
+  g3wsdk.core.plugin.PluginsRegistry.onafter('registerPlugin', plugin => {  
+    if (plugin && 'editing' === plugin.name) {
+      VM.$watch(
+        () => g3wsdk.core.ApplicationState.sidebar.contentsdata,
+        (data = []) => {
+          data
+          .filter(d => 'editing-panel' === d.content.id)
+          .forEach(d => {
+            const editing_tolboxes = d.content.internalPanel.$el.querySelector('#toolboxes');
+            let iframe_btn = document.querySelector('#edit_in_iframe');
+            if (editing_tolboxes && !iframe_btn) {
+                editing_tolboxes.insertAdjacentHTML('afterend', `<p><a href="#" id="edit_in_iframe">&#x270f; Edit in iframe</a></p>`);
+                iframe_btn = document.querySelector('#edit_in_iframe');
+                iframe_btn.addEventListener('click', () => {
+                  const w = window.open('about:blank', '_blank', `fullscreen=yes`);
+                  w.document.write(`<!doctype HTML><html><head><title>Test Iframe</title><style>html,body,iframe{width:100%;height:100%;margin:0;border:0;display:block;}</style></head><body><iframe src="${location.href}"></iframe></body></html>`);
+                  //Listen message from application
+                  w.addEventListener('message', e => {
+                    if ('app:ready' === e.data.action) {
+                      const qgs_layer_id = [];
+                      for (let item of editing_tolboxes.children) {
+                        if (item.classList.contains('toolbox')) {
+                          qgs_layer_id.push(item.id.split('id_toolbox_')[1]);
+                        }
+                      }
+                      
+                      // send message to iframe every time ifrema send a message con contentWindow
+                      w.document.querySelector('iframe').contentWindow.postMessage({
+                        id:      null,
+                        action: 'editing:add',
+                        data: {
+                          qgs_layer_id,
+                          properties: { },
+                        }
+                      }, '*');
+                    }
+                  }, false);
+          
+                  // prevent page refresh (eg. CTRL+R)
+                  w.onbeforeunload = () => w.close();
+                });
+              }
+
+          })
+        }
+      )
+    }
+  })
 
   g3wsdk.gui.GUI.getService('map').once('ready', function() {
     this.createMapControl('onclick',

--- a/src/index.dev.js
+++ b/src/index.dev.js
@@ -233,6 +233,7 @@ g3wsdk.gui.GUI.once('ready', () => {
           w.document.write(`<!doctype HTML><html><head><title>Test Iframe</title><style>html,body,iframe{width:100%;height:100%;margin:0;border:0;display:block;}</style></head><body><iframe src="${location.href}"></iframe></body></html>`);
           // send message to iframe every time ifrema send a message con contentWindow
           w.addEventListener('message', e => {
+            //Emit iframe:message to handle the message in config.js file
             setTimeout(() => g3wsdk.gui.GUI.emit('iframe:message', w.document.querySelector('iframe').contentWindow, e), 2000)
           }, false);
           // prevent page refresh (eg. CTRL+R)

--- a/src/index.dev.js
+++ b/src/index.dev.js
@@ -231,11 +231,9 @@ g3wsdk.gui.GUI.once('ready', () => {
         onclick() {
           const w = window.open('about:blank', '_blank', `fullscreen=yes`);
           w.document.write(`<!doctype HTML><html><head><title>Test Iframe</title><style>html,body,iframe{width:100%;height:100%;margin:0;border:0;display:block;}</style></head><body><iframe src="${location.href}"></iframe></body></html>`);
-          // send message to iframe when app is ready
+          // send message to iframe every time ifrema send a message con contentWindow
           w.addEventListener('message', e => {
-            if (e.data.action === 'app:ready') {
-              setTimeout(() => g3wsdk.gui.GUI.emit('iframe:message', w.document.querySelector('iframe').contentWindow, e), 2000)
-            }
+            setTimeout(() => g3wsdk.gui.GUI.emit('iframe:message', w.document.querySelector('iframe').contentWindow, e), 2000)
           }, false);
           // prevent page refresh (eg. CTRL+R)
           w.onbeforeunload = () => w.close();

--- a/src/services/iframe.js
+++ b/src/services/iframe.js
@@ -814,20 +814,19 @@ class EditingService extends BaseIframeService {
 
       // call method common
       await this.startAction({ toolboxes: qgs_layer_id, resolve, reject });
-
-      // return all toolboxes
+        // return all toolboxes
       const toolboxes = (
-        await this.startEditing(qgs_layer_id, {
-          tools:            this.config.tools.add,
-          startstopediting: false,
-          action :          'add',
-          selected:         1 === qgs_layer_id.length,
-        })
-      )
-      .filter(p => 'fulfilled' === p.status)
-      .map(p => p.value);
+          await this.startEditing(qgs_layer_id, {
+            tools:            this.config.tools.add,
+            startstopediting: false,
+            action :          'add',
+            selected:         1 === qgs_layer_id.length,
+          })
+        )
+        .filter(p => 'fulfilled' === p.status)
+        .map(p => p.value);
 
-      /** @FIXME add description */
+           /** @FIXME add description */
       if (!GUI.isSidebarVisible()) {
         GUI.showSidebar();
       }
@@ -882,9 +881,9 @@ class EditingService extends BaseIframeService {
       // return all toolboxes
       await this.startEditing([response.qgs_layer_id], {
         feature,
-        tools: this.config.tools.update,
+        tools:            this.config.tools.update,
         startstopediting: false,
-        action: 'update',
+        action:           'update',
       });
 
       if (!GUI.isSidebarVisible()) {
@@ -916,9 +915,10 @@ class EditingService extends BaseIframeService {
       case 'add':    filter.nofeatures = true;                                   break;
       case 'update': filter.field      = `${feature.field}|eq|${feature.value}`; break;
     }
-    const promises = [];
-    qgs_layer_id.forEach(id => { promises.push(this.dependencyApi.startEditing(id, options)) });
-    return await Promise.allSettled(promises);
+    //only in case of one layer id start editing otherwise client need to click on the layer
+    return await Promise.allSettled((1 === qgs_layer_id.length ? qgs_layer_id : [])
+      .map(id => this.dependencyApi.startEditing(id, options) ));
+
   }
 
   /**

--- a/src/store/application.js
+++ b/src/store/application.js
@@ -255,9 +255,6 @@ const STATE = Vue.observable({
 
   /** @since 3.11.0 */
   highlightlayers: false,
-  
-  /** @since 4.0.0 state of application development (true) production(false) */
-  development: false,
 
 });
 

--- a/src/store/application.js
+++ b/src/store/application.js
@@ -255,6 +255,9 @@ const STATE = Vue.observable({
 
   /** @since 3.11.0 */
   highlightlayers: false,
+  
+  /** @since 4.0.0 state of application development (true) production(false) */
+  development: false,
 
 });
 


### PR DESCRIPTION
## Test:

In case of edit multi layers , on iframe context, **qgs_layer_id**  contains more than one layer id:

Steps:

1. Set at least 2 layers in editing
2. Copy layer id of two layer on project config

![Screenshot_20250219_081658-1](https://github.com/user-attachments/assets/946cf8f0-92f8-4dca-9ab6-34049a02b932)



```js
window.postMessage({                
  id: null,
  action: 'editing:add',
  data: {
    qgs_layer_id: ['buildings_2f43dc1d_6725_42d2_a09b_dd446220104a, 'roads_ea006d6f_bd87_4635_aae0_4e9e7842b3f4],
    properties: { }
  }
}, '*');
```


## Before:

Doesn't show editing panel

![Screenshot_20250218_150203](https://github.com/user-attachments/assets/b4fd0453-b8d5-4d71-8d51-36cf75de5f9c)


## After:

Show editing panel  and layer editing toolbox need to be activated by user.


![Screenshot_20250218_150011](https://github.com/user-attachments/assets/dec40a08-a007-448c-a907-a1fa512e21db)

