### PR TITLE
🐛 Download layer features from search with pagination

### DIFF
--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -760,7 +760,7 @@
         this.$options.service.printAtlas(layer);
       },
       showLayerDownloadFormats(layer) {
-        this.$options.service.showLayerDownloadFormats(layer)
+        this.$options.service.showLayerDownloadFormats(layer);
       },
       saveLayerResult(layer, type = "csv") {
         this.$options.service.downloadFeatures(type, layer, layer.features);

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -1624,9 +1624,11 @@ export default new (class QueryResultsService extends G3WObject {
     }
 
     const { query = {} } = this.state;
-    const data           = {
-      fids: features.map(f => f.attributes[G3W_FID]).join(',')
-    };
+    //@since 3.11.5 In case of search, need to set field parameter instead fids
+    // In this way we reduce the amount of fids and issue due of search with pagination
+    const data           = 'search' === query.type 
+      ? { field: query.search.join()} 
+      : { fids: features.map(f => f.attributes[G3W_FID]).join(',') };
 
     //In the case of pdf type need to add html element
     if ('pdf' === type) {

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -1624,11 +1624,10 @@ export default new (class QueryResultsService extends G3WObject {
     }
 
     const { query = {} } = this.state;
-    //@since 3.11.5 In case of search, need to set field parameter instead fids
-    // In this way we reduce the amount of fids and issue due of search with pagination
-    const data           = 'search' === query.type 
-      ? { field: query.search.join()} 
-      : { fids: features.map(f => f.attributes[G3W_FID]).join(',') };
+
+    const data = 'search' === query.type 
+      ? { field: query.search.join() }                                // search results + pagination (see: https://github.com/g3w-suite/g3w-client/pull/743)
+      : { fids: features.map(f => f.attributes[G3W_FID]).join(',') }; // query results (default behavior)
 
     //In the case of pdf type need to add html element
     if ('pdf' === type) {

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -1625,9 +1625,9 @@ export default new (class QueryResultsService extends G3WObject {
 
     const { query = {} } = this.state;
 
-    const data = 'search' === query.type 
+    const data = 'search' === query.type
       ? { field: query.search.join() }                                // search results + pagination (see: https://github.com/g3w-suite/g3w-client/pull/743)
-      : { fids: features.map(f => f.attributes[G3W_FID]).join(',') }; // query results (default behavior)
+      : { fids: features.map(f => f.attributes[G3W_FID]).join(',') }; // other query types ('point', 'polygon', 'bbox' ..)
 
     //In the case of pdf type need to add html element
     if ('pdf' === type) {


### PR DESCRIPTION
If we set a search with pagination

![Screenshot_20250225_123221](https://github.com/user-attachments/assets/817acb0a-a1e7-4543-b798-6ec96cc43f69)

and we try to download all feature from search belong to layer

![Screenshot_20250225_123347](https://github.com/user-attachments/assets/2d267d01-8026-4bb7-9bd8-43e03e80df49)

we get only visible features

![Screenshot_20250225_123543](https://github.com/user-attachments/assets/28128f21-1a9b-4f72-bb4b-1fd61f0a8754)

and not all features from search (10 to 17)


**After**

![Screenshot_20250225_123658](https://github.com/user-attachments/assets/ac1d788b-8002-4ceb-b82a-5b1c84d76c81)

we get all 17 features