### PR TITLE
🐛 Repeated values found on multi search layers with the same value of a select input

### DIFF
--- a/src/components/CatalogTristateTree.vue
+++ b/src/components/CatalogTristateTree.vue
@@ -155,7 +155,7 @@
 
         <!-- TOGGLE FILTER  -->
         <span
-          v-if                         = "!layerstree.external && (layerstree.selection.active || layerstree.filter.active) && !layerstree.filter.pagination"
+          v-if                         = "!layerstree.external && layerstree.selection.active && layerstree.filter.active && !layerstree.filter.pagination"
           class                        = "action-button skin-tooltip-left selection-filter-icon"
           data-placement               = "left"
           data-toggle                  = "tooltip"

--- a/src/components/CatalogTristateTree.vue
+++ b/src/components/CatalogTristateTree.vue
@@ -155,7 +155,7 @@
 
         <!-- TOGGLE FILTER  -->
         <span
-          v-if                         = "!layerstree.external && layerstree.selection.active && layerstree.filter.active && !layerstree.filter.pagination"
+          v-if                         = "!layerstree.external && (layerstree.selection.active || layerstree.filter.active) && !layerstree.filter.pagination"
           class                        = "action-button skin-tooltip-left selection-filter-icon"
           data-placement               = "left"
           data-toggle                  = "tooltip"

--- a/src/utils/getDataForSearchInput.js
+++ b/src/utils/getDataForSearchInput.js
@@ -21,7 +21,7 @@ export async function getDataForSearchInput({ state, field, suggest }) {
       })))
     )
       .filter(d => 'fulfilled' === d.status)
-      .reduce((acc, d) => acc.concat(d.value.data || []), []) // uniques by fformatter
+      .reduce((acc, d, i) => 0 === i ? acc.concat(d.value.data || []) : [...new Set([...(d.value.data || []), ...acc].map(JSON.stringify))].map(JSON.parse), []) // uniques by fformatter and get unique data from more than one serach_layers
       .map(([value, key]) => ({ key, value }));
 
   } catch(e) { console.warn(e); }

--- a/src/utils/getDataForSearchInput.js
+++ b/src/utils/getDataForSearchInput.js
@@ -21,7 +21,11 @@ export async function getDataForSearchInput({ state, field, suggest }) {
       })))
     )
       .filter(d => 'fulfilled' === d.status)
-      .reduce((acc, d, i) => 0 === i ? acc.concat(d.value.data || []) : [...new Set([...(d.value.data || []), ...acc].map(JSON.stringify))].map(JSON.parse), []) // uniques by fformatter and get unique data from more than one serach_layers
+      .reduce((acc, d, i) => 0 === i
+        ? acc.concat(d.value.data || [])                                                       // TODO: add description
+        : [...new Set([...(d.value.data || []), ...acc].map(JSON.stringify))].map(JSON.parse), // ensure uniques values (search performed on multiple serach_layers)
+        [] 
+      )
       .map(([value, key]) => ({ key, value }));
 
   } catch(e) { console.warn(e); }

--- a/src/utils/getDataForSearchInput.js
+++ b/src/utils/getDataForSearchInput.js
@@ -22,7 +22,7 @@ export async function getDataForSearchInput({ state, field, suggest }) {
     )
       .filter(d => 'fulfilled' === d.status)
       .reduce((acc, d, i) => 0 === i
-        ? acc.concat(d.value.data || [])                                                       // TODO: add description
+        ? acc.concat(d.value.data || [])                                                       // for first layer get all uninques values 
         : [...new Set([...(d.value.data || []), ...acc].map(JSON.stringify))].map(JSON.parse), // ensure uniques values (search performed on multiple serach_layers)
         [] 
       )


### PR DESCRIPTION
The issue id due when a we create a search with a select input and search from another layer:

Project https://dev.g3wsuite.it/en/map/test-walter/qdjango/296/

![Screenshot_20250225_160758](https://github.com/user-attachments/assets/535d0c9d-73bf-49ca-9ab2-a0058df85778)

**Before:**


Application search get values, key/value, from each layers. It happen that if layer 1, layer 2 and layer 3 have some item equal, for example [keyA, valueA], these values are show repeated on select input list options:

![Screenshot_20250225_161126](https://github.com/user-attachments/assets/7c214cb2-e5c2-4b01-bc5d-58e13602c1bc)

**After:**

No name is repeated

![Screenshot_20250225_161637](https://github.com/user-attachments/assets/7ac5017b-a727-4099-8399-f2ffadd1d0f7)
