### PR TITLE
Custom query result action button: “Update feature in iframe” (ref: `index.dev.js`)

### DIFF
--- a/src/index.dev.js
+++ b/src/index.dev.js
@@ -8,6 +8,8 @@ import shpwrite    from '@mapbox/shp-write';
 
 // expose global variables
 import 'g3w-globals';
+import g3wConstants from 'g3w-constants';
+import { color } from 'app/gui/inputs/services';
 
 // apply dev config overrides (config.js)
 (require('../config').devConfig || (() => { })).call();
@@ -221,6 +223,7 @@ C,"POINT (11.2474811 43.7910709)"`],
  * @see https://github.com/g3w-suite/g3w-client/pull/736
  */
 g3wsdk.gui.GUI.once('ready', () => {
+  //ADD EDITING FEATURE (editing:add)
   (new Vue).$watch(
     () => g3wsdk.core.ApplicationState.sidebar.contentsdata,
     (data = []) => data.filter(d => 'editing-panel' === d.content.id).forEach(d => { //wait for editing panel
@@ -251,6 +254,50 @@ g3wsdk.gui.GUI.once('ready', () => {
         w.onbeforeunload = () => w.close();
       });
     }));
+
+  //UPDATE EDITING FEATURE (editing:update)
+  g3wsdk.gui.GUI.getService('queryresults').onafter('addActionsForLayers', (actions, layers) => {
+    Object.keys(actions).forEach(id => {
+      if (layers.find(l => id === l.id).editable) {
+        //Check only if has primay key value to ge unique feature to edit
+        const pkField = g3wsdk.core.catalog.CatalogLayersStoresRegistry.getLayerById(id).getEditingFields().find(f => f.pk);
+        // in case that layer has not pk field, iframe editing action is not
+        if (!pkField) {
+          return;
+        }
+        actions[id].push({
+          id: 'iframe_editing_update',
+          class: GUI.getFontClass('pencil'),
+          hint:  'Iframe update feature',
+          style: {
+            color: '#000000 !important'
+          },
+          cbk:   (layer, feature) => {
+            
+            const w = window.open('about:blank', '_blank', `fullscreen=yes`);
+            w.document.write(`<!doctype HTML><html><head><title>Test Iframe</title><style>html,body,iframe{width:100%;height:100%;margin:0;border:0;display:block;}</style></head><body><iframe src="${location.href}"></iframe></body></html>`);
+            w.addEventListener('message', e => {
+              if ('app:ready' === e.data.action) {
+                w.document.querySelector('iframe').contentWindow.postMessage({
+                  id:      null,
+                  action: 'editing:update',
+                  data: {
+                    qgs_layer_id: layer.id,
+                    feature: {
+                      field: pkField.name,
+                      value: feature.attributes[pkField.name]//
+                    }
+                  }
+                }, '*');
+              }
+            }, false);
+            // prevent page refresh (eg. CTRL+R)
+            w.onbeforeunload = () => w.close();
+          }
+        })
+      }
+    })
+  })
 });
 
 /**

--- a/src/index.dev.js
+++ b/src/index.dev.js
@@ -8,8 +8,6 @@ import shpwrite    from '@mapbox/shp-write';
 
 // expose global variables
 import 'g3w-globals';
-import g3wConstants from 'g3w-constants';
-import { color } from 'app/gui/inputs/services';
 
 // apply dev config overrides (config.js)
 (require('../config').devConfig || (() => { })).call();
@@ -218,12 +216,11 @@ C,"POINT (11.2474811 43.7910709)"`],
 });
 
 /**
- * Custom editing control: "Edit in iframe"
+ * Custom editing control: “Edit in iframe”
  * 
  * @see https://github.com/g3w-suite/g3w-client/pull/736
  */
 g3wsdk.gui.GUI.once('ready', () => {
-  //ADD EDITING FEATURE (editing:add)
   (new Vue).$watch(
     () => g3wsdk.core.ApplicationState.sidebar.contentsdata,
     (data = []) => data.filter(d => 'editing-panel' === d.content.id).forEach(d => { //wait for editing panel
@@ -253,55 +250,59 @@ g3wsdk.gui.GUI.once('ready', () => {
         // prevent page refresh (eg. CTRL+R)
         w.onbeforeunload = () => w.close();
       });
-    }));
+    })
+  );
+});
 
-  //UPDATE EDITING FEATURE (editing:update)
+/**
+ * Custom query result action button: “Update feature in iframe”
+ * 
+ * @see https://github.com/g3w-suite/g3w-client/pull/736
+ */
+g3wsdk.gui.GUI.once('ready', () => {
   g3wsdk.gui.GUI.getService('queryresults').onafter('addActionsForLayers', (actions, layers) => {
-    Object.keys(actions).forEach(id => {
-      if (layers.find(l => id === l.id).editable) {
-        //Check only if has primay key value to ge unique feature to edit
-        const pkField = g3wsdk.core.catalog.CatalogLayersStoresRegistry.getLayerById(id).getEditingFields().find(f => f.pk);
-        // in case that layer has not pk field, iframe editing action is not
-        if (!pkField) {
-          return;
-        }
-        actions[id].push({
-          id: 'iframe_editing_update',
-          class: GUI.getFontClass('pencil'),
-          hint:  'Iframe update feature',
-          style: {
-            color: '#000000 !important'
-          },
-          cbk:   (layer, feature) => {
-            
-            const w = window.open('about:blank', '_blank', `fullscreen=yes`);
-            w.document.write(`<!doctype HTML><html><head><title>Test Iframe</title><style>html,body,iframe{width:100%;height:100%;margin:0;border:0;display:block;}</style></head><body><iframe src="${location.href}"></iframe></body></html>`);
-            w.addEventListener('message', e => {
-              if ('app:ready' === e.data.action) {
-                w.document.querySelector('iframe').contentWindow.postMessage({
-                  id:      null,
-                  action: 'editing:update',
-                  data: {
-                    qgs_layer_id: layer.id,
-                    feature: {
-                      field: pkField.name,
-                      value: feature.attributes[pkField.name]//
-                    }
-                  }
-                }, '*');
-              }
-            }, false);
-            // prevent page refresh (eg. CTRL+R)
-            w.onbeforeunload = () => w.close();
-          }
-        })
+    Object.keys(actions)
+    .filter(id => layers.find(l => id === l.id).editable)
+    .forEach(id => {
+      //Check only if has primay key value to ge unique feature to edit
+      const pkField = g3wsdk.core.catalog.CatalogLayersStoresRegistry.getLayerById(id).getEditingFields().find(f => f.pk);
+      // in case that layer has not pk field, iframe editing action is not
+      if (!pkField) {
+        return;
       }
+      actions[id].push({
+        id: 'update_feature_in_iframe',
+        class: 'fa fa-window-restore',
+        hint:  'Update feature in iframe',
+        style: { color: 'black !important' },
+        cbk:   (layer, feature) => {
+          const w = window.open('about:blank', '_blank', `fullscreen=yes`);
+          w.document.write(`<!doctype HTML><html><head><title>Test Iframe</title><style>html,body,iframe{width:100%;height:100%;margin:0;border:0;display:block;}</style></head><body><iframe src="${location.href}"></iframe></body></html>`);
+          w.addEventListener('message', e => {
+            if ('app:ready' === e.data.action) {
+              w.document.querySelector('iframe').contentWindow.postMessage({
+                id:      null,
+                action: 'editing:update',
+                data: {
+                  qgs_layer_id: layer.id,
+                  feature: {
+                    field: pkField.name,
+                    value: feature.attributes[pkField.name]
+                  }
+                }
+              }, '*');
+            }
+          }, false);
+          // prevent page refresh (eg. CTRL+R)
+          w.onbeforeunload = () => w.close();
+        }
+      })
     })
   })
 });
 
 /**
- * Custom map control: "Open in iframe"
+ * Custom map control: “Open in iframe”
  */
 g3wsdk.gui.GUI.once('ready', () => {
   g3wsdk.gui.GUI.getService('map').once('ready', function() {


### PR DESCRIPTION
## Motivation

Add icon on query result content (development env only), to test update feature in editing on iframe.

## How to test

1. Query a feature on a layer (that is editable)
2. click on "black window icon" within query results

![image](https://github.com/user-attachments/assets/e93d2305-61a0-46b1-87b8-27fab571a48b)

4. an iframe window will open, loading that feature

![Screenshot_20250220_115206](https://github.com/user-attachments/assets/63df7ca6-6b88-4ecb-8875-96f52f2cde0c)

