### PR TITLE
Show a warning message to user in case of server error (user themes API)

### DIFF
--- a/src/components/CatalogChangeMapThemes.vue
+++ b/src/components/CatalogChangeMapThemes.vue
@@ -300,30 +300,30 @@ export default {
         return;
       }
       try {
-        const params = this._getMapThemeParams();
-        const saved = await XHR.post({
+        const params   = this._getMapThemeParams();
+        const response = await XHR.post({
           url:         `${ApplicationState.project.urls.map_themes}${encodeURIComponent(theme)}/`,
           contentType: 'application/json',
           data:        JSON.stringify(params),
         });
-        if (saved.result) {
-          this.map_themes.custom.push({ theme: this.custom_theme.value, styles: params.styles });
-          // show a success add custom matp theme message to user
-          GUI.showUserMessage({ type: 'success', message: 'sdk.catalog.saved_map_theme', autoclose: true });
-          // close dialog
-          this.show_form    = false;
-          //set as current active name map theme
-          this.active_theme = this.custom_theme.value;
-          //need to wait watch
-          await this.$nextTick();
-          //set custom map theme value to null. Reset value
-          this.custom_theme.value = null;
-        } else {
-          throw saved;
-        }       
+        // handle server error
+        if (!response.result) {
+          throw response;
+        }
+        this.map_themes.custom.push({ theme: this.custom_theme.value, styles: params.styles });
+        // show a success add custom matp theme message to user
+        GUI.showUserMessage({ type: 'success', message: 'sdk.catalog.saved_map_theme', autoclose: true });
+        // close dialog
+        this.show_form    = false;
+        //set as current active name map theme
+        this.active_theme = this.custom_theme.value;
+        //need to wait watch
+        await this.$nextTick();
+        //set custom map theme value to null. Reset value
+        this.custom_theme.value = null;
       } catch(e) {
         console.warn(e);
-        GUI.showUserMessage({ type: 'alert', message: saved.error || 'info.server_error', autoclose: false });
+        GUI.showUserMessage({ type: 'alert', message: e.error || 'info.server_error', autoclose: false });
       }
     },
 
@@ -384,7 +384,6 @@ export default {
           if (theme === this.active_theme) { this.active_theme = null;}
         } catch(e) {
           console.warn(e);
-          // show a error message to user
           GUI.showUserMessage({ type: 'alert', message: e.error || 'info.server_error', autoclose: false });
         }
       });

--- a/src/components/CatalogChangeMapThemes.vue
+++ b/src/components/CatalogChangeMapThemes.vue
@@ -333,22 +333,22 @@ export default {
         return;
       }
       try {
-        const params = this._getMapThemeParams();
-        const update = await XHR.post({
+        const params   = this._getMapThemeParams();
+        const response = await XHR.post({
           url:         `${ApplicationState.project.urls.map_themes}${encodeURIComponent(theme)}/`,
           contentType: 'application/json',
           data:        JSON.stringify(params),
         });
-        if (update.result) {
-          // update custom map theme styles
-          const c_theme = this.map_themes.custom.find(mt => theme === mt.theme)
-          c_theme.styles     = params.styles;
-          c_theme.layerstree = params.layerstree;
-          // show a success update map theme message to user
-          GUI.showUserMessage({ type: 'success', message: 'sdk.catalog.updated_map_theme', autoclose: true });
-        } else {
-          throw update;
+        // handle server error
+        if (!response.result) {
+          throw response;
         }
+        // update custom map theme styles
+        const c_theme = this.map_themes.custom.find(mt => theme === mt.theme)
+        c_theme.styles     = params.styles;
+        c_theme.layerstree = params.layerstree;
+        // show a success update map theme message to user
+        GUI.showUserMessage({ type: 'success', message: 'sdk.catalog.updated_map_theme', autoclose: true });
       } catch(e) {
         console.warn(e);
         GUI.showUserMessage({ type: 'alert', message: e.error || 'info.server_error', autoclose: false });
@@ -370,18 +370,18 @@ export default {
           return;
         }
         try {
-          const deleted = await (await fetch(`${ApplicationState.project.urls.map_themes}${encodeURIComponent(theme)}/`, {
+          const response = await (await fetch(`${ApplicationState.project.urls.map_themes}${encodeURIComponent(theme)}/`, {
             method: 'DELETE',
           })).json();
-          if (deleted.result) {
-            this.map_themes.custom = this.map_themes.custom.filter(({ theme:t }) => t !== theme);
-            // show a success message to user
-            GUI.showUserMessage({ type: 'success', message: 'sdk.catalog.delete_map_theme', autoclose: true })
-            // in the case of deleted current map theme set current theme to null
-            if (theme === this.active_theme) { this.active_theme = null;}
-          } else {
-            throw deleted;
-          }        
+          // handle server error
+          if (!response.result) {
+            throw response;
+          }
+          this.map_themes.custom = this.map_themes.custom.filter(({ theme:t }) => t !== theme);
+          // show a success message to user
+          GUI.showUserMessage({ type: 'success', message: 'sdk.catalog.delete_map_theme', autoclose: true })
+          // in the case of deleted current map theme set current theme to null
+          if (theme === this.active_theme) { this.active_theme = null;}
         } catch(e) {
           console.warn(e);
           // show a error message to user

--- a/src/components/CatalogChangeMapThemes.vue
+++ b/src/components/CatalogChangeMapThemes.vue
@@ -311,16 +311,19 @@ export default {
           // show a success add custom matp theme message to user
           GUI.showUserMessage({ type: 'success', message: 'sdk.catalog.saved_map_theme', autoclose: true });
           // close dialog
-          this.show_form = false;
+          this.show_form    = false;
           //set as current active name map theme
           this.active_theme = this.custom_theme.value;
           //need to wait watch
           await this.$nextTick();
           //set custom map theme value to null. Reset value
           this.custom_theme.value = null;
-        }        
-      } catch (e) {
+        } else {
+          throw saved;
+        }       
+      } catch(e) {
         console.warn(e);
+        GUI.showUserMessage({ type: 'alert', message: saved.error || 'info.server_error', autoclose: false });
       }
     },
 
@@ -331,19 +334,24 @@ export default {
       }
       try {
         const params = this._getMapThemeParams();
-        await XHR.post({
+        const update = await XHR.post({
           url:         `${ApplicationState.project.urls.map_themes}${encodeURIComponent(theme)}/`,
           contentType: 'application/json',
           data:        JSON.stringify(params),
         });
-        // update custom map theme styles
-        const c_theme = this.map_themes.custom.find(mt => theme === mt.theme)
-        c_theme.styles     = params.styles;
-        c_theme.layerstree = params.layerstree;
-        // show a success update map theme message to user
-        GUI.showUserMessage({ type: 'success', message: 'sdk.catalog.updated_map_theme', autoclose: true });
+        if (update.result) {
+          // update custom map theme styles
+          const c_theme = this.map_themes.custom.find(mt => theme === mt.theme)
+          c_theme.styles     = params.styles;
+          c_theme.layerstree = params.layerstree;
+          // show a success update map theme message to user
+          GUI.showUserMessage({ type: 'success', message: 'sdk.catalog.updated_map_theme', autoclose: true });
+        } else {
+          throw update;
+        }
       } catch(e) {
         console.warn(e);
+        GUI.showUserMessage({ type: 'alert', message: e.error || 'info.server_error', autoclose: false });
       }
 
     },
@@ -371,9 +379,13 @@ export default {
             GUI.showUserMessage({ type: 'success', message: 'sdk.catalog.delete_map_theme', autoclose: true })
             // in the case of deleted current map theme set current theme to null
             if (theme === this.active_theme) { this.active_theme = null;}
-          }          
-        } catch (e) {
-          console.warn(e)
+          } else {
+            throw deleted;
+          }        
+        } catch(e) {
+          console.warn(e);
+          // show a error message to user
+          GUI.showUserMessage({ type: 'alert', message: e.error || 'info.server_error', autoclose: false });
         }
       });
     },

--- a/src/components/CatalogChangeMapThemes.vue
+++ b/src/components/CatalogChangeMapThemes.vue
@@ -344,9 +344,10 @@ export default {
           throw response;
         }
         // update custom map theme styles
-        const c_theme = this.map_themes.custom.find(mt => theme === mt.theme)
-        c_theme.styles     = params.styles;
-        c_theme.layerstree = params.layerstree;
+        Object.assign(this.map_themes.custom.find(mt => theme === mt.theme), {
+          styles:     params.styles,
+          layerstree: params.layerstree,
+        });
         // show a success update map theme message to user
         GUI.showUserMessage({ type: 'success', message: 'sdk.catalog.updated_map_theme', autoclose: true });
       } catch(e) {

--- a/src/components/CatalogChangeMapThemes.vue
+++ b/src/components/CatalogChangeMapThemes.vue
@@ -354,7 +354,6 @@ export default {
         console.warn(e);
         GUI.showUserMessage({ type: 'alert', message: e.error || 'info.server_error', autoclose: false });
       }
-
     },
 
     /**


### PR DESCRIPTION
Related to https://github.com/g3w-suite/g3w-admin/issues/1061

## Before:

If you try to delete test theme from User Theme on https://v39.g3wsuite.it/it/map/g3w-suite-demo/qdjango/97/

![Screenshot_20250312_093946](https://github.com/user-attachments/assets/dfc3e835-0d5c-48ff-813c-dab860b93b2b)

No message is show. Instead on debug console we can see

![Screenshot_20250312_094059](https://github.com/user-attachments/assets/59b8a43d-5f9e-4a3c-b1f7-230db0cca393)

## After

![Screenshot_20250312_094222](https://github.com/user-attachments/assets/56242f1d-b044-48e0-bf6f-e5fae5774658)
