### PR TITLE
🐛 Missing `FORMAT` parameter in server requests (WMS GetMap image format)

### DIFF
--- a/src/services/map.js
+++ b/src/services/map.js
@@ -1424,7 +1424,7 @@ class MapService extends G3WObject {
           /** @since 3.11.7 Get Format from layer */ 
           format: layer.getFormat()
         },
-        1 === layers.length ? {} : this.layersExtraParams
+        this.layersExtraParams
       );
       layers.reverse().forEach(l => mapLayer.addLayer(l));
       mapLayers.push(mapLayer);

--- a/src/services/map.js
+++ b/src/services/map.js
@@ -1421,8 +1421,8 @@ class MapService extends G3WObject {
         {
           id: `layer_${id}`,
           projection: this.getProjection(),
-          /** @since 3.9.1 */
-          format: 1 === layers.length ? layer.getFormat() : null
+          /** @since 3.11.7 Get Format from layer */ 
+          format: layer.getFormat()
         },
         1 === layers.length ? {} : this.layersExtraParams
       );

--- a/src/services/map.js
+++ b/src/services/map.js
@@ -1421,7 +1421,6 @@ class MapService extends G3WObject {
         {
           id: `layer_${id}`,
           projection: this.getProjection(),
-          /** @since 3.11.7 Get Format from layer */ 
           format: layer.getFormat()
         },
         1 === layers.length ? {} : this.layersExtraParams


### PR DESCRIPTION
Closes: #763 

Set WMS GetMap image format within g3w-admin:

![Screenshot_20250327_161048](https://github.com/user-attachments/assets/ba46525e-97ed-412b-85bb-6862e827f2bd)

## Before

FORMAT is missing

![Screenshot_20250327_161334](https://github.com/user-attachments/assets/13391e77-0185-42bc-8acf-90900983cfde)

## After

FORMAT parameter is set

![Screenshot_20250327_161439](https://github.com/user-attachments/assets/50de5575-4320-4359-9cbe-a61377b2a4cd)

