### PR TITLE
Allow to specify `G3WObject~setters` property as an array of strings

### DIFF
--- a/src/components/g3w-form.js
+++ b/src/components/g3w-form.js
@@ -80,42 +80,78 @@ export class FormService extends G3WObject {
 
     this.layer;
 
-    this.setters = {
-
-      setInitForm(opts = {}) {
-        this._setInitForm(opts);
-      },
-
-      setFormStructure(formStructure) {
-        this.state.formstructure = formStructure;
-      },
-
-      setFormFields(fields = []) {
-        this.state.fields = fields;
-        this.handleFieldsWithExpression(fields);
-      },
-
-      setupFields() {},
-
-      setFormData(fields = []) {
-        this.setFormFields(fields);
-      },
-
-      setField(field) {},
-
-      setState(state) {
-        this._setState(state);
-      },
-
-      addActionsForForm(actions) {},
-
-      postRender(element) {
-        // hook for listener to change DOM
-      },
-
-    };
+    this.setters = [
+      'setInitForm',
+      'setFormStructure',
+      'setFormFields',
+      'setupFields',
+      'setFormData',
+      'setField',
+      'setState',
+      'addActionsForForm',
+      'postRender',
+    ];
 
   }
+
+  /**
+   * @since 4.0.0. 
+   */
+  setInitForm(opts = {}) {
+    this._setInitForm(opts);
+  }
+
+  /**
+   * @since 4.0.0. 
+   */
+  setFormStructure(formStructure) {
+    this.state.formstructure = formStructure;
+  }
+
+  /**
+   * @since 4.0.0. 
+   */
+  setFormFields(fields = []) {
+    this.state.fields = fields;
+    this.handleFieldsWithExpression(fields);
+  }
+
+  /**
+   * @since 4.0.0. 
+   */
+  setupFields() {}
+
+  /**
+   * @since 4.0.0. 
+   */
+  setFormData(fields = []) {
+    this.setFormFields(fields);
+  }
+
+  /**
+   * @since 4.0.0. 
+   */
+  setField(field) {}
+
+  /**
+   * @since 4.0.0. 
+   */
+  setState(state) {
+    this._setState(state);
+  }
+
+  /**
+   * @since 4.0.0. 
+   */
+  addActionsForForm(actions) {}
+
+  /**
+   * @since 4.0.0. 
+   */
+  postRender(element) {
+    // hook for listener to change DOM
+  }
+
   init(opts = {}) {
     this._setInitForm(opts);
   }

--- a/src/g3w-object.js
+++ b/src/g3w-object.js
@@ -34,6 +34,12 @@ export default class G3WObject extends EventEmitter {
   };
 
   set setters(value) {
+
+    // setters is an array strings → convert it into an object
+    if (Array.isArray(value)) {
+      value = value.reduce((setters, i) => Object.assign(setters, { [i]: this[i] }), {});
+    }
+
     this.___setters = value;
     if (value) {
       // all methods inside object "setters" of child class.

--- a/src/map/layers/featuresstore.js
+++ b/src/map/layers/featuresstore.js
@@ -19,85 +19,124 @@ export class FeaturesStore extends G3WObject {
     this._loadedIds = []; // store features id load by current user
     this._lockIds   = []; // store locked features
 
-    //setters
-    this.setters    = {
-      /**
-       * Add an array of features
-       * @param { Array } features
-       */
-      addFeatures(features = []) {
-        features.forEach(f => this._addFeature(f))
-      },
-      /**
-       * Add single feature
-       * @param feature
-       */
-      addFeature(feature) {
-        this._addFeature(feature);
-      },
-      /**
-       * Remove a feature
-       * @param feature
-       */
-      removeFeature(feature) {
-        this._removeFeature(feature);
-      },
-      /**
-       * Update (substitute) a feature
-       * @param feature
-       */
-      updateFeature(feature) {
-        this._updateFeature(feature);
-      },
-      /**
-       * Remove all feature
-       */
-      clear() {
-        this._clearFeatures();
-      },
-      /**
-       * Get features from server
-       * @param opts
-       * @return { Promise }
-       */
-      getFeatures(opts = {}) {
-        return $promisify(async () => {
-          if (this._provider) {
-            //call provider getFeatures to get features from server
-            //get the feature base on response from server features, featurelockis etc ...
-            const features = this._filterFeaturesResponse(await this._provider.getFeatures(opts));
-            this.addFeatures(features);
-            return features;
-          }
-          return this._features; // Get features stored. No call to server is done
-        });
-      },
-      /**
-       * Commit changes (add, update, delete) to server
-       * @param commitItems
-       * @param featurestore Its is used????
-       * @return {*}
-       */
-      commit(commitItems, featurestore) {
-        return $promisify(async () => {
-          if (commitItems && this._provider) {
-            commitItems.lockids = this._lockIds;
-            return await XHR.post({
-              url:         this._provider._layer.getUrl('commit'),
-              data:        JSON.stringify(commitItems),
-              contentType: 'application/json',
-            });
-          }
-          return Promise.reject();
-        });
-      },
-      /**
-       * setter to know when some features are locked
-       */
-      featuresLockedByOtherUser(features = []) {},
-    };
+    this.setters    = [
+      'addFeatures',
+      'addFeature',
+      'removeFeature',
+      'updateFeature',
+      'clear',
+      'getFeatures',
+      'commit',
+      'featuresLockedByOtherUser',
+    ];
 
   }
+
+  /**
+   * Add an array of features
+   * 
+   * @param { Array } features
+   * 
+   * @since 4.0.0
+   */
+  addFeatures(features = []) {
+    features.forEach(f => this._addFeature(f))
+  }
+
+  /**
+   * Add single feature
+   * 
+   * @param feature
+   * 
+   * @since 4.0.0
+   */
+  addFeature(feature) {
+    this._addFeature(feature);
+  }
+
+  /**
+   * Remove a feature
+   * 
+   * @param feature
+   * 
+   * @since 4.0.0
+   */
+  removeFeature(feature) {
+    this._removeFeature(feature);
+  }
+
+  /**
+   * Update (substitute) a feature
+   * 
+   * @param feature
+   * 
+   * @since 4.0.0
+   */
+  updateFeature(feature) {
+    this._updateFeature(feature);
+  }
+
+  /**
+   * Remove all feature
+   * 
+   * @since 4.0.0
+   */
+  clear() {
+    this._clearFeatures();
+  }
+
+  /**
+   * Get features from server
+   * 
+   * @param opts
+   * 
+   * @return { Promise }
+   * 
+   * @since 4.0.0
+   */
+  getFeatures(opts = {}) {
+    return $promisify(async () => {
+      if (this._provider) {
+        //call provider getFeatures to get features from server
+        //get the feature base on response from server features, featurelockis etc ...
+        const features = this._filterFeaturesResponse(await this._provider.getFeatures(opts));
+        this.addFeatures(features);
+        return features;
+      }
+      return this._features; // Get features stored. No call to server is done
+    });
+  }
+
+  /**
+   * Commit changes (add, update, delete) to server
+   * 
+   * @param commitItems
+   * @param featurestore Its is used????
+   * 
+   * @return {*}
+   * 
+   * @since 4.0.0
+   */
+  commit(commitItems, featurestore) {
+    return $promisify(async () => {
+      if (commitItems && this._provider) {
+        commitItems.lockids = this._lockIds;
+        return await XHR.post({
+          url:         this._provider._layer.getUrl('commit'),
+          data:        JSON.stringify(commitItems),
+          contentType: 'application/json',
+        });
+      }
+      return Promise.reject();
+    });
+  }
+
+  /**
+   * setter to know when some features are locked
+   * 
+   * @since 4.0.0
+   */
+  featuresLockedByOtherUser(features = []) {}
 
   clone() {
     return _cloneDeep(this);

--- a/src/map/layers/imagelayer.js
+++ b/src/map/layers/imagelayer.js
@@ -378,9 +378,7 @@ class ImageLayer extends GeoLayerMixin(Layer) {
 
     this._BASE_LAYER = options._BASE_LAYER;
 
-    this.setters = {
-      change(){},
-    };
+    this.setters = ['change'];
 
     this.config.baselayer = config.baselayer || false;
     this.type             = Layer.LayerTypes.IMAGE;
@@ -581,6 +579,11 @@ class ImageLayer extends GeoLayerMixin(Layer) {
       this._mapLayer = this;
     }
   }
+
+  /**
+   * @since 4.0.0
+   */
+  change() {}
 
   /**
    *

--- a/src/map/layers/layersstore.js
+++ b/src/map/layers/layersstore.js
@@ -26,20 +26,40 @@ export class LayersStore extends G3WObject {
     this._isQueryable = (true === config.queryable || false === config.queryable ) ? config.queryable : true;
     this._layers = this.config.layers || {};
 
-    this.setters = {
-      setLayerSelected(id, selected) {
-        this.getLayers().forEach(l => l.state.selected = (id === l.getId()) ? selected : false);
-      },
-      addLayers(layers = []) {
-        layers.forEach(l => this.addLayer(l))
-      },
-      addLayer(layer) {
-        this._addLayer(layer);
-      },
-      removeLayer(id) {
-        this._removeLayer(id);
-      }
-    };
+    this.setters = [
+      'setLayerSelected',
+      'addLayers',
+      'addLayer',
+      'removeLayer',
+    ];
+  }
+
+  /**
+   * @since 4.0.0 
+   */
+  setLayerSelected(id, selected) {
+    this.getLayers().forEach(l => l.state.selected = (id === l.getId()) ? selected : false);
+  }
+
+  /**
+   * @since 4.0.0 
+   */
+  addLayers(layers = []) {
+    layers.forEach(l => this.addLayer(l))
+  }
+
+  /**
+   * @since 4.0.0 
+   */
+  addLayer(layer) {
+    this._addLayer(layer);
+  }
+
+  /**
+   * @since 4.0.0 
+   */
+  removeLayer(id) {
+    this._removeLayer(id);
   }
 
   isQueryable() {

--- a/src/map/layers/tablelayer.js
+++ b/src/map/layers/tablelayer.js
@@ -27,65 +27,16 @@ export class TableLayer extends Layer {
 
     /**
      * @TODO Move it on  https://github.com/g3w-suite/g3w-client-plugin-editing
-     * Hook setters methods
      */
-    this.setters = {
-      /**
-       * Clear all features of the layer
-       */
-      clearFeatures()        { this._featuresstore.clearFeatures(); },
-      addFeature(feature)    { this._featuresstore.addFeature(feature); },
-      /**
-       * @TODO it used ????
-       * @param feature
-       */
-      updateFeature(feature) { this._featuresstore.updateFeature(feature);},
-      setFeatures(features)  { this._featuresstore.setFeatures(features); },
-      setColor(color)        { this._color = color; },
-
-      /**
-       * get data from every sources (server, wms, etc..)
-       * through provider related to featuresstore
-       *
-       * @param {*} opts
-       */
-      getFeatures(opts = {}) {
-        return $promisify(async () => {
-          const features = await promisify(this._featuresstore.getFeatures(opts));
-          this.emit('getFeatures', features);
-          return features;
-        });
-      },
-
-      commit(commitItems) {
-        return $promisify(async () => {
-          const response = await promisify(this._featuresstore.commit(commitItems));
-          // sync selection filter features
-          if (response && response.result) {
-            try {
-              const layer = getCatalogLayerById(this.getId());
-              //if layer has geometry
-              if (layer.isGeoLayer()) {
-                commitItems.update.forEach(({ id, geometry } = {}) => {
-                  if (layer.getOlSelectionFeature(id)) {
-                    layer.updateOlSelectionFeature({id, geometry});
-                  }
-                });
-              }
-              commitItems.delete.forEach(id => {
-                if (layer.hasSelectionFid(id)) {
-                  layer.excludeSelectionFid(id);
-                }
-              })
-            } catch(e) {
-              console.warn(e);
-            }
-          }
-          return response;
-        });
-      },
-
-    };
+    this.setters = [
+      'clearFeatures',
+      'addFeature',
+      'updateFeature',
+      'setFeatures',
+      'setColor',
+      'getFeatures',
+      'commit',
+    ];
 
     /**
      * EDITING API URL: /api/vector/<type of request: data/editing/config>/<project_type>/<project_id>/<layer_id>
@@ -159,6 +110,86 @@ export class TableLayer extends Layer {
      */
     this._featuresstore = new FeaturesStore({ provider: this.providers.data });
 
+  }
+
+  /**
+   * Clear all features of the layer
+   * 
+   * @since 4.0.0
+   */
+  clearFeatures()        { this._featuresstore.clearFeatures(); }
+
+  /**
+   * @since 4.0.0 
+   */
+  addFeature(feature)    { this._featuresstore.addFeature(feature); }
+
+  /**
+   * @TODO check if it unusued
+   * 
+   * @since 4.0.0
+   */
+  updateFeature(feature) { this._featuresstore.updateFeature(feature);}
+
+  /**
+   * @TODO check if it unusued
+   * 
+   * @since 4.0.0
+   */
+  setFeatures(features)  { this._featuresstore.setFeatures(features); }
+
+  /**
+   * @TODO check if it unusued
+   * 
+   * @since 4.0.0
+   */
+  setColor(color)        { this._color = color; }
+
+  /**
+   * get data from every sources (server, wms, etc..)
+   * through provider related to featuresstore
+   *
+   * @param {*} opts
+   * 
+   * @since 4.0.0
+   */
+  getFeatures(opts = {}) {
+    return $promisify(async () => {
+      const features = await promisify(this._featuresstore.getFeatures(opts));
+      this.emit('getFeatures', features);
+      return features;
+    });
+  }
+
+  /**
+   * @since 4.0.0 
+   */
+  commit(commitItems) {
+    return $promisify(async () => {
+      const response = await promisify(this._featuresstore.commit(commitItems));
+      // sync selection filter features
+      if (response && response.result) {
+        try {
+          const layer = getCatalogLayerById(this.getId());
+          //if layer has geometry
+          if (layer.isGeoLayer()) {
+            commitItems.update.forEach(({ id, geometry } = {}) => {
+              if (layer.getOlSelectionFeature(id)) {
+                layer.updateOlSelectionFeature({id, geometry});
+              }
+            });
+          }
+          commitItems.delete.forEach(id => {
+            if (layer.hasSelectionFid(id)) {
+              layer.excludeSelectionFid(id);
+            }
+          })
+        } catch(e) {
+          console.warn(e);
+        }
+      }
+      return response;
+    });
   }
 
   /**

--- a/src/services/gui.js
+++ b/src/services/gui.js
@@ -127,97 +127,7 @@ export default new (class GUI extends G3WObject {
   constructor(opts) {
     super(opts);
 
-    this.setters = {
-
-      async setContent(options = {}) {
-        this.emit('opencontent', true);
-
-        // close user message before set content
-        if (this._closeUserMessage) {
-          this.closeUserMessage();
-        }
-
-        options.content     = options.content || null;
-        options.title       = options.title || "";
-        options.push        = (true === options.push || false === options.push) ? options.push : false;
-        options.perc        = isMobile.any ? 100 : options.perc;
-        options.split       = options.split || 'h';
-        options.backonclose = (true === options.backonclose || false === options.backonclose) ? options.backonclose : false;
-        options.showtitle   = (true === options.showtitle || false === options.showtitle) ? options.showtitle : true;
-
-        const opts = options;
-
-        const content_perc = ApplicationState.gui.layout[ApplicationState.gui.layout.__current].rightpanel['h' === ApplicationState.viewport.split ? 'width': 'height'];
-        opts.perc = opts.perc !== undefined ? opts.perc : content_perc;
-
-        // check if push is set
-        opts.push = opts.push || false;
-        const event = opts.perc === 100 ? 'show-content-full' : 'show-content';
-
-        // set all content parameters
-        Object.assign(ApplicationState.viewport.content, {
-          title:        opts.title,
-          split:        undefined === opts.split       ? null : opts.split,
-          closable:     undefined === opts.closable    || opts.closable,
-          backonclose:  undefined === opts.backonclose || opts.backonclose,
-          style:        undefined === opts.style ? {} : opts.style,
-          headertools:  undefined === opts.headertools ? [] : opts.headertools,
-          showgoback:   undefined === opts.showgoback  || opts.showgoback,
-          contentsdata: this.getComponent('contents').contentsdata,
-        });
-
-        // call show view (in this case content (other is map)
-        this._showView('content', opts);
-
-        const contents = this.getComponent('contents');
-        
-        // whether to clean the stack every time, sure to have just one component.
-        if (!opts.push) {
-          await _clearContents();
-        }
-
-        const content = opts.content;
-        const _options = Object.assign(opts, { parent: contents.internalComponent.$el, append: true });
-        contents.parent = _options.parent;
-
-        // check the type of content:
-
-        // String or JQuery
-        if (content instanceof jQuery || 'string' === typeof content) {
-          let el = 'string' === typeof content ? ($(content).length ? $(`<div> ${content} </div>`) : $(content)) : content
-          $(contents.parent).append(el);
-          ApplicationState.contentsdata.push({ content: el, options: _options });
-          console.warn('[G3W-CLIENT] jQuery components will be discontinued, please update your code as soon as possible', ApplicationState.contentsdata.at(-1));
-        }
-
-        // Vue element
-        else if (content.mount && 'function' === typeof content.mount) {
-          // Check a duplicate element by component id (if already exist)
-          let id = ApplicationState.contentsdata.findIndex(d => d.content.getId && (content.getId() === d.content.getId()));
-          if (-1 !== id) {
-            await promisify(ApplicationState.contentsdata[id].content.unmount());
-            ApplicationState.contentsdata.splice(id, 1);
-          }
-          // Mount vue component
-          await promisify(content.mount(contents.parent, _options.append || false));
-          ApplicationState.contentsdata.push({ content, options: _options });
-        }
-
-        // DOM element
-        else {
-          contents.parent.appendChild(content);
-          ApplicationState.contentsdata.push({ content, options: _options });
-        }
-
-        Array
-          .from(contents.internalComponent.$el.children)  // hide other elements but not the last one
-          .forEach((el, i, a) => el.style.display = (i === a.length - 1) ? 'block' : 'none');
-
-        contents.setOpen(true);
-
-        this._layoutComponents(event);
-      }
-    };
+    this.setters = ['setContent'];
 
     this.isready           = false;
 
@@ -932,6 +842,98 @@ export default new (class GUI extends G3WObject {
     const { rightpanel } = ApplicationState.gui.layout[ApplicationState.gui.layout.__current];
     rightpanel[`${state.split === 'h' ? 'width' : 'height'}_100`] = !rightpanel[`${state.split === 'h' ? 'width' : 'height'}_100`];
     this._layoutComponents();
+  }
+
+  /**
+   * @since 4.0.0 
+   */
+  async setContent(options = {}) {
+    this.emit('opencontent', true);
+
+    // close user message before set content
+    if (this._closeUserMessage) {
+      this.closeUserMessage();
+    }
+
+    options.content     = options.content || null;
+    options.title       = options.title || "";
+    options.push        = (true === options.push || false === options.push) ? options.push : false;
+    options.perc        = isMobile.any ? 100 : options.perc;
+    options.split       = options.split || 'h';
+    options.backonclose = (true === options.backonclose || false === options.backonclose) ? options.backonclose : false;
+    options.showtitle   = (true === options.showtitle || false === options.showtitle) ? options.showtitle : true;
+
+    const opts = options;
+
+    const content_perc = ApplicationState.gui.layout[ApplicationState.gui.layout.__current].rightpanel['h' === ApplicationState.viewport.split ? 'width': 'height'];
+    opts.perc = opts.perc !== undefined ? opts.perc : content_perc;
+
+    // check if push is set
+    opts.push = opts.push || false;
+    const event = opts.perc === 100 ? 'show-content-full' : 'show-content';
+
+    // set all content parameters
+    Object.assign(ApplicationState.viewport.content, {
+      title:        opts.title,
+      split:        undefined === opts.split       ? null : opts.split,
+      closable:     undefined === opts.closable    || opts.closable,
+      backonclose:  undefined === opts.backonclose || opts.backonclose,
+      style:        undefined === opts.style ? {} : opts.style,
+      headertools:  undefined === opts.headertools ? [] : opts.headertools,
+      showgoback:   undefined === opts.showgoback  || opts.showgoback,
+      contentsdata: this.getComponent('contents').contentsdata,
+    });
+
+    // call show view (in this case content (other is map)
+    this._showView('content', opts);
+
+    const contents = this.getComponent('contents');
+    
+    // whether to clean the stack every time, sure to have just one component.
+    if (!opts.push) {
+      await _clearContents();
+    }
+
+    const content = opts.content;
+    const _options = Object.assign(opts, { parent: contents.internalComponent.$el, append: true });
+    contents.parent = _options.parent;
+
+    // check the type of content:
+
+    // String or JQuery
+    if (content instanceof jQuery || 'string' === typeof content) {
+      let el = 'string' === typeof content ? ($(content).length ? $(`<div> ${content} </div>`) : $(content)) : content
+      $(contents.parent).append(el);
+      ApplicationState.contentsdata.push({ content: el, options: _options });
+      console.warn('[G3W-CLIENT] jQuery components will be discontinued, please update your code as soon as possible', ApplicationState.contentsdata.at(-1));
+    }
+
+    // Vue element
+    else if (content.mount && 'function' === typeof content.mount) {
+      // Check a duplicate element by component id (if already exist)
+      let id = ApplicationState.contentsdata.findIndex(d => d.content.getId && (content.getId() === d.content.getId()));
+      if (-1 !== id) {
+        await promisify(ApplicationState.contentsdata[id].content.unmount());
+        ApplicationState.contentsdata.splice(id, 1);
+      }
+      // Mount vue component
+      await promisify(content.mount(contents.parent, _options.append || false));
+      ApplicationState.contentsdata.push({ content, options: _options });
+    }
+
+    // DOM element
+    else {
+      contents.parent.appendChild(content);
+      ApplicationState.contentsdata.push({ content, options: _options });
+    }
+
+    Array
+      .from(contents.internalComponent.$el.children)  // hide other elements but not the last one
+      .forEach((el, i, a) => el.style.display = (i === a.length - 1) ? 'block' : 'none');
+
+    contents.setOpen(true);
+
+    this._layoutComponents(event);
   }
 
   // hide content

--- a/src/services/map.js
+++ b/src/services/map.js
@@ -270,457 +270,15 @@ class MapService extends G3WObject {
 
     this.setupCustomMapParamsToLegendUrl = debounce(this.setupCustomMapParamsToLegendUrl.bind(this), 1000);
 
-    this.setters = {
-
-      setupControls() {
-
-        const { header_terms_of_use_text, header_terms_of_use_link } = this.config;
-
-        // set layers attribution
-        const attribution = header_terms_of_use_text
-          ? header_terms_of_use_link
-            ? `<a href="${header_terms_of_use_link}">${header_terms_of_use_text}</a>`
-            : `<span class="skin-color" style="font-weight: bold">${header_terms_of_use_text}</span>`
-          : false;
-
-        this.getMapLayers().forEach(l => l.getSource().setAttributions(attribution));
-
-        // check if a base layer is set. If true, add attribution control
-        if (attribution || getMapLayersByFilter({ BASELAYER: true }).length) {
-          this.getMap().addControl(new ol.control.Attribution({ collapsible: false, target: 'map_footer_left' }));
-        }
-
-        // skip when no controls
-        if (!this.config || !this.config.mapcontrols) {
-          return;
-        }
-
-        // BACKCOMP (g3w-admin < v3.7.0)
-        const mapcontrols = Array.isArray(this.config.mapcontrols)
-          ? this.config.mapcontrols.reduce((a, v) => { a[v] = {}; return a; }, {}) // convert `initConfig.mapcontrols` from an array of strings to a key-value config Object (eg. ["geocoding"] --> "geocoding" = {})
-          : this.config.mapcontrols;
-
-        Object
-          .entries(mapcontrols)
-          .forEach(([type, config = {}]) => {
-            switch (type) {
-              case 'zoom':
-                this.createMapControl(type);
-                break;
-
-              case 'zoombox':
-                if (!isMobile.any) {
-                  this.createMapControl(type, {}).on('zoomend', (e) => this.viewer.fit(e.extent) );
-                }
-                break;
-
-              case 'zoomtoextent':
-                this.createMapControl(type, {
-                  options: {
-                    extent: this.project.state.initextent
-                  }
-                });
-                break;
-
-              case 'mouseposition':
-                if (!isMobile.any) {
-                  // @since 3.8.
-                  const degrees = 'degrees' === this.getProjection().getUnits();
-                  const mapEpsg = this.getEpsg();
-                  const coordinateFormat = (epsg, coords) => {
-                    if ('EPSG:4326' === epsg) {
-                      return ol.coordinate.format(ol.proj.transform(coords, mapEpsg, 'EPSG:4326'), `\u00A0Lng: {x}, Lat: {y}\u00A0\u00A0 [EPSG:4326]\u00A0`, 4);
-                    }
-                    return ol.coordinate.format(coords, `\u00A0${degrees ? 'Lng' : 'X'}: {x}, ${degrees ? 'Lat' : 'Y'}: {y}\u00A0\u00A0 [${epsg}]\u00A0`, degrees ? 4 : 2);
-                  };
-                  const control = this.createMapControl(type, {
-                    add: false,
-                    options: {
-                      coordinateFormat: coordinateFormat.bind(null, mapEpsg),
-                      undefinedHTML:    false,
-                      projection:       this.getCrs()
-                    }
-                  });
-                  if ('EPSG:4326' !== mapEpsg) {
-                    control.on('change:epsg', e => control.setCoordinateFormat(coordinateFormat.bind(null, e.epsg)));
-                  }
-                }
-                break;
-
-              case 'screenshot':
-              case 'geoscreenshot':
-                if (!isMobile.any ) {
-                  if (this.getMapControlByType('screenshot')) {
-                    this.getMapControlByType('screenshot').addType(type)
-                  } else {
-                    this.createMapControl('screenshot', {
-                      options: {
-                        types:   [type],
-                        layers:  [...MAP.layers.getLayers(), ...this._layers.external],
-                      }
-                    });
-                  }
-                }
-                break;
-
-              case 'scale':
-                this.createMapControl(type, {
-                  add: false,
-                  options: {
-                    coordinateFormat: ol.coordinate.createStringXY(4),
-                    projection:       this.getCrs(),
-                    isMobile:         isMobile.any
-                  }
-                });
-                break;
-
-              case 'query':
-                this.createMapControl(type, {
-                  add: true,
-                  toggled: true
-                });
-                break;
-
-              case 'querybypolygon':
-              case 'querybbox':
-              case 'querybycircle':
-              case 'querybydrawpolygon':
-                if (!isMobile.any) {
-                  if (this.getMapControlByType('queryby')) {
-                    this.getMapControlByType('queryby').addType(type)
-                  } else {
-                    this.createMapControl('queryby', {
-                      options: {
-                        types:   [type],
-                      }
-                    });
-                  }
-                }
-                break;
-
-              case 'streetview':
-                this.createMapControl(type, {});
-                break;
-
-              case 'scaleline':
-                this.createMapControl(type, {
-                  add: false,
-                  options: {
-                    position: 'br'
-                  }
-                });
-                break;
-
-              case 'overview':
-                if (!isMobile.any && window.initConfig.overviewproject) {
-                  getProject(window.initConfig.overviewproject)
-                    .then(project => {
-                      const view = new ol.View(this._calculateViewOptions({ project, width: 200, height: 150 })); // at moment hardcoded
-                      this.createMapControl(type, {
-                        add: false,
-                          options: {
-                            view,
-                            position:      'bl',
-                            collapsed:     false,
-                            className:     'ol-overviewmap ol-custom-overviewmap',
-                            collapseLabel: $(`<span class="${GUI.getFontClass('arrow-left')}"></span>`)[0],
-                            label:         $(`<span class="${GUI.getFontClass('arrow-right')}"></span>`)[0],
-                            layers:        Object
-                              .entries(
-                                //group layer by multilayerId
-                                project.getLayersStore().getLayers({ GEOLAYER: true, BASELAYER: false })
-                                  .reduce((group, l) => {
-                                    const id = l.getMultiLayerId();
-                                    group[id] = group[id] || [];
-                                    group[id].push(l);
-                                    return group;
-                                  }, {}) || []
-                              ).map(([id, layers]) => {
-                                const mapLayer = new RasterLayer({
-                                  url:   project.state.WMSUrl,
-                                  id:    `overview_layer_${id}`,
-                                  tiled: layers[0].state.tiled,
-                                });
-                                layers.reverse().forEach(l => mapLayer.addLayer(l));
-                                return mapLayer.getOLLayer(true);
-                              }).reverse()
-                          }
-                      })
-                      /** @since 3.10.0 Move another bottom left map controls bottom to a left of overview control**/
-                      document.querySelector('.g3w-map-controls-left-bottom').style.left = '230px';
-                      const observer = new MutationObserver((mutations) => {
-                        mutations.forEach((mutation) => {
-                          if ("class" === mutation.attributeName) {
-                            document.querySelector('.g3w-map-controls-left-bottom').style.left = mutation.target.classList.contains('ol-collapsed') ? '50px' : '230px';
-                          }
-                        });
-                      });
-                      observer.observe(document.querySelector('.ol-custom-overviewmap'), { attributes: true });
-                    })
-                    .catch(e => console.warn(e))
-                }
-                break;
-
-              case 'geocoding':
-              case 'nominatim':
-                this.createMapControl(type, {
-                  add: false,
-                  options: { config }
-                });
-                break;
-
-              case 'geolocation':
-                this.createMapControl(type).on('click', throttle(e => this.showMarker(e.coordinates)));
-                break;
-
-              case 'addlayers':
-                if (!isMobile.any) {
-                  this.createMapControl(type, {}).on('addlayer', () => this.showAddLayerModal());
-                }
-                break;
-
-              case 'length':
-              case 'area':
-                if (!isMobile.any) {
-                  if (this.getMapControlByType('measure')) {
-                    this.getMapControlByType('measure').addType(type)
-                  } else {
-                    this.createMapControl('measure', {
-                      options: {
-                        name: "measure",
-                        tipLabel: 'sdk.mapcontrols.measures.title',
-                        types: [type],
-                        interactionClassOptions: {
-                          projection: this.getProjection(),
-                          help:       `sdk.mapcontrols.measures.${type}.help`
-                        }
-                      }
-                    });
-                  }
-                }
-                break;
-
-              /**
-               * @since 3.8.0
-               */
-              case 'zoomhistory':
-                $('.g3w-map-controls-left-bottom').append(this.createMapControl(type, { add: false }).element);
-                break;
-
-            }
-        });
-        return this.getMapControls()
-      },
-
-      addHideMap({ switchable=false } = {}) {
-        const idMap = {
-          id: `hidemap_${Date.now()}`,
-          map: null,
-          switchable
-        };
-        this.state.hidemaps.push(idMap);
-        return idMap;
-      },
-
-      setHidden(bool) {
-        this.state.hidden = bool;
-      },
-
-      /** Set view based on project config */
-      async setupViewer(width, height) {
-        if (0 === width || 0 === height) {
-          console.warn('[G3W-CLIENT] map was hidden during bootstrap');
-          return;
-        }
-
-        const search = new URLSearchParams(location.search); // search params
-
-        const showmarker       = 1 * (search.get('showmarker') || 0);  /** @since 3.10.0 0 or 1. Show marker on map center*/
-        const iframetype       = search.get('iframetype');             /** @since 3.10.0 type of iframe: map (only map, no control)*/
-        const zoom_to_fid      = search.get('zoom_to_fid');
-        const zoom_to_features = search.get('ztf');                    // zoom to features
-        const coords           = {
-          lat: parseFloat(search.get('lat')),
-          lon: parseFloat(search.get('lon')),
-          x:   parseFloat(search.get('x')),
-          y:   parseFloat(search.get('y')),
-        };
-
-        if (this.viewer) {
-          this.viewer.destroy();
-        }
-
-        const olMap = new ol.Map({
-          controls:            ol.control.defaults({ attribution: false, zoom: false, rotateOptions: { autoHide: true, tipLabel: "Reset rotation (CTRL+DRAG to rotate)" } }),
-          interactions:        ol.interaction.defaults().extend([ new ol.interaction.DragRotate({ condition: ol.events.condition.platformModifierKeyOnly, }) ]),
-          ol3Logo:             false,
-          keyboardEventTarget: document,
-          target:              this.target,
-          view:                new ol.View(this._calculateViewOptions({
-            width,
-            height,
-            project: this.project,
-            map_extent: search.get('map_extent'), /** @since 3.10.0 */
-          })),
-        });
-
-        this.viewer = {
-          map: olMap,
-          getMap:        () => this.viewer.map,
-          getView:       () => this.viewer.map.getView(),
-          getZoom:       () => this.viewer.map.getView().getZoom(),
-          getResolution: () => this.viewer.map.getView().getResolution(),
-          getCenter:     () => this.viewer.map.getView().getCenter(),
-          destroy:       () => { if (this.viewer.map) { this.viewer.map.dispose(); this.viewer.map = null } },
-          zoomTo:        this.zoomTo.bind(this),
-          goTo:          this.goTo.bind(this),
-          fit:           this._fit.bind(this),
-          /** @TODO check if deprecated */
-          changeBaseLayer: name => this.map.getLayers().insertAt(0, this.map.getLayers().find(l => name === l.get('name'))),
-        };
-
-        const map = this.viewer.getMap();
-
-        // disable douclickzoom
-        map.getInteractions().getArray().find(i => i instanceof ol.interaction.DoubleClickZoom).setActive(false);
-
-        // visual click (sonar effect)
-        map.on('click', ({ coordinate }) => {
-          const circle = new ol.layer.Vector({
-            source: new ol.source.Vector({ features: [ new ol.Feature({ geometry: new ol.geom.Point(coordinate) }) ] }),
-            style:  new ol.style.Style()
-          });
-          const start    = +new Date();
-          const duration = 1700;
-          const interval = circle.on('postcompose', ({ frameState }) => {
-            const elapsed  = frameState.time - start;
-            const ratio   = ol.easing.easeOut(elapsed / duration);
-            circle.setStyle(
-              new ol.style.Style({
-                image: new ol.style.Circle({
-                  radius: 40 * ratio, // start = 0, end = 40
-                  fill:   new ol.style.Fill({ color: [225, 227, 228, .1] }),
-                  stroke: new ol.style.Stroke({ color: [225, 227, 228, 1], width: 1.85 * (1 - ratio) }), // start = 1.85, end = 0
-                })
-              })
-            );
-            if (elapsed > duration) {
-              map.removeLayer(circle);
-              ol.Observable.unByKey(interval); // stop the effect
-            }
-          });
-          map.addLayer(circle);
-        });
-
-        let currentControl;
-        let can_drag = false;
-
-        // set mouse cursor (dragging)
-        (new Vue()).$watch(
-          () => [this.getCurrentToggledMapControl(), (PluginsRegistry.getPlugin('editing') && PluginsRegistry.getPlugin('editing').getActiveTool())],
-          ([control, activeTool]) => {
-            currentControl = control
-            can_drag = !control && !activeTool;
-            map.getViewport().classList.toggle('ol-grab', can_drag);
-            map.getInteractions().getArray().find(i => i instanceof ol.interaction.DoubleClickZoom).setActive(can_drag);
-          }
-        );
-        map.on(['pointerdrag', 'pointerup'], (e) => {
-          /** @TODO disable default interaction "shift+zoom" ? */
-          map.getViewport().classList.toggle('ol-grabbing', e.type == 'pointerdrag' && (!currentControl || !(currentControl.getInteraction() instanceof ol.interaction.DragBox)));
-          map.getViewport().classList.toggle('ol-grab',     e.type == 'pointerup' && can_drag);
-        });
-
-        let geom;
-        if (zoom_to_fid) {
-          await this.zoomToFid(zoom_to_fid);
-        } else if (zoom_to_features) {
-          await this.zoomToFeaturesUrl(zoom_to_features);
-        } else if (!isNaN(coords.lat) && !isNaN(coords.lon)) {
-          geom = new ol.geom.Point(ol.proj.transform([coords.lon, coords.lat], 'EPSG:4326', this.getEpsg()));
-        } else if (!isNaN(coords.x) && !isNaN(coords.y)) {
-          geom = new ol.geom.Point([coords.x, coords.y]);
-        }
-
-        if (geom && geom.getExtent()) {
-          await this.zoomToGeometry(geom);
-        }
-
-        // show marker on map center
-        if (1 === showmarker) {
-          this.defaultsLayers.mapcenter.getSource().addFeature(new ol.Feature({ geometry: new ol.geom.Point(this.getCenter()) }))
-        }
-
-        // iframe → hide map controls (empty object)
-        if ('map' === iframetype) {
-          this.config.mapcontrols = {};
-        }
-
-        // update max scale
-        MAP.maxZoom = Math.min(
-          getScaleFromResolution(this.getMap().getView().getResolutionForExtent(this.project.state.initextent, this.getMap().getSize()), this.getMapUnits()),
-          MAP.maxZoom
-        );
-
-        this.state.size     = this.viewer.map.getSize();
-        this.state.mapUnits = this.viewer.map.getView().getProjection().getUnits();
-
-        if (this.config.background_color) {
-          $('#' + this.target).css('background-color', this.config.background_color);
-        }
-
-        $(this.viewer.map.getViewport()).prepend('<div id="map-spinner" style="position:absolute; top: 50%; right: 50%; z-index: 1;"></div>');
-
-        this.viewer.map.getInteractions().forEach(int => this._watchInteraction(int));
-        this.viewer.map.getInteractions().on('add', int => this._watchInteraction(int.element));
-
-        this._marker = new ol.Overlay({
-          position:    null,
-          positioning: 'center-center',
-          element:     document.getElementById('marker'),
-          stopEvent:   false,
-        });
-
-        this.viewer.map.addOverlay(this._marker);
-
-        // keep default layers above others
-        this.viewer.map.getLayers().on('add', e => {
-          const zindex = this.setLayerZIndex({
-            layer:  e.element,
-            zindex: e.element.get('basemap') || 'bottom' === e.element.get('position') ? 0 : undefined,
-          });
-          if (this.defaultsLayers.mapcenter)      { this.defaultsLayers.mapcenter.setZIndex(zindex + 1); }
-          if (this.defaultsLayers.highlightLayer) { this.defaultsLayers.highlightLayer.setZIndex(zindex + 1); }
-          if (this.defaultsLayers.selectionLayer) { this.defaultsLayers.selectionLayer.setZIndex(zindex + 2); }
-        });
-
-        this.viewer.map.getLayers().on('remove', e => {
-          if (e.element.getZIndex() === this.layersCount) {
-            this.layersCount--;
-          }
-        })
-
-        this.state.bbox       = this.getMapBBOX();
-        this.state.resolution = this.viewer.getResolution();
-        this.state.center     = this.viewer.getCenter();
-        this._setupAllLayers();
-        this.setUpMapOlEvents();
-
-        // CHECK IF MAPLAYESRSTOREREGISTRY HAS LAYERSTORE
-        MAP.layers.getLayersStores().forEach(this._setUpEventsKeysToLayersStore.bind(this));
-        MAP.layers.onafter('addLayersStore',    this._setUpEventsKeysToLayersStore.bind(this));
-        MAP.layers.onafter('removeLayersStore', this._removeEventsKeysToLayersStore.bind(this));
-
-        this.emit('viewerset');
-        this.setupControls();
-        this.emit('ready');
-      },
-
-      controlClick(mapcontrol, info = {}) {},
-      loadExternalLayer(layer) {}, // used in general to alert external layer is  loaded
-      unloadExternalLayer(layer) {},
-
-    };
+    this.setters = [
+      'setupControls',
+      'addHideMap',
+      'setHidden',
+      'setupViewer',
+      'controlClick',
+      'loadExternalLayer',
+      'unloadExternalLayer'
+    ];
 
     this.on('extraParamsSet', this.onExtraParamsSet);
   }
@@ -1349,6 +907,480 @@ class MapService extends G3WObject {
   getMapUnits() {
     return this.state.mapUnits;
   }
+
+  /**
+   * @since 4.0.0
+   */
+  setupControls() {
+
+    const { header_terms_of_use_text, header_terms_of_use_link } = this.config;
+
+    // set layers attribution
+    const attribution = header_terms_of_use_text
+      ? header_terms_of_use_link
+        ? `<a href="${header_terms_of_use_link}">${header_terms_of_use_text}</a>`
+        : `<span class="skin-color" style="font-weight: bold">${header_terms_of_use_text}</span>`
+      : false;
+
+    this.getMapLayers().forEach(l => l.getSource().setAttributions(attribution));
+
+    // check if a base layer is set. If true, add attribution control
+    if (attribution || getMapLayersByFilter({ BASELAYER: true }).length) {
+      this.getMap().addControl(new ol.control.Attribution({ collapsible: false, target: 'map_footer_left' }));
+    }
+
+    // skip when no controls
+    if (!this.config || !this.config.mapcontrols) {
+      return;
+    }
+
+    // BACKCOMP (g3w-admin < v3.7.0)
+    const mapcontrols = Array.isArray(this.config.mapcontrols)
+      ? this.config.mapcontrols.reduce((a, v) => { a[v] = {}; return a; }, {}) // convert `initConfig.mapcontrols` from an array of strings to a key-value config Object (eg. ["geocoding"] --> "geocoding" = {})
+      : this.config.mapcontrols;
+
+    Object
+      .entries(mapcontrols)
+      .forEach(([type, config = {}]) => {
+        switch (type) {
+          case 'zoom':
+            this.createMapControl(type);
+            break;
+
+          case 'zoombox':
+            if (!isMobile.any) {
+              this.createMapControl(type, {}).on('zoomend', (e) => this.viewer.fit(e.extent) );
+            }
+            break;
+
+          case 'zoomtoextent':
+            this.createMapControl(type, {
+              options: {
+                extent: this.project.state.initextent
+              }
+            });
+            break;
+
+          case 'mouseposition':
+            if (!isMobile.any) {
+              // @since 3.8.
+              const degrees = 'degrees' === this.getProjection().getUnits();
+              const mapEpsg = this.getEpsg();
+              const coordinateFormat = (epsg, coords) => {
+                if ('EPSG:4326' === epsg) {
+                  return ol.coordinate.format(ol.proj.transform(coords, mapEpsg, 'EPSG:4326'), `\u00A0Lng: {x}, Lat: {y}\u00A0\u00A0 [EPSG:4326]\u00A0`, 4);
+                }
+                return ol.coordinate.format(coords, `\u00A0${degrees ? 'Lng' : 'X'}: {x}, ${degrees ? 'Lat' : 'Y'}: {y}\u00A0\u00A0 [${epsg}]\u00A0`, degrees ? 4 : 2);
+              };
+              const control = this.createMapControl(type, {
+                add: false,
+                options: {
+                  coordinateFormat: coordinateFormat.bind(null, mapEpsg),
+                  undefinedHTML:    false,
+                  projection:       this.getCrs()
+                }
+              });
+              if ('EPSG:4326' !== mapEpsg) {
+                control.on('change:epsg', e => control.setCoordinateFormat(coordinateFormat.bind(null, e.epsg)));
+              }
+            }
+            break;
+
+          case 'screenshot':
+          case 'geoscreenshot':
+            if (!isMobile.any ) {
+              if (this.getMapControlByType('screenshot')) {
+                this.getMapControlByType('screenshot').addType(type)
+              } else {
+                this.createMapControl('screenshot', {
+                  options: {
+                    types:   [type],
+                    layers:  [...MAP.layers.getLayers(), ...this._layers.external],
+                  }
+                });
+              }
+            }
+            break;
+
+          case 'scale':
+            this.createMapControl(type, {
+              add: false,
+              options: {
+                coordinateFormat: ol.coordinate.createStringXY(4),
+                projection:       this.getCrs(),
+                isMobile:         isMobile.any
+              }
+            });
+            break;
+
+          case 'query':
+            this.createMapControl(type, {
+              add: true,
+              toggled: true
+            });
+            break;
+
+          case 'querybypolygon':
+          case 'querybbox':
+          case 'querybycircle':
+          case 'querybydrawpolygon':
+            if (!isMobile.any) {
+              if (this.getMapControlByType('queryby')) {
+                this.getMapControlByType('queryby').addType(type)
+              } else {
+                this.createMapControl('queryby', {
+                  options: {
+                    types:   [type],
+                  }
+                });
+              }
+            }
+            break;
+
+          case 'streetview':
+            this.createMapControl(type, {});
+            break;
+
+          case 'scaleline':
+            this.createMapControl(type, {
+              add: false,
+              options: {
+                position: 'br'
+              }
+            });
+            break;
+
+          case 'overview':
+            if (!isMobile.any && window.initConfig.overviewproject) {
+              getProject(window.initConfig.overviewproject)
+                .then(project => {
+                  const view = new ol.View(this._calculateViewOptions({ project, width: 200, height: 150 })); // at moment hardcoded
+                  this.createMapControl(type, {
+                    add: false,
+                      options: {
+                        view,
+                        position:      'bl',
+                        collapsed:     false,
+                        className:     'ol-overviewmap ol-custom-overviewmap',
+                        collapseLabel: $(`<span class="${GUI.getFontClass('arrow-left')}"></span>`)[0],
+                        label:         $(`<span class="${GUI.getFontClass('arrow-right')}"></span>`)[0],
+                        layers:        Object
+                          .entries(
+                            //group layer by multilayerId
+                            project.getLayersStore().getLayers({ GEOLAYER: true, BASELAYER: false })
+                              .reduce((group, l) => {
+                                const id = l.getMultiLayerId();
+                                group[id] = group[id] || [];
+                                group[id].push(l);
+                                return group;
+                              }, {}) || []
+                          ).map(([id, layers]) => {
+                            const mapLayer = new RasterLayer({
+                              url:   project.state.WMSUrl,
+                              id:    `overview_layer_${id}`,
+                              tiled: layers[0].state.tiled,
+                            });
+                            layers.reverse().forEach(l => mapLayer.addLayer(l));
+                            return mapLayer.getOLLayer(true);
+                          }).reverse()
+                      }
+                  })
+                  /** @since 3.10.0 Move another bottom left map controls bottom to a left of overview control**/
+                  document.querySelector('.g3w-map-controls-left-bottom').style.left = '230px';
+                  const observer = new MutationObserver((mutations) => {
+                    mutations.forEach((mutation) => {
+                      if ("class" === mutation.attributeName) {
+                        document.querySelector('.g3w-map-controls-left-bottom').style.left = mutation.target.classList.contains('ol-collapsed') ? '50px' : '230px';
+                      }
+                    });
+                  });
+                  observer.observe(document.querySelector('.ol-custom-overviewmap'), { attributes: true });
+                })
+                .catch(e => console.warn(e))
+            }
+            break;
+
+          case 'geocoding':
+          case 'nominatim':
+            this.createMapControl(type, {
+              add: false,
+              options: { config }
+            });
+            break;
+
+          case 'geolocation':
+            this.createMapControl(type).on('click', throttle(e => this.showMarker(e.coordinates)));
+            break;
+
+          case 'addlayers':
+            if (!isMobile.any) {
+              this.createMapControl(type, {}).on('addlayer', () => this.showAddLayerModal());
+            }
+            break;
+
+          case 'length':
+          case 'area':
+            if (!isMobile.any) {
+              if (this.getMapControlByType('measure')) {
+                this.getMapControlByType('measure').addType(type)
+              } else {
+                this.createMapControl('measure', {
+                  options: {
+                    name: "measure",
+                    tipLabel: 'sdk.mapcontrols.measures.title',
+                    types: [type],
+                    interactionClassOptions: {
+                      projection: this.getProjection(),
+                      help:       `sdk.mapcontrols.measures.${type}.help`
+                    }
+                  }
+                });
+              }
+            }
+            break;
+
+          /**
+           * @since 3.8.0
+           */
+          case 'zoomhistory':
+            $('.g3w-map-controls-left-bottom').append(this.createMapControl(type, { add: false }).element);
+            break;
+
+        }
+    });
+    return this.getMapControls()
+  }
+
+  /**
+   * @since 4.0.0
+   */
+  addHideMap({ switchable=false } = {}) {
+    const idMap = {
+      id: `hidemap_${Date.now()}`,
+      map: null,
+      switchable
+    };
+    this.state.hidemaps.push(idMap);
+    return idMap;
+  }
+
+  /**
+   * @since 4.0.0
+   */
+  setHidden(bool) {
+    this.state.hidden = bool;
+  }
+
+  /**
+   * Set view based on project config
+   * 
+   * @since 4.0.0
+   */
+  async setupViewer(width, height) {
+    if (0 === width || 0 === height) {
+      console.warn('[G3W-CLIENT] map was hidden during bootstrap');
+      return;
+    }
+
+    const search = new URLSearchParams(location.search); // search params
+
+    const showmarker       = 1 * (search.get('showmarker') || 0);  /** @since 3.10.0 0 or 1. Show marker on map center*/
+    const iframetype       = search.get('iframetype');             /** @since 3.10.0 type of iframe: map (only map, no control)*/
+    const zoom_to_fid      = search.get('zoom_to_fid');
+    const zoom_to_features = search.get('ztf');                    // zoom to features
+    const coords           = {
+      lat: parseFloat(search.get('lat')),
+      lon: parseFloat(search.get('lon')),
+      x:   parseFloat(search.get('x')),
+      y:   parseFloat(search.get('y')),
+    };
+
+    if (this.viewer) {
+      this.viewer.destroy();
+    }
+
+    const olMap = new ol.Map({
+      controls:            ol.control.defaults({ attribution: false, zoom: false, rotateOptions: { autoHide: true, tipLabel: "Reset rotation (CTRL+DRAG to rotate)" } }),
+      interactions:        ol.interaction.defaults().extend([ new ol.interaction.DragRotate({ condition: ol.events.condition.platformModifierKeyOnly, }) ]),
+      ol3Logo:             false,
+      keyboardEventTarget: document,
+      target:              this.target,
+      view:                new ol.View(this._calculateViewOptions({
+        width,
+        height,
+        project: this.project,
+        map_extent: search.get('map_extent'), /** @since 3.10.0 */
+      })),
+    });
+
+    this.viewer = {
+      map: olMap,
+      getMap:        () => this.viewer.map,
+      getView:       () => this.viewer.map.getView(),
+      getZoom:       () => this.viewer.map.getView().getZoom(),
+      getResolution: () => this.viewer.map.getView().getResolution(),
+      getCenter:     () => this.viewer.map.getView().getCenter(),
+      destroy:       () => { if (this.viewer.map) { this.viewer.map.dispose(); this.viewer.map = null } },
+      zoomTo:        this.zoomTo.bind(this),
+      goTo:          this.goTo.bind(this),
+      fit:           this._fit.bind(this),
+      /** @TODO check if deprecated */
+      changeBaseLayer: name => this.map.getLayers().insertAt(0, this.map.getLayers().find(l => name === l.get('name'))),
+    };
+
+    const map = this.viewer.getMap();
+
+    // disable douclickzoom
+    map.getInteractions().getArray().find(i => i instanceof ol.interaction.DoubleClickZoom).setActive(false);
+
+    // visual click (sonar effect)
+    map.on('click', ({ coordinate }) => {
+      const circle = new ol.layer.Vector({
+        source: new ol.source.Vector({ features: [ new ol.Feature({ geometry: new ol.geom.Point(coordinate) }) ] }),
+        style:  new ol.style.Style()
+      });
+      const start    = +new Date();
+      const duration = 1700;
+      const interval = circle.on('postcompose', ({ frameState }) => {
+        const elapsed  = frameState.time - start;
+        const ratio   = ol.easing.easeOut(elapsed / duration);
+        circle.setStyle(
+          new ol.style.Style({
+            image: new ol.style.Circle({
+              radius: 40 * ratio, // start = 0, end = 40
+              fill:   new ol.style.Fill({ color: [225, 227, 228, .1] }),
+              stroke: new ol.style.Stroke({ color: [225, 227, 228, 1], width: 1.85 * (1 - ratio) }), // start = 1.85, end = 0
+            })
+          })
+        );
+        if (elapsed > duration) {
+          map.removeLayer(circle);
+          ol.Observable.unByKey(interval); // stop the effect
+        }
+      });
+      map.addLayer(circle);
+    });
+
+    let currentControl;
+    let can_drag = false;
+
+    // set mouse cursor (dragging)
+    (new Vue()).$watch(
+      () => [this.getCurrentToggledMapControl(), (PluginsRegistry.getPlugin('editing') && PluginsRegistry.getPlugin('editing').getActiveTool())],
+      ([control, activeTool]) => {
+        currentControl = control
+        can_drag = !control && !activeTool;
+        map.getViewport().classList.toggle('ol-grab', can_drag);
+        map.getInteractions().getArray().find(i => i instanceof ol.interaction.DoubleClickZoom).setActive(can_drag);
+      }
+    );
+    map.on(['pointerdrag', 'pointerup'], (e) => {
+      /** @TODO disable default interaction "shift+zoom" ? */
+      map.getViewport().classList.toggle('ol-grabbing', e.type == 'pointerdrag' && (!currentControl || !(currentControl.getInteraction() instanceof ol.interaction.DragBox)));
+      map.getViewport().classList.toggle('ol-grab',     e.type == 'pointerup' && can_drag);
+    });
+
+    let geom;
+    if (zoom_to_fid) {
+      await this.zoomToFid(zoom_to_fid);
+    } else if (zoom_to_features) {
+      await this.zoomToFeaturesUrl(zoom_to_features);
+    } else if (!isNaN(coords.lat) && !isNaN(coords.lon)) {
+      geom = new ol.geom.Point(ol.proj.transform([coords.lon, coords.lat], 'EPSG:4326', this.getEpsg()));
+    } else if (!isNaN(coords.x) && !isNaN(coords.y)) {
+      geom = new ol.geom.Point([coords.x, coords.y]);
+    }
+
+    if (geom && geom.getExtent()) {
+      await this.zoomToGeometry(geom);
+    }
+
+    // show marker on map center
+    if (1 === showmarker) {
+      this.defaultsLayers.mapcenter.getSource().addFeature(new ol.Feature({ geometry: new ol.geom.Point(this.getCenter()) }))
+    }
+
+    // iframe → hide map controls (empty object)
+    if ('map' === iframetype) {
+      this.config.mapcontrols = {};
+    }
+
+    // update max scale
+    MAP.maxZoom = Math.min(
+      getScaleFromResolution(this.getMap().getView().getResolutionForExtent(this.project.state.initextent, this.getMap().getSize()), this.getMapUnits()),
+      MAP.maxZoom
+    );
+
+    this.state.size     = this.viewer.map.getSize();
+    this.state.mapUnits = this.viewer.map.getView().getProjection().getUnits();
+
+    if (this.config.background_color) {
+      $('#' + this.target).css('background-color', this.config.background_color);
+    }
+
+    $(this.viewer.map.getViewport()).prepend('<div id="map-spinner" style="position:absolute; top: 50%; right: 50%; z-index: 1;"></div>');
+
+    this.viewer.map.getInteractions().forEach(int => this._watchInteraction(int));
+    this.viewer.map.getInteractions().on('add', int => this._watchInteraction(int.element));
+
+    this._marker = new ol.Overlay({
+      position:    null,
+      positioning: 'center-center',
+      element:     document.getElementById('marker'),
+      stopEvent:   false,
+    });
+
+    this.viewer.map.addOverlay(this._marker);
+
+    // keep default layers above others
+    this.viewer.map.getLayers().on('add', e => {
+      const zindex = this.setLayerZIndex({
+        layer:  e.element,
+        zindex: e.element.get('basemap') || 'bottom' === e.element.get('position') ? 0 : undefined,
+      });
+      if (this.defaultsLayers.mapcenter)      { this.defaultsLayers.mapcenter.setZIndex(zindex + 1); }
+      if (this.defaultsLayers.highlightLayer) { this.defaultsLayers.highlightLayer.setZIndex(zindex + 1); }
+      if (this.defaultsLayers.selectionLayer) { this.defaultsLayers.selectionLayer.setZIndex(zindex + 2); }
+    });
+
+    this.viewer.map.getLayers().on('remove', e => {
+      if (e.element.getZIndex() === this.layersCount) {
+        this.layersCount--;
+      }
+    })
+
+    this.state.bbox       = this.getMapBBOX();
+    this.state.resolution = this.viewer.getResolution();
+    this.state.center     = this.viewer.getCenter();
+    this._setupAllLayers();
+    this.setUpMapOlEvents();
+
+    // CHECK IF MAPLAYESRSTOREREGISTRY HAS LAYERSTORE
+    MAP.layers.getLayersStores().forEach(this._setUpEventsKeysToLayersStore.bind(this));
+    MAP.layers.onafter('addLayersStore',    this._setUpEventsKeysToLayersStore.bind(this));
+    MAP.layers.onafter('removeLayersStore', this._removeEventsKeysToLayersStore.bind(this));
+
+    this.emit('viewerset');
+    this.setupControls();
+    this.emit('ready');
+  }
+
+  /**
+   * @since 4.0.0
+   */
+  controlClick(mapcontrol, info = {}) {}
+
+  /**
+   * called when an external layer is loaded
+   * 
+   * @since 4.0.0
+   */
+  loadExternalLayer(layer) {} 
+
+  /**
+   * @since 4.0.0
+   */
+  unloadExternalLayer(layer) {}
 
   // remove all events of layersStore
   _removeEventsKeysToLayersStore(store) {

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -50,337 +50,19 @@ export default new (class QueryResultsService extends G3WObject {
     /**
      * Core methods used from other classes to react before or after its call
      */
-    this.setters = {
-
-      /**
-       * Hook method called when response is handled by Data Provider
-       *
-       * @param { Object }                             queryResponse
-       * @param { Array }                              queryResponse.data
-       * @param { 'coordinates' | 'bbox' | 'polygon' } queryResponse.type
-       * @param { Object }                             queryResponse.query
-       * @param { Object }                             queryResponse.query.external
-       * @param { boolean }                            queryResponse.query.external.add       - whether add external layers to response
-       * @param { Object }                             queryResponse.query.external.filter
-       * @param { boolean }                            queryResponse.query.external.SELECTED
-       * @param { Object }                             options
-       * @param { boolean }                            options.add                            - whether is a new query request (add/remove query request)
-       */
-      setQueryResponse(queryResponse, options = { add: false, update: false }) {
-        // set mandatory queryResponse fields
-        if (!queryResponse.data)           queryResponse.data           = [];
-        if (!queryResponse.query)          queryResponse.query          = { external: { add: false, filter: { SELECTED: false } } };
-        if (!queryResponse.query.external) queryResponse.query.external = { add: false, filter: { SELECTED: false }};
-
-
-        if (false === options.add && !!options.update) {
-          // in case of new request results reset the query otherwise maintain the previous request
-          this.state.query      = queryResponse.query;
-          this.state.type       = queryResponse.type;
-        }
-        // whether add response to current results using addLayerFeaturesToResultsAction
-        if (false === options.add && !options.update) {
-          // in case of new request results reset the query otherwise maintain the previous request
-          this.clearState();
-          this.state.query      = queryResponse.query;
-          this.state.type       = queryResponse.type;
-        }
-        // whether add external layers to response
-        if (true === queryResponse.query.external.add && false === options.add) {
-          const catalog = GUI.getService('catalog');
-
-          /** @type { boolean | undefined } */
-          const FILTER_SELECTED = queryResponse.query.external.filter.SELECTED;
-      
-          // add visible layers to query response (vector layers)
-          this._vectorLayers.forEach(layer => {
-            const id = layer.get('id');
-            // TODO: extract this into `layer.isSomething()` ?
-            if (
-              layer.getVisible()
-              && [undefined, !!(catalog.state.external.vector.find(l => l.id === id) || {}).selected].includes(FILTER_SELECTED)
-            ) {
-              queryResponse.data[
-                '__g3w_marker' === id // keep geocoding control "marker" layer at the top
-                ? 'unshift'
-                : 'push'
-              ](this.getVectorLayerFeaturesFromQueryRequest(layer, queryResponse.query));
-            }
-          });
-        }
-
-        const geom = false === options.add && ({
-          'coordinates': 2 === (this.state.query.coordinates || []).length && new ol.geom.Point(this.state.query.coordinates),
-          'bbox':        4 === (this.state.query.bbox || []).length        && ol.geom.Polygon.fromExtent(this.state.query.bbox),
-          'polygon':     this.state.query.geometry,
-          'drawpolygon': this.state.query.geometry,
-          'circle':      this.state.query.geometry,
-        })[this.state.query.type];
-
-        // show a query result on map
-        if (geom) {
-          const feature = new ol.Feature(geom);
-          feature.setId(undefined);
-          this.resultsQueryLayer.getSource().clear();
-          GUI.getService('map').getMap().removeLayer(this.resultsQueryLayer);
-          this.resultsQueryLayer.getSource().addFeature(feature);
-          GUI.getService('map').getMap().addLayer(this.resultsQueryLayer);
-          this.resultsQueryLayer.setZIndex(GUI.getService('map').getMap().getLayers().getLength()); // ensure layer is on top of others
-        }
-
-        // Convert response from DataProvider into a QueryResult component data structure
-        // Skip when the layer has no features or rawdata is undefined (external wms)
-        const layers = queryResponse.data
-          .flatMap(d => [].concat(d))
-          .filter(d => d && (undefined !== d.rawdata || (Array.isArray(d.features) && d.features.length > 0)))
-          .map(({
-            layer,
-            features,
-            rawdata, // rawdata response
-            error
-          } = {}) => {
-
-            const is_layer  = layer instanceof Layer;
-            const is_vector = layer instanceof ol.layer.Vector;                     // instance of openlayers layer Vector Class
-            const is_string = 'string' === typeof layer || layer instanceof String; // can be created by string
-
-            let sourceType;
-
-            if (is_string) {
-              sourceType = Layer.LayerTypes.VECTOR;
-            } else if (is_layer) {
-              try {
-                sourceType = layer.getSourceType();
-              } catch (error) {
-                console.warn('uknown source type for layer:', error, layer);
-              }
-            }
-            
-            const name = is_string && layer.split('_');
-
-            const id = (is_layer ? layer.getId() : undefined) ||
-              (is_vector ? layer.get('id') : undefined) ||
-              (is_string ? layer : undefined);
-
-            let attributes;
-            let layerAttrs;
-
-            // sanity check (eg. external layers ?)
-            if (!features || !features.length) {
-              attributes = [];
-            }
-        
-            // Sanitize OWS Layer attributes
-            if (!attributes && layer instanceof Layer) {
-              layerAttrs = layer.getAttributes().map(attr => 'ows' === this.state.type ? ({ ...attr, name: attr.name.replace(/ /g, '_') }) : attr);
-            }
-        
-            if (!attributes && layer instanceof ol.layer.Vector) {
-              layerAttrs = layer.getProperties();
-            }
-        
-            if (!attributes && 'string' === typeof layer || layer instanceof String) {
-              layerAttrs = (features[0] ? features[0].getProperties() : [])
-            }
-        
-            const specialAttrs = (!attributes && layer instanceof Layer && layerAttrs || []).filter(attr => {
-                try {
-                  return ('_' === attr.name[0] || Number.isInteger(1 * attr.name[0]))
-                } catch(e) {
-                  return false;
-                }
-              }).map(attr => ({ alias: attr.name.replace(/_/, ''), name: attr.name }));
-        
-            if (!attributes && specialAttrs.length) {
-              features.forEach(f => {
-                // get attributes special keys from feature properties received by server request
-                const attrs = Object.keys(f.getProperties());
-                specialAttrs.forEach(layerAttr => {
-                  attrs.find(attr => {
-                    if (attr === layerAttr.alias) {
-                      f.set(layerAttr.name, f.get(attr));
-                      return true
-                    }
-                  })
-                });
-              });
-            }
-        
-            // Parse attributes to show on a result based on field
-        
-            let attrs = !attributes && getAlphanumericPropertiesFromFeature(
-              Object.keys(features[0] instanceof ol.Feature ? features[0].getProperties() : features[0].properties)
-            );
-        
-            if (!attributes) {
-              attributes = (layerAttrs && layerAttrs.length > 0)
-                ? layerAttrs.filter(attr => attrs.includes(attr.name))
-                : attrs.map(featureAttr => ({
-                  name:  featureAttr,
-                  label: featureAttr,
-                  show:  G3W_FID !== featureAttr && [undefined, 'gdal', 'wms', 'wcs', 'wmst', 'postgresraster'].includes(sourceType),
-                  type:  'varchar'
-                }));
-            }
-
-            const external   = (is_vector || is_string);
-            const structure  = is_layer && layer.hasFormStructure() && layer.getLayerEditingFormStructure();
-
-            if (structure && Array.isArray(this._relations[layer.getId()]) && this._relations[layer.getId()].length > 0) {
-              for (const node of structure) {
-                _setRelationField(node);
-              }
-            }
-            // layerObj
-            return {
-              id,
-              attributes,
-              external,
-              features: (!rawdata && features || []).map(f => ({
-                id:         external ? f.getId() : (f instanceof ol.Feature ? f.getId() : f.id),
-                attributes: f instanceof ol.Feature ? f.getProperties() : f.properties,
-                geometry:   f instanceof ol.Feature ? f.getGeometry()   : f.geometry,
-                selection:  { selected: !external && (!!queryResponse.query.autofilter || layer.state.selection.active) }, //@since 3.11.8 check if autofilter is set
-                show:       true,
-              })),
-              hasgeometry:            Array.isArray(features) && !rawdata && features.some(f => f instanceof ol.Feature ? f.getGeometry() : f.geometry),
-              hasImageField:          Array.isArray(features) && !rawdata && features.length && attributes.some(attr => 'image' === attr.type),
-              loading:                false,
-              show:                   true,
-              expandable:             true,
-              addfeaturesresults:     { active: false },
-              downloadformats:        { active: false },
-              editable:               is_layer   ? layer.isEditable() && layer.config.editing.visible : false,
-              inediting:              is_layer   ? layer.isInEditing()                                : false,
-              source:                 is_layer   ? layer.getSource()                                  : undefined,
-              infoformat:             is_layer   ? layer.getInfoFormat()                              : undefined,
-              infoformats:            is_layer   ? layer.getInfoFormats()                             : [],
-              downloads:              is_layer   ? layer.getDownloadableFormats()                     : [],
-              formStructure:          structure  ? {
-                structure,
-                // get field show
-                fields: layer.getFields().filter(f => f.show).concat(
-                  (Array.isArray(features) && !rawdata && features.length > 0 && attributes || []).filter(attr => layer.getFields().some(f => f.name === attr.name))
-                ),
-              } : undefined,
-              relationsattributes:      (is_layer || is_vector || is_string)                       ? []                     : undefined,
-              hasdownloadablerelations: !external && layer.hasDowloadableRelations(), //@since 3.11.7
-              filter:                   (is_layer && !['wms', 'wcs', 'wmst'].includes(sourceType)) ? layer.state.filter     : {},
-              selection:                (is_layer && !['wms', 'wcs', 'wmst'].includes(sourceType) && layer.state.selection) || (is_vector && layer.selection) || {},
-              title:                    (is_layer && layer.getTitle()) || (is_vector && layer.get('name')) || (is_string && name && (name.length > 4 ? name.slice(0, name.length - 4).join(' ') : layer)) || undefined,
-              atlas:                    this._atlas.filter(a => a.atlas.qgs_layer_id === id),
-              rawdata:                  rawdata  || null,
-              error:                    error    || '',
-              toc:                      external || layer.state.toc, //@since v3.10.0
-            };
-          });
-        this.setLayersData(layers, options);
-      },
-
-      /**
-       * Setter method called when adding layer and feature for response
-       *
-       * @param layers
-       * @param options
-       */
-      setLayersData(layers = [], options = { add: false, update: false }) {
-        if (false === options.add) {
-          // sort layers as Catalog project layers.
-          //external layer always on bottom
-          layers.sort((a, b) => a.external ? 0 : (this._projectLayerIds.indexOf(a.id) > this._projectLayerIds.indexOf(b.id) ? 1 : -1));
-        }
-        // get features from added pick layer in case of a new request query
-        layers.forEach((l, index) => {
-          //@since 3.11.0 check if a result comes from pagination
-          l.filter.pagination = l.filter.pagination || !!(this.state.query.pagination && this.state.query.pagination.counts[index] > l.features.length) ;
-          options.add || options.update ? this.updateLayerResultFeatures(l, options.update) : this.state.layers.push(l)
-        });
-        this.setActionsForLayers(layers, { add: options.add, update: options.update });
-        this.state.changed = true;
-      },
-
-      /**
-       * Add custom component in query result
-       *
-       * @param component
-       */
-      addComponent(component) {
-        this.state.components.push(component)
-      },
-
-      /**
-       * @FIXME add description
-       *
-       * @param actions
-       * @param layers
-       */
-      addActionsForLayers(actions, layers) {},
-
-      /**
-       * @FIXME add description
-       *
-       * @param element
-       */
-      postRender(element) {},
-
-      /**
-       * @FIXME add description
-       */
-      closeComponent() {},
-
-      /**
-       * Called when layer result features is changed
-       *
-       * @param layer
-       */
-      changeLayerResult(layer) {
-        this.state.layersactions[layer.id].forEach(action => action.change && action.change(layer));  // call if present change method to action
-        // reset layer current actions tools
-        (layer.features || []).forEach((_, idx) => {
-            const tool = this.state.currentactiontools[layer.id];
-            if (undefined === tool) {
-              return;
-            }
-            if (undefined === tool[idx]) {
-              Vue.set(tool, idx, null);
-            }
-            tool[idx] = null;
-          });
-      },
-
-      /**
-       * @FIXME add description
-       */
-      activeMapInteraction() {},
-
-      /**
-       * Setter method related to relation table
-       */
-      editFeature({layer, feature}={}) {},
-
-      /**
-       * Setter method called when opening/closing feature info data content.
-       *
-       * @param opts.open
-       * @param opts.layer
-       * @param opts.feature
-       * @param opts.container
-       */
-      openCloseFeatureResult({open, layer, feature, container}={}) {},
-
-      /**
-       * Remove a feature from current layer result
-       *
-       * @param layer
-       * @param feature
-       * 
-       * @since 3.9.0
-       */
-      removeFeatureLayerFromResult(layer, feature) {
-        this.updateLayerResultFeatures({ id: layer.id, external: layer.external, features: [feature] });
-      }
-
-    };
+    this.setters = [
+      'setQueryResponse',
+      'setLayersData',
+      'addComponent',
+      'addActionsForLayers',
+      'postRender',
+      'closeComponent',
+      'changeLayerResult',
+      'activeMapInteraction',
+      'editFeature',
+      'openCloseFeatureResult',
+      'removeFeatureLayerFromResult',
+    ];
 
     /**
      * @FIXME add description
@@ -586,6 +268,354 @@ export default new (class QueryResultsService extends G3WObject {
       }
     });
 
+  }
+
+  /**
+   * Hook method called when response is handled by Data Provider
+   *
+   * @param { Object }                             queryResponse
+   * @param { Array }                              queryResponse.data
+   * @param { 'coordinates' | 'bbox' | 'polygon' } queryResponse.type
+   * @param { Object }                             queryResponse.query
+   * @param { Object }                             queryResponse.query.external
+   * @param { boolean }                            queryResponse.query.external.add       - whether add external layers to response
+   * @param { Object }                             queryResponse.query.external.filter
+   * @param { boolean }                            queryResponse.query.external.SELECTED
+   * @param { Object }                             options
+   * @param { boolean }                            options.add                            - whether is a new query request (add/remove query request)
+   * 
+   * @since 4.0.0
+   */
+  setQueryResponse(queryResponse, options = { add: false, update: false }) {
+    // set mandatory queryResponse fields
+    if (!queryResponse.data)           queryResponse.data           = [];
+    if (!queryResponse.query)          queryResponse.query          = { external: { add: false, filter: { SELECTED: false } } };
+    if (!queryResponse.query.external) queryResponse.query.external = { add: false, filter: { SELECTED: false }};
+
+
+    if (false === options.add && !!options.update) {
+      // in case of new request results reset the query otherwise maintain the previous request
+      this.state.query      = queryResponse.query;
+      this.state.type       = queryResponse.type;
+    }
+    // whether add response to current results using addLayerFeaturesToResultsAction
+    if (false === options.add && !options.update) {
+      // in case of new request results reset the query otherwise maintain the previous request
+      this.clearState();
+      this.state.query      = queryResponse.query;
+      this.state.type       = queryResponse.type;
+    }
+    // whether add external layers to response
+    if (true === queryResponse.query.external.add && false === options.add) {
+      const catalog = GUI.getService('catalog');
+
+      /** @type { boolean | undefined } */
+      const FILTER_SELECTED = queryResponse.query.external.filter.SELECTED;
+  
+      // add visible layers to query response (vector layers)
+      this._vectorLayers.forEach(layer => {
+        const id = layer.get('id');
+        // TODO: extract this into `layer.isSomething()` ?
+        if (
+          layer.getVisible()
+          && [undefined, !!(catalog.state.external.vector.find(l => l.id === id) || {}).selected].includes(FILTER_SELECTED)
+        ) {
+          queryResponse.data[
+            '__g3w_marker' === id // keep geocoding control "marker" layer at the top
+            ? 'unshift'
+            : 'push'
+          ](this.getVectorLayerFeaturesFromQueryRequest(layer, queryResponse.query));
+        }
+      });
+    }
+
+    const geom = false === options.add && ({
+      'coordinates': 2 === (this.state.query.coordinates || []).length && new ol.geom.Point(this.state.query.coordinates),
+      'bbox':        4 === (this.state.query.bbox || []).length        && ol.geom.Polygon.fromExtent(this.state.query.bbox),
+      'polygon':     this.state.query.geometry,
+      'drawpolygon': this.state.query.geometry,
+      'circle':      this.state.query.geometry,
+    })[this.state.query.type];
+
+    // show a query result on map
+    if (geom) {
+      const feature = new ol.Feature(geom);
+      feature.setId(undefined);
+      this.resultsQueryLayer.getSource().clear();
+      GUI.getService('map').getMap().removeLayer(this.resultsQueryLayer);
+      this.resultsQueryLayer.getSource().addFeature(feature);
+      GUI.getService('map').getMap().addLayer(this.resultsQueryLayer);
+      this.resultsQueryLayer.setZIndex(GUI.getService('map').getMap().getLayers().getLength()); // ensure layer is on top of others
+    }
+
+    // Convert response from DataProvider into a QueryResult component data structure
+    // Skip when the layer has no features or rawdata is undefined (external wms)
+    const layers = queryResponse.data
+      .flatMap(d => [].concat(d))
+      .filter(d => d && (undefined !== d.rawdata || (Array.isArray(d.features) && d.features.length > 0)))
+      .map(({
+        layer,
+        features,
+        rawdata, // rawdata response
+        error
+      } = {}) => {
+
+        const is_layer  = layer instanceof Layer;
+        const is_vector = layer instanceof ol.layer.Vector;                     // instance of openlayers layer Vector Class
+        const is_string = 'string' === typeof layer || layer instanceof String; // can be created by string
+
+        let sourceType;
+
+        if (is_string) {
+          sourceType = Layer.LayerTypes.VECTOR;
+        } else if (is_layer) {
+          try {
+            sourceType = layer.getSourceType();
+          } catch (error) {
+            console.warn('uknown source type for layer:', error, layer);
+          }
+        }
+        
+        const name = is_string && layer.split('_');
+
+        const id = (is_layer ? layer.getId() : undefined) ||
+          (is_vector ? layer.get('id') : undefined) ||
+          (is_string ? layer : undefined);
+
+        let attributes;
+        let layerAttrs;
+
+        // sanity check (eg. external layers ?)
+        if (!features || !features.length) {
+          attributes = [];
+        }
+    
+        // Sanitize OWS Layer attributes
+        if (!attributes && layer instanceof Layer) {
+          layerAttrs = layer.getAttributes().map(attr => 'ows' === this.state.type ? ({ ...attr, name: attr.name.replace(/ /g, '_') }) : attr);
+        }
+    
+        if (!attributes && layer instanceof ol.layer.Vector) {
+          layerAttrs = layer.getProperties();
+        }
+    
+        if (!attributes && 'string' === typeof layer || layer instanceof String) {
+          layerAttrs = (features[0] ? features[0].getProperties() : [])
+        }
+    
+        const specialAttrs = (!attributes && layer instanceof Layer && layerAttrs || []).filter(attr => {
+            try {
+              return ('_' === attr.name[0] || Number.isInteger(1 * attr.name[0]))
+            } catch(e) {
+              return false;
+            }
+          }).map(attr => ({ alias: attr.name.replace(/_/, ''), name: attr.name }));
+    
+        if (!attributes && specialAttrs.length) {
+          features.forEach(f => {
+            // get attributes special keys from feature properties received by server request
+            const attrs = Object.keys(f.getProperties());
+            specialAttrs.forEach(layerAttr => {
+              attrs.find(attr => {
+                if (attr === layerAttr.alias) {
+                  f.set(layerAttr.name, f.get(attr));
+                  return true
+                }
+              })
+            });
+          });
+        }
+    
+        // Parse attributes to show on a result based on field
+    
+        let attrs = !attributes && getAlphanumericPropertiesFromFeature(
+          Object.keys(features[0] instanceof ol.Feature ? features[0].getProperties() : features[0].properties)
+        );
+    
+        if (!attributes) {
+          attributes = (layerAttrs && layerAttrs.length > 0)
+            ? layerAttrs.filter(attr => attrs.includes(attr.name))
+            : attrs.map(featureAttr => ({
+              name:  featureAttr,
+              label: featureAttr,
+              show:  G3W_FID !== featureAttr && [undefined, 'gdal', 'wms', 'wcs', 'wmst', 'postgresraster'].includes(sourceType),
+              type:  'varchar'
+            }));
+        }
+
+        const external   = (is_vector || is_string);
+        const structure  = is_layer && layer.hasFormStructure() && layer.getLayerEditingFormStructure();
+
+        if (structure && Array.isArray(this._relations[layer.getId()]) && this._relations[layer.getId()].length > 0) {
+          for (const node of structure) {
+            _setRelationField(node);
+          }
+        }
+        // layerObj
+        return {
+          id,
+          attributes,
+          external,
+          features: (!rawdata && features || []).map(f => ({
+            id:         external ? f.getId() : (f instanceof ol.Feature ? f.getId() : f.id),
+            attributes: f instanceof ol.Feature ? f.getProperties() : f.properties,
+            geometry:   f instanceof ol.Feature ? f.getGeometry()   : f.geometry,
+            selection:  { selected: !external && (!!queryResponse.query.autofilter || layer.state.selection.active) }, //@since 3.11.8 check if autofilter is set
+            show:       true,
+          })),
+          hasgeometry:            Array.isArray(features) && !rawdata && features.some(f => f instanceof ol.Feature ? f.getGeometry() : f.geometry),
+          hasImageField:          Array.isArray(features) && !rawdata && features.length && attributes.some(attr => 'image' === attr.type),
+          loading:                false,
+          show:                   true,
+          expandable:             true,
+          addfeaturesresults:     { active: false },
+          downloadformats:        { active: false },
+          editable:               is_layer   ? layer.isEditable() && layer.config.editing.visible : false,
+          inediting:              is_layer   ? layer.isInEditing()                                : false,
+          source:                 is_layer   ? layer.getSource()                                  : undefined,
+          infoformat:             is_layer   ? layer.getInfoFormat()                              : undefined,
+          infoformats:            is_layer   ? layer.getInfoFormats()                             : [],
+          downloads:              is_layer   ? layer.getDownloadableFormats()                     : [],
+          formStructure:          structure  ? {
+            structure,
+            // get field show
+            fields: layer.getFields().filter(f => f.show).concat(
+              (Array.isArray(features) && !rawdata && features.length > 0 && attributes || []).filter(attr => layer.getFields().some(f => f.name === attr.name))
+            ),
+          } : undefined,
+          relationsattributes:      (is_layer || is_vector || is_string)                       ? []                     : undefined,
+          hasdownloadablerelations: !external && layer.hasDowloadableRelations(), //@since 3.11.7
+          filter:                   (is_layer && !['wms', 'wcs', 'wmst'].includes(sourceType)) ? layer.state.filter     : {},
+          selection:                (is_layer && !['wms', 'wcs', 'wmst'].includes(sourceType) && layer.state.selection) || (is_vector && layer.selection) || {},
+          title:                    (is_layer && layer.getTitle()) || (is_vector && layer.get('name')) || (is_string && name && (name.length > 4 ? name.slice(0, name.length - 4).join(' ') : layer)) || undefined,
+          atlas:                    this._atlas.filter(a => a.atlas.qgs_layer_id === id),
+          rawdata:                  rawdata  || null,
+          error:                    error    || '',
+          toc:                      external || layer.state.toc, //@since v3.10.0
+        };
+      });
+    this.setLayersData(layers, options);
+  }
+
+  /**
+   * Setter method called when adding layer and feature for response
+   *
+   * @param layers
+   * @param options
+   * 
+   * @since 4.0.0
+   */
+  setLayersData(layers = [], options = { add: false, update: false }) {
+    if (false === options.add) {
+      // sort layers as Catalog project layers.
+      //external layer always on bottom
+      layers.sort((a, b) => a.external ? 0 : (this._projectLayerIds.indexOf(a.id) > this._projectLayerIds.indexOf(b.id) ? 1 : -1));
+    }
+    // get features from added pick layer in case of a new request query
+    layers.forEach((l, index) => {
+      //@since 3.11.0 check if a result comes from pagination
+      l.filter.pagination = l.filter.pagination || !!(this.state.query.pagination && this.state.query.pagination.counts[index] > l.features.length) ;
+      options.add || options.update ? this.updateLayerResultFeatures(l, options.update) : this.state.layers.push(l)
+    });
+    this.setActionsForLayers(layers, { add: options.add, update: options.update });
+    this.state.changed = true;
+  }
+
+  /**
+   * Add custom component in query result
+   *
+   * @param component
+   * 
+   * @since 4.0.0
+   */
+  addComponent(component) {
+    this.state.components.push(component)
+  }
+
+  /**
+   * @FIXME add description
+   *
+   * @param actions
+   * @param layers
+   * 
+   * @since 4.0.0
+   */
+  addActionsForLayers(actions, layers) {}
+
+  /**
+   * @FIXME add description
+   *
+   * @param element
+   * 
+   * @since 4.0.0
+   */
+  postRender(element) {}
+
+  /**
+   * @FIXME add description
+   * 
+   * @since 4.0.0
+   */
+  closeComponent() {}
+
+  /**
+   * Called when layer result features is changed
+   *
+   * @param layer
+   * 
+   * @since 4.0.0
+   */
+  changeLayerResult(layer) {
+    this.state.layersactions[layer.id].forEach(action => action.change && action.change(layer));  // call if present change method to action
+    // reset layer current actions tools
+    (layer.features || []).forEach((_, idx) => {
+        const tool = this.state.currentactiontools[layer.id];
+        if (undefined === tool) {
+          return;
+        }
+        if (undefined === tool[idx]) {
+          Vue.set(tool, idx, null);
+        }
+        tool[idx] = null;
+      });
+  }
+
+  /**
+   * @FIXME add description
+   * 
+   * @since 4.0.0
+   */
+  activeMapInteraction() {}
+
+  /**
+   * Setter method related to relation table
+   * 
+   * @since 4.0.0
+   */
+  editFeature({layer, feature}={}) {}
+
+  /**
+   * Setter method called when opening/closing feature info data content.
+   *
+   * @param opts.open
+   * @param opts.layer
+   * @param opts.feature
+   * @param opts.container
+   * 
+   * @since 4.0.0
+   */
+  openCloseFeatureResult({open, layer, feature, container}={}) {}
+
+  /**
+   * Remove a feature from current layer result
+   *
+   * @param layer
+   * @param feature
+   * 
+   * @since 4.0.0
+   */
+  removeFeatureLayerFromResult(layer, feature) {
+    this.updateLayerResultFeatures({ id: layer.id, external: layer.external, features: [feature] });
   }
 
   /**


### PR DESCRIPTION
Related to: https://github.com/g3w-suite/g3w-client/issues/92 and https://github.com/g3w-suite/g3w-client/issues/348

## Motivation

Bring code autocompletion for the most common functions, (or at least when you are developing something else within the same JS class).

## Before

```js
this.setters = [
  async setContent(options = {}) {
    // some zilion of rows later..
  }
];
```

## After

```js
this.setters = ['setContent'];
```