### PR TITLE
Prevent copying static assets from `g3w-admin-*` plugins  (`npm run build`)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -320,6 +320,7 @@ gulp.task('images', async function () {
   return gulp.src([
     `./src/assets/images/**/*.{png,jpg,gif,svg}`,
     `${g3w.pluginsFolder}/**/*.{png,jpg,gif,svg}`,
+    `!${g3w.pluginsFolder}/g3w-admin-*/**/`, //exclude admin plugins
     `!${g3w.pluginsFolder}/**/node_modules/**/`,
     '!./src/**/node_modules/**/'
   ])
@@ -346,6 +347,7 @@ gulp.task('cursors', function () {
     `./src/assets/fonts/**/*.{eot,ttf,woff,woff2}`,
     `./node_modules/@fortawesome/fontawesome-free/webfonts//**/*.{eot,ttf,woff,woff2}`,
     `${g3w.pluginsFolder}/**/*.{eot,ttf,woff,woff2}`,
+    `!${g3w.pluginsFolder}/g3w-admin-*/**/`, //exclude admin plugins
     `!${g3w.pluginsFolder}/**/node_modules/**`,
     '!./src/**/node_modules/**/'
   ])


### PR DESCRIPTION
Exclude to copy g3w-admin client plugins assests to g3w-admin static client folder when run **npm run build** script  

https://github.com/g3w-suite/g3w-client/blob/b89bfb36abb3187c40ce70f73a654c18321e11bd/gulpfile.js#L48


Below  show qplotly g3w-admin plugin images

![Screenshot_20250320_111526](https://github.com/user-attachments/assets/bf0a6122-de47-4aa7-9467-fe4bfbb37e35)
