### PR TITLE
Prevent copying static assets from `g3w-admin-*` plugins (`npm run build`)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -320,6 +320,7 @@ gulp.task('images', async function () {
   return gulp.src([
     `./src/assets/images/**/*.{png,jpg,gif,svg}`,
     `${g3w.pluginsFolder}/**/*.{png,jpg,gif,svg}`,
+    `!${g3w.pluginsFolder}/g3w-admin-*/**/`, //exclude admin plugins
     `!${g3w.pluginsFolder}/**/node_modules/**/`,
     '!./src/**/node_modules/**/'
   ])
@@ -346,6 +347,7 @@ gulp.task('cursors', function () {
     `./src/assets/fonts/**/*.{eot,ttf,woff,woff2}`,
     `./node_modules/@fortawesome/fontawesome-free/webfonts//**/*.{eot,ttf,woff,woff2}`,
     `${g3w.pluginsFolder}/**/*.{eot,ttf,woff,woff2}`,
+    `!${g3w.pluginsFolder}/g3w-admin-*/**/`, //exclude admin plugins
     `!${g3w.pluginsFolder}/**/node_modules/**`,
     '!./src/**/node_modules/**/'
   ])

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -320,7 +320,7 @@ gulp.task('images', async function () {
   return gulp.src([
     `./src/assets/images/**/*.{png,jpg,gif,svg}`,
     `${g3w.pluginsFolder}/**/*.{png,jpg,gif,svg}`,
-    `!${g3w.pluginsFolder}/g3w-admin-*/**/`, //exclude admin plugins
+    `!${g3w.pluginsFolder}/g3w-admin-*/**/*`, //exclude admin plugins
     `!${g3w.pluginsFolder}/**/node_modules/**/`,
     '!./src/**/node_modules/**/'
   ])
@@ -347,7 +347,7 @@ gulp.task('cursors', function () {
     `./src/assets/fonts/**/*.{eot,ttf,woff,woff2}`,
     `./node_modules/@fortawesome/fontawesome-free/webfonts//**/*.{eot,ttf,woff,woff2}`,
     `${g3w.pluginsFolder}/**/*.{eot,ttf,woff,woff2}`,
-    `!${g3w.pluginsFolder}/g3w-admin-*/**/`, //exclude admin plugins
+    `!${g3w.pluginsFolder}/g3w-admin-*/**/*`, //exclude admin plugins
     `!${g3w.pluginsFolder}/**/node_modules/**`,
     '!./src/**/node_modules/**/'
   ])

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -320,9 +320,9 @@ gulp.task('images', async function () {
   return gulp.src([
     `./src/assets/images/**/*.{png,jpg,gif,svg}`,
     `${g3w.pluginsFolder}/**/*.{png,jpg,gif,svg}`,
-    `!${g3w.pluginsFolder}/g3w-admin-*/**/*`, //exclude admin plugins
-    `!${g3w.pluginsFolder}/**/node_modules/**/`,
-    '!./src/**/node_modules/**/'
+    `!${g3w.pluginsFolder}/g3w-admin-*/**`, //exclude admin plugins
+    `!${g3w.pluginsFolder}/**/node_modules/**`,
+    '!./src/**/node_modules/**'
   ])
   .pipe(flatten())
   .pipe(gulp.dest(`${outputFolder}/static/client/images/`))
@@ -347,9 +347,9 @@ gulp.task('cursors', function () {
     `./src/assets/fonts/**/*.{eot,ttf,woff,woff2}`,
     `./node_modules/@fortawesome/fontawesome-free/webfonts//**/*.{eot,ttf,woff,woff2}`,
     `${g3w.pluginsFolder}/**/*.{eot,ttf,woff,woff2}`,
-    `!${g3w.pluginsFolder}/g3w-admin-*/**/*`, //exclude admin plugins
+    `!${g3w.pluginsFolder}/g3w-admin-*/**`, //exclude admin plugins
     `!${g3w.pluginsFolder}/**/node_modules/**`,
-    '!./src/**/node_modules/**/'
+    '!./src/**/node_modules/**'
   ])
   .pipe(flatten())
   .pipe(gulp.dest(`${outputFolder}/static/client/fonts/`))


### PR DESCRIPTION
Improves/Fixes: https://github.com/g3w-suite/g3w-client/pull/758
