### PR TITLE
Prevent feature ID collision when selecting features from multiple layers

### DIFF
--- a/src/map/layers/geo-mixin.js
+++ b/src/map/layers/geo-mixin.js
@@ -237,7 +237,9 @@ export default BaseClass => class extends BaseClass {
   addOlSelectionFeature({ id, feature: feat } = {}) {
     //create a new ol feature
     const feature = new ol.Feature(feat.geometry);
-    feature.setId(id);
+    //@since 3.11.8 need to add layerId prefix to feature id, because if another feature of another layer has same feature id, 
+    //OL doesn't add it to vector selection source
+    feature.setId(`${this.getId()}_${id}`); 
     Object.entries(feat.attributes).forEach(([a, v]) => feature.set(a, v));
     this.olSelectionFeatures[id] = this.olSelectionFeatures[id] || {
       feature,

--- a/src/map/layers/geo-mixin.js
+++ b/src/map/layers/geo-mixin.js
@@ -237,9 +237,7 @@ export default BaseClass => class extends BaseClass {
   addOlSelectionFeature({ id, feature: feat } = {}) {
     //create a new ol feature
     const feature = new ol.Feature(feat.geometry);
-    //@since 3.11.8 need to add layerId prefix to feature id, because if another feature of another layer has same feature id, 
-    //OL doesn't add it to vector selection source
-    feature.setId(`${this.getId()}_${id}`); 
+    feature.setId(`${this.getId()}_${id}`); // see: #777, prevent ID collision when selecting features from multiple layers
     Object.entries(feat.attributes).forEach(([a, v]) => feature.set(a, v));
     this.olSelectionFeatures[id] = this.olSelectionFeatures[id] || {
       feature,


### PR DESCRIPTION
Closes: #776 

**Before**

![Screenshot_20250410_135932](https://github.com/user-attachments/assets/e4c3e410-c32f-4bcf-a32d-f7d08dbae5e2)

**After**

![Screenshot_20250410_141019](https://github.com/user-attachments/assets/884af42d-b423-4a9b-8b7a-96c5fa5cf37c)

Both are selected and show in red