### PR TITLE
:bug: Prevent registering invalid `proj4.defs`

### DIFF
--- a/src/store/projections.js
+++ b/src/store/projections.js
@@ -4,7 +4,7 @@
  * @since 3.11.0
  */
 import { normalizeEpsg } from 'utils/normalizeEpsg';
-import proj4             from 'proj4/dist/proj4-src';
+import proj4             from 'proj4';
 
 /**
  * ORIGINAL SOURCE: src/app/g3w-ol/projection/projection.js@v3.10.1
@@ -13,11 +13,9 @@ import proj4             from 'proj4/dist/proj4-src';
 export default {
 
   get(crs = {}) {
-    let p = ol.proj.get(crs.epsg);
+    let p = ol.proj.get(normalizeEpsg(crs.epsg));
     if (!p) {
-      if (crs.proj4) {
-        proj4.defs(crs.epsg, crs.proj4);
-      }
+      
       const proj = {
         code:            crs.epsg,
         extent:          crs.extent,
@@ -27,7 +25,15 @@ export default {
       p = new ol.proj.Projection(proj);
       p.getAxisOrientation = () => proj.axisOrientation;
       ol.proj.addProjection(p);
-      ol.proj.proj4.register(proj4);
+      //Only in case of proj4.defs change need to register
+      if (crs.proj4) {
+        proj4.defs(crs.epsg, crs.proj4);
+        ol.proj.proj4.register(proj4);
+      }
+    }
+    //in case of missing extent
+    if (crs.extent && !p.getExtent()){
+      p.setExtent(crs.extent);
     }
     return p;
   },

--- a/src/store/projections.js
+++ b/src/store/projections.js
@@ -14,27 +14,31 @@ export default {
 
   get(crs = {}) {
     let p = ol.proj.get(normalizeEpsg(crs.epsg));
+    const proj = !p && {
+      code:            crs.epsg,
+      extent:          crs.extent,
+      axisOrientation: crs.axisinverted ? 'neu' : 'enu',
+      units:           crs.geographic ? 'degrees' : 'm'
+    };
+
+    // crs not yet registered
     if (!p) {
-      
-      const proj = {
-        code:            crs.epsg,
-        extent:          crs.extent,
-        axisOrientation: crs.axisinverted ? 'neu' : 'enu',
-        units:           crs.geographic ? 'degrees' : 'm'
-      };
       p = new ol.proj.Projection(proj);
       p.getAxisOrientation = () => proj.axisOrientation;
       ol.proj.addProjection(p);
-      //Only in case of proj4.defs change need to register
-      if (crs.proj4) {
-        proj4.defs(crs.epsg, crs.proj4);
-        ol.proj.proj4.register(proj4);
-      }
     }
-    //in case of missing extent
+
+    // crs is a proj4 object
+    if (proj && crs.proj4) {
+      proj4.defs(crs.epsg, crs.proj4);
+      ol.proj.proj4.register(proj4);
+    }
+
+    // crs has no extent
     if (crs.extent && !p.getExtent()){
       p.setExtent(crs.extent);
     }
+
     return p;
   },
 


### PR DESCRIPTION
It seems that proj4js version 2.15.0 define below projections:

**// UTM WGS84
      for (var i = 1; i <= 60; ++i) {
        defs('EPSG:' + (32600 + i), "+proj=utm +zone=" + i + " +datum=WGS84 +units=m");
        defs('EPSG:' + (32700 + i), "+proj=utm +zone=" + i + " +south +datum=WGS84 +units=m");
      }**

Example of using projection.getExtent() value:


https://github.com/g3w-suite/g3w-client/blob/f1a49893922bcec59a5dc72e98d71a778b0506bb/src/map/layers/imagelayer.js#L461


## Before

![Screenshot_20250218_151009](https://github.com/user-attachments/assets/6656183d-5524-4288-9f27-6a710196ecca)

## After

![Screenshot_20250218_151104](https://github.com/user-attachments/assets/66be6665-67e5-47d6-a034-d73e987f44d8)
