### PR TITLE
Filter selection on query area control + saving of forms with fields with a default expression (without dependencies)

### DIFF
--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -285,7 +285,7 @@
                 <template v-else-if = "hasFormStructure(layer)">
                   <table class = "table" :class = "{'mobile': isMobile()}">
                     <tbody>
-                      <template v-if = "showFeature(layer, feature)" v-for = "(feature, index) in layer.features">
+                      <template v-for = "(feature, index) in layer.features.filter(f => showFeature(layer, f))">
                         <header-feature-actions-body
                           :colspan                 = "getColSpan(layer)"
                           :actions                 = "state.layersactions[layer.id]"
@@ -388,8 +388,7 @@
                   <!-- CASE SIMPLE LAYER WITH NO STRUCTURE -->
                   <table class = "table" :class = "{'mobile': isMobile()}">
                     <tbody
-                      v-if  = "showFeature(layer, feature)"
-                      v-for = "(feature, index) in layer.features"
+                      v-for = "(feature, index) in layer.features.filter(f => showFeature(layer, f))"
                       :key  = "feature.id"
                     >
                       <header-feature-actions-body
@@ -439,7 +438,7 @@
                         </td>
                       </tr>
                       <header-feature-body
-                        v-if="!hasLayerOneFeature(layer) && getLayerFeatureBox(layer, feature).collapsed"
+                        v-if = "!hasLayerOneFeature(layer) && getLayerFeatureBox(layer, feature).collapsed"
                         :actions                 = "state.layersactions[layer.id]"
                         :layer                   = "layer"
                         :feature                 = "feature"
@@ -503,7 +502,6 @@
                         </td>
                       </tr>
                     </tbody>
-                    <tbody v-else></tbody>
                   </table>
                 </template>
               </div>

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -284,8 +284,11 @@
                 <!-- CASE FORM STRUCTURE LAYER-->
                 <template v-else-if = "hasFormStructure(layer)">
                   <table class = "table" :class = "{'mobile': isMobile()}">
-                    <tbody>
-                      <template v-for = "(feature, index) in layer.features.filter(f => showFeature(layer, f))">
+                    <tbody 
+                      v-for = "(feature, index) in layer.features"
+                      v-if  = "showFeature(layer, feature)"
+                      :key  = "feature.id"
+                      > 
                         <header-feature-actions-body
                           :colspan                 = "getColSpan(layer)"
                           :actions                 = "state.layersactions[layer.id]"
@@ -380,7 +383,6 @@
                               :feature = "feature"/>
                           </td>
                         </tr>
-                      </template>
                     </tbody>
                   </table>
                 </template>
@@ -388,7 +390,8 @@
                   <!-- CASE SIMPLE LAYER WITH NO STRUCTURE -->
                   <table class = "table" :class = "{'mobile': isMobile()}">
                     <tbody
-                      v-for = "(feature, index) in layer.features.filter(f => showFeature(layer, f))"
+                      v-for = "(feature, index) in layer.features"
+                      v-if  = "showFeature(layer, feature)"
                       :key  = "feature.id"
                     >
                       <header-feature-actions-body
@@ -761,11 +764,9 @@
       saveFilter(layer) {
         getCatalogLayerById(layer.id).saveFilter();
       },
-
       async addRemoveFilter(layer) {
         await getCatalogLayerById(layer.id).toggleFilterToken();
       },
-
       getContainerFromFeatureLayer({ layer, index } = {}) {
         return $(`#${layer.id}_${index} > td`);
       },
@@ -859,7 +860,7 @@
        * Show only features that have show true and in case of active filter, only selected 
        */
       showFeature(layer, feature) {
-        return feature.show && ((layer.filter || { active: false }).active ? feature.selection.selected : true);
+        return this.$options.service.showFeature(layer, feature);
       },
       getBoxId(layer, feature, relation_index) {
         return this.$options.service.getBoxId(layer, feature, relation_index);

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -285,7 +285,7 @@
                 <template v-else-if = "hasFormStructure(layer)">
                   <table class = "table" :class = "{'mobile': isMobile()}">
                     <tbody>
-                      <template v-if = "feature.show" v-for = "(feature, index) in layer.features">
+                      <template v-if = "showFeature(layer, feature)" v-for = "(feature, index) in layer.features">
                         <header-feature-actions-body
                           :colspan                 = "getColSpan(layer)"
                           :actions                 = "state.layersactions[layer.id]"
@@ -388,7 +388,7 @@
                   <!-- CASE SIMPLE LAYER WITH NO STRUCTURE -->
                   <table class = "table" :class = "{'mobile': isMobile()}">
                     <tbody
-                      v-if  = "feature.show"
+                      v-if  = "showFeature(layer, feature)"
                       v-for = "(feature, index) in layer.features"
                       :key  = "feature.id"
                     >
@@ -766,12 +766,6 @@
 
       async addRemoveFilter(layer) {
         await getCatalogLayerById(layer.id).toggleFilterToken();
-        //@since 3.11.0 In case of set active filter, remove all features not selected
-        if (layer.filter.active) {
-         layer.features
-          .filter(f => !f.selection.selected)
-          .forEach(f => this.$options.service.removeFeatureLayerFromResult(layer, f))
-        }
       },
 
       getContainerFromFeatureLayer({ layer, index } = {}) {
@@ -860,6 +854,14 @@
           tabs: this.hasFormStructure(layer),
           show: box ? !box.collapsed : false,
         });
+      },
+
+      /**
+       * @since 3.11.8
+       * Show only features that have show true and in case of active filter, only selected 
+       */
+      showFeature(layer, feature) {
+        return feature.show && ((layer.filter || { active: false }).active ? feature.selection.selected : true);
       },
       getBoxId(layer, feature, relation_index) {
         return this.$options.service.getBoxId(layer, feature, relation_index);

--- a/src/components/QueryResultsHeaderFeatureBody.vue
+++ b/src/components/QueryResultsHeaderFeatureBody.vue
@@ -24,7 +24,7 @@
         v-else-if = "isImage(getLayerField({layer, feature, fieldName: attribute.name}))"
         class     = "skin-color"
         :class    = "g3wtemplate.getFontClass('image')"></span>
-      <span v-else >{{feature.attributes[attribute.name]}}</span>
+      <span v-else v-html = "feature.attributes[attribute.name]"></span>
 
     </td>
     <td v-if="!hasLayerOneFeature(layer)">

--- a/src/components/g3w-form.js
+++ b/src/components/g3w-form.js
@@ -638,20 +638,13 @@ export class FormService extends G3WObject {
       await Promise.allSettled(fields_without_dependencies
         .map(field => new Promise(async (resolve, reject) => {
             try {
-              //get current value of field
-              const cvalue = field.value;
-              //get value after calculate default expression from server
-              const value = await getDefaultExpression({
+              //await until default expression is resolved and set value to field
+              await getDefaultExpression({
                 field,
                 feature:      this.feature,
                 qgs_layer_id: this.layer.getId(),
                 parentData:   this.parentData
               });
-              //check if changed
-              if (cvalue !== value) {
-                //wait until changeInput method is resolved
-                await new Promise((resolve) => this.once('changeInput', resolve))
-              }
               resolve();
             } catch(e) {
               console.warn(e);

--- a/src/map/layers/layer.js
+++ b/src/map/layers/layer.js
@@ -445,6 +445,7 @@ const Providers = {
           params.geo_filter_mode = 'within' === spatialMethod ? 'contains' : spatialMethod;
           params.geo_filter_wkt  = (new ol.format.WKT({ dataProjection: ApplicationState.map.epsg, featureProjection: ApplicationState.map.epsg })).writeFeature(new ol.Feature({ geometry: filter.value }));
           params.formatter       = 1;
+          params.filtertoken     = ApplicationState.tokens.filtertoken; // add filtertoken
           break;
         case 'expression':
           break;    
@@ -875,6 +876,7 @@ class Layer extends G3WObject {
    */
   async getDownloadFilefromDownloadDataType(type, { data = {} }) {
     data.filtertoken = this.getFilterToken();
+    console.log(data)
 
     let url, response;
     switch(type) {

--- a/src/map/layers/layer.js
+++ b/src/map/layers/layer.js
@@ -9,6 +9,7 @@ import {
   DOTS_PER_INCH,
   QUERY_POINT_TOLERANCE,
   TIMEOUT,
+  G3W_FID,
 }                                from 'g3w-constants';
 import ApplicationState          from 'store/application';
 import DataRouterService         from 'services/data';
@@ -462,8 +463,8 @@ const Providers = {
             layer:    this._layer,
             features: ResponseParser.get('g3w-vector/json')(
               response.vector && response.vector.data || {},
-              { projections: { map: this._layer.getMapProjection() || this._layer.getProjection(), layer: null }},
-            ),
+              { projections: { map: this._layer.getMapProjection() || this._layer.getProjection(), layer: null }})
+              .map(f => { f.set(G3W_FID, f.getId()); return f; }) //set g3w_fid to have G3W_FID property,
           })
          } else {
           throw response.error;

--- a/src/map/layers/layer.js
+++ b/src/map/layers/layer.js
@@ -876,7 +876,6 @@ class Layer extends G3WObject {
    */
   async getDownloadFilefromDownloadDataType(type, { data = {} }) {
     data.filtertoken = this.getFilterToken();
-    console.log(data)
 
     let url, response;
     switch(type) {

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -1278,16 +1278,26 @@ export default new (class QueryResultsService extends G3WObject {
   }
 
   /**
+   * @since 3.11.8
+   * @param {*} layer 
+   * @param {*} feature 
+   */
+  showFeature(layer, feature) {
+    return feature.show && ((layer.filter || { active: false }).active ? feature.selection.selected : true);
+  }
+
+  /**
    * @FIXME add description
    *
    * @param layer
    * @param options
    */
   highLightLayerFeatures(layer, options = {}) {
+    const features = (layer.features || []).filter(f => this.showFeature(layer, f));
     if (this._asyncFnc.highLightLayerFeatures.async) {
-      this._asyncFnc.todo = GUI.getService('map').highlightFeatures.bind(GUI.getService('map'), layer.features || [], options);
+      this._asyncFnc.todo = GUI.getService('map').highlightFeatures.bind(GUI.getService('map'), features, options);
     } else {
-      GUI.getService('map').highlightFeatures(layer.features || [], options);
+      GUI.getService('map').highlightFeatures(features, options);
     }
   }
 
@@ -1834,7 +1844,6 @@ export default new (class QueryResultsService extends G3WObject {
    * @since 3.9.0
    */
   addToSelection(layer, feature, action, index) {
-
     const service          = GUI.getService('queryresults');
     const map              = GUI.getService('map');
 
@@ -1944,7 +1953,6 @@ export default new (class QueryResultsService extends G3WObject {
           layers.splice(0);
         }
       });
-
     }
 
     /**

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -240,7 +240,7 @@ export default new (class QueryResultsService extends G3WObject {
                 id:         external ? f.getId() : (f instanceof ol.Feature ? f.getId() : f.id),
                 attributes: f instanceof ol.Feature ? f.getProperties() : f.properties,
                 geometry:   f instanceof ol.Feature ? f.getGeometry()   : f.geometry,
-                selection:  { selected: false },
+                selection:  { selected: !!queryResponse.query.autofilter }, //@snce 3.11.8 check if autofilter is set
                 show:       true,
               })),
               hasgeometry:            Array.isArray(features) && !rawdata && features.some(f => f instanceof ol.Feature ? f.getGeometry() : f.geometry),

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -1876,8 +1876,6 @@ export default new (class QueryResultsService extends G3WObject {
       _layer.clearSelectionFids();
       return;
     }
-
-    console.log(params.fids)
     /**
      * PROJECT LAYER
      */

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -240,7 +240,7 @@ export default new (class QueryResultsService extends G3WObject {
                 id:         external ? f.getId() : (f instanceof ol.Feature ? f.getId() : f.id),
                 attributes: f instanceof ol.Feature ? f.getProperties() : f.properties,
                 geometry:   f instanceof ol.Feature ? f.getGeometry()   : f.geometry,
-                selection:  { selected: !!queryResponse.query.autofilter }, //@snce 3.11.8 check if autofilter is set
+                selection:  { selected: !external && (!!queryResponse.query.autofilter || layer.state.selection.active) }, //@since 3.11.8 check if autofilter is set
                 show:       true,
               })),
               hasgeometry:            Array.isArray(features) && !rawdata && features.some(f => f instanceof ol.Feature ? f.getGeometry() : f.geometry),

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -1270,10 +1270,11 @@ export default new (class QueryResultsService extends G3WObject {
    */
   zoomToLayerFeaturesExtent(layer, options = {}) {
     options.highlight = !this.isOneLayerResult();
+    const features = (layer.features || []).filter(f => this.showFeature(layer, f));
     if (this._asyncFnc.zoomToLayerFeaturesExtent.async) {
-      this._asyncFnc.todo = GUI.getService('map').zoomToFeatures.bind(GUI.getService('map'), layer.features || [], options);
+      this._asyncFnc.todo = GUI.getService('map').zoomToFeatures.bind(GUI.getService('map'), features, options);
     } else {
-      GUI.getService('map').zoomToFeatures(layer.features || [], options);
+      GUI.getService('map').zoomToFeatures(features, options);
     }
   }
 

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -693,10 +693,10 @@ export default new (class QueryResultsService extends G3WObject {
   updateLayerResultFeatures(responseLayer, replace = false) {
     const layer            = this.state.layers.find(l => l.id === responseLayer.id);                // get layer from current `state.layers` showed on a result
     const responseFeatures = responseLayer.features || [];                                            // extract features from responseLayer object
-    const external         = (this.state.layers.find(l => l.id === responseLayer.id) || {}).external; // get id of external layer or not (`external` is a layer added by mapcontrol addexternlayer)
+    const external         = (layer || {}).external; // get id of external layer or not (`external` is a layer added by mapcontrol addexternlayer)
     const has_features     = layer && (layer.features || []).length > 0;                              // check if the current layer has features on response
     if (has_features) {
-      const features_ids = replace ? [] : layer.features.map(f => external ? f.id : f.attributes[G3W_FID]) // get features id from current layer on a result
+      const features_ids = replace ? [] : layer.features.map(f => this._getFeatureId(f, external)) // get features id from current layer on a result
       //get action selection;
       const action = this.state.layersactions[layer.id].find(a => 'selection' === a.id);
       if (replace) {
@@ -712,7 +712,7 @@ export default new (class QueryResultsService extends G3WObject {
             (external ? layer : getCatalogLayerById(layer.id)).excludeSelectionFid(feature_id, layer.filter.active);
           }
           //filter feature
-          layer.features.splice(index, 1);
+          layer.features = layer.features.filter(f => feature_id !== this._getFeatureId(f, external));
           delete this.state.layersFeaturesBoxes[this.getBoxId(layer, feat)]
           if (action) {
             delete action.state.toggled[index];

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -1820,7 +1820,7 @@ export default new (class QueryResultsService extends G3WObject {
    * @since 3.9.0
    */
   _getFeatureId(feature, external) {
-    return external ? feature.id : feature.attributes[G3W_FID];
+    return external ? feature.id : (feature.attributes[G3W_FID] || feature.id); //@v3.11.8 in case of query by geometry, features are returned without G3W_FID. They have id 
   }
 
   /**
@@ -1850,7 +1850,7 @@ export default new (class QueryResultsService extends G3WObject {
     const _layer         = layerSelection ? (layer.external ? layer : getCatalogLayerById(layer.id))        : (((service.state.layers.find(l => l.id === layer.id) || {}).external || false) ? layer : getCatalogLayerById(layer.id));
     const features       = layerSelection ? (layer.features && layer.features.length ? layer.features : []) : [feature];
     const params         = layerSelection ? {
-      fids: features.length > 0 ? features.map(f => _layer.external ? f.id : f.attributes[G3W_FID]) : null,
+      fids: features.length > 0 ? features.map(f => _layer.external ? f.id : (f.attributes[G3W_FID] || f.id)) : null,
       features,
       force: toggled ? 'remove' : 'add'
     } : {
@@ -1877,6 +1877,7 @@ export default new (class QueryResultsService extends G3WObject {
       return;
     }
 
+    console.log(params.fids)
     /**
      * PROJECT LAYER
      */

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -1279,12 +1279,12 @@ export default new (class QueryResultsService extends G3WObject {
   }
 
   /**
+   * @returns { boolean } whether show feature in results (show + active filter + selected)
+   * 
    * @since 3.11.8
-   * @param {*} layer 
-   * @param {*} feature 
    */
   showFeature(layer, feature) {
-    return feature.show && ((layer.filter || { active: false }).active ? feature.selection.selected : true);
+    return feature.show && ((layer.filter || {}).active ? feature.selection.selected : true);
   }
 
   /**
@@ -1615,7 +1615,7 @@ export default new (class QueryResultsService extends G3WObject {
 
     const data = 'search' === query.type
       ? { field: query.search.join() }                                // search results + pagination (see: https://github.com/g3w-suite/g3w-client/pull/743)
-      : { fids: features.filter(f => !(layer.filter || { active: false }).active || f.selection.selected).map(f => f.attributes[G3W_FID]).join(',') }; // other query types ('point', 'polygon', 'bbox' ..)
+      : { fids: features.filter(f => !(layer.filter || {}).active || f.selection.selected).map(f => f.attributes[G3W_FID]).join(',') }; // other query types ('point', 'polygon', 'bbox' ..)
     
     data.down_with_relations = down_with_relations; 
   
@@ -1831,7 +1831,7 @@ export default new (class QueryResultsService extends G3WObject {
    * @since 3.9.0
    */
   _getFeatureId(feature, external) {
-    return external ? feature.id : (feature.attributes[G3W_FID] || feature.id); //@v3.11.8 in case of query by geometry, features are returned without G3W_FID. They have id 
+    return external ? feature.id : (feature.attributes[G3W_FID] || feature.id); // in case of query by geometry, features are returned without G3W_FID. They have id 
   }
 
   /**

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -1850,7 +1850,7 @@ export default new (class QueryResultsService extends G3WObject {
     const _layer         = layerSelection ? (layer.external ? layer : getCatalogLayerById(layer.id))        : (((service.state.layers.find(l => l.id === layer.id) || {}).external || false) ? layer : getCatalogLayerById(layer.id));
     const features       = layerSelection ? (layer.features && layer.features.length ? layer.features : []) : [feature];
     const params         = layerSelection ? {
-      fids: features.length > 0 ? features.map(f => _layer.external ? f.id : (f.attributes[G3W_FID] || f.id)) : null,
+      fids: features.length > 0 ? features.map(f => getFeatureId(f, layer.external)) : null,
       features,
       force: toggled ? 'remove' : 'add'
     } : {

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -1615,7 +1615,7 @@ export default new (class QueryResultsService extends G3WObject {
 
     const data = 'search' === query.type
       ? { field: query.search.join() }                                // search results + pagination (see: https://github.com/g3w-suite/g3w-client/pull/743)
-      : { fids: features.map(f => f.attributes[G3W_FID]).join(',') }; // other query types ('point', 'polygon', 'bbox' ..)
+      : { fids: features.filter(f => !(layer.filter || { active: false }).active || f.selection.selected).map(f => f.attributes[G3W_FID]).join(',') }; // other query types ('point', 'polygon', 'bbox' ..)
     
     data.down_with_relations = down_with_relations; 
   

--- a/src/utils/parsers/index.js
+++ b/src/utils/parsers/index.js
@@ -114,7 +114,6 @@ export const ResponseParser = {
               featureProjection: options.mapCrs || options.crs,
             }))
             .readFeatures('string' === typeof data ? JSON.parse(data) : data)
-            .map(f => { f.set(G3W_FID, f.getId()); return f; }); //set g3w_fid to have G3W_FID property
           } catch (e) {
             console.warn(e);
             return [];

--- a/src/utils/parsers/index.js
+++ b/src/utils/parsers/index.js
@@ -112,7 +112,9 @@ export const ResponseParser = {
               geometryName:      'geometry',
               dataProjection:    options.crs,
               featureProjection: options.mapCrs || options.crs,
-            })).readFeatures('string' === typeof data ? JSON.parse(data) : data);
+            }))
+            .readFeatures('string' === typeof data ? JSON.parse(data) : data)
+            .map(f => { f.set(G3W_FID, f.getId()); return f; }); //set g3w_fid to have G3W_FID property
           } catch (e) {
             console.warn(e);
             return [];

--- a/src/utils/parsers/index.js
+++ b/src/utils/parsers/index.js
@@ -112,8 +112,7 @@ export const ResponseParser = {
               geometryName:      'geometry',
               dataProjection:    options.crs,
               featureProjection: options.mapCrs || options.crs,
-            }))
-            .readFeatures('string' === typeof data ? JSON.parse(data) : data)
+            })).readFeatures('string' === typeof data ? JSON.parse(data) : data)
           } catch (e) {
             console.warn(e);
             return [];


### PR DESCRIPTION
# 🐛 Filter selection on query area

Improves: https://github.com/g3w-suite/g3w-client/pull/757, When do a query selection with Query Area Map control  ![Screenshot_20250408_154844](https://github.com/user-attachments/assets/8ce2ca89-f4be-46c1-8c6d-8f7233d48e3d), selection doesn't work beacuse G3W_FID field in feature is missing

# 💄 Show html in feature body header

In case of feature value contains html code on response, in feature body result header it is show interpreted html

**Before** 

description has paint text

![Screenshot_20250408_150500](https://github.com/user-attachments/assets/c244cfc2-3cb4-477d-a56a-cafc04fc0000)


**After**

![Screenshot_20250408_151433](https://github.com/user-attachments/assets/4f9ff460-eea1-486b-af8d-282f476142bb)

# 🐛  saveDefaultExpressionFieldsNotDependencies

When save current form changes, and fields have default expression without dependencies and expression value is different to current field value, it was waiting a _changeInput_ event. It as wrong because field input with new value is set directly in _getDefaultExpression_

Test: https://dev.g3wsuite.it/en/map/g3w-suite-demo/qdjango/97/ building