### PR TITLE
Remove `"show-plots-relations"` layers action from core

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "datatables.net-dt": "^1.10.16",
     "eonasdan-bootstrap-datetimepicker": "^4.17.49",
     "i18next": "^18.0.1",
+    "invokers-polyfill": "^0.5.5",
     "ismobilejs": "^1.1.1",
     "jquery": "^2.2.1",
     "jsts": "^2.11.3",

--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -598,6 +598,7 @@ table.dataTable th.sorting_desc::after                         { color:#7a80dd; 
   .nav-links > li                                            { color: inherit; border: 0; }
   .nav-links > li > a:not(.nav-user) [hidden]                { display: inline-block; }
   .nav-links > li > a:not(.nav-user)                         { margin: 5px 8px; padding: 10px; border: 1px dashed #fff; display: flex; flex-direction: row; justify-content: left; align-items: center; gap: 8px; }
+  .nav-lang button                                           { width: 100%; }
   .navbar .dropdown-menu li.divider                          { background-color: rgba(255, 255, 255, 0.1); }
   .navbar .dropdown-menu li a                                { color: #fff; }
   .navbar .dropdown-menu li a:hover                          { background: hsl(from var(--skin-color) h s calc(l - 5)); }

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -183,7 +183,7 @@
                 :key      = "lang[0]"
                 style     = "cursor:pointer; text-align: left;"
               >
-                <input type="radio" :value="lang[0]" v-model="language" @change="$event.target.closest('dialog').hidePopover()" style="pointer-events:none;margin-right: 8px;">
+                <input type="radio" :value="lang[0]" v-model="language" @click="$event.target.closest('dialog').close()" style="pointer-events:none;margin-right: 8px;">
                 <img :src="urls.staticurl +'img/flags/' + lang[0].toLowerCase() + '.png'" width="24" height="16" :alt="lang[0].toLowerCase()" />
                 <span style="margin-left: 5px;">{{ lang[1] }}</span> 
               </label>

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -956,28 +956,6 @@ export default {
 };
 </script>
 
-<style>
-  .nav-lang .select2-container--default .select2-selection--single {
-    background: none;
-    border: none;
-  }
-  .nav-lang .select2-container--default .select2-selection--single .select2-selection__arrow b {
-    border-color: #fff transparent transparent transparent
-  }
-  .nav-lang .select2-container--default.select2-container--open .select2-selection--single .select2-selection__arrow b {
-    border-color: transparent transparent #fff transparent;
-  }
-  .nav-lang .select2-container--default .select2-selection--single .select2-selection__rendered {
-    color: #fff !important;
-  }
-  @media (min-width: 768px) {
-    .nav-lang .select2-container {
-      right: 0;
-      left: auto !important;
-    }
-  }
-</style>
-
 <style scoped>
   .project_title     { display: inline-flex; flex-direction: column; justify-content: center; height: 100%; font-weight: bold; color: white; max-height: 50px; overflow: hidden; max-width: calc(100% - 150px); }
   .project_title > * { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-weight: bold; margin: 0; }

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -176,7 +176,7 @@
             {{ languages.find(l => l[0] === language).at(1) }}
             <i class="triangle" style="margin-top: 8px;"></i>
           </button>
-          <dialog id="nav-lang-dialog">
+          <dialog id="nav-lang-dialog" @click="$event.target === $event.target.closest('dialog') && $event.target.closest('dialog').close()">
             <form method="dialog" style=" display: grid;grid-template-columns: repeat(auto-fill, minmax(120px, 1fr)); gap: 10px; user-select: none;">
               <label
                 v-for     = "lang in languages"

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -171,12 +171,12 @@
 
         <!-- LANGUAGE SWITCHER -->
         <li v-if = "languages" class="nav-lang">
-          <button type="button" popovertarget="nav-lang-popover" style="display: flex; gap:5px;">
+          <button type="button" commandfor="nav-lang-dialog" command="show-modal" style="display: flex; gap:5px;">
             <img :src="urls.staticurl +'img/flags/' + language.toLowerCase() + '.png'" width="24" height="16" alt="" />
             {{ languages.find(l => l[0] === language).at(1) }}
             <i class="triangle" style="margin-top: 8px;"></i>
           </button>
-          <dialog id="nav-lang-popover" popover>
+          <dialog id="nav-lang-dialog">
             <form method="dialog" style=" display: grid;grid-template-columns: repeat(auto-fill, minmax(120px, 1fr)); gap: 10px; user-select: none;">
               <label
                 v-for     = "lang in languages"

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -44,6 +44,7 @@
 
         <!-- CUSTOM LINKS -->
         <li
+          :id     = "`g3w-nav-custom-links-${item.id}`"
           v-for  = "item in custom_links"
           :key   = "item.id"
           :style = "{ order: item.position }"
@@ -67,6 +68,7 @@
 
         <!-- ACCOUNT -->
         <li
+          id    = "g3w-nav-account"
           class = "nav-user dropdown"
         >
           <a
@@ -170,7 +172,11 @@
         </li>
 
         <!-- LANGUAGE SWITCHER -->
-        <li v-if = "languages" class="nav-lang">
+        <li 
+          id    = "g3w-nav-language"
+          v-if  = "languages" 
+          class ="nav-lang"
+        >
           <button type="button" commandfor="nav-lang-dialog" command="show-modal" style="display: flex; gap:5px;">
             <img :src="urls.staticurl +'img/flags/' + language.toLowerCase() + '.png'" width="24" height="16" alt="" />
             {{ languages.find(l => l[0] === language).at(1) }}

--- a/src/components/CatalogContextMenu.vue
+++ b/src/components/CatalogContextMenu.vue
@@ -330,14 +330,14 @@
       <a :href = "layers_url" target = "_blank" style = "color: initial">
         <!-- TODO: g3wtemplate.getFontClass('qgis') -->
         <i>
-          <svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 32 32" style="height: 14px; vertical-align: -1.5px; fill: currentColor;">
-            <path d="m17.61 17.63 4.36-.02-4-3.98h-4.36v4l4 4.45z"/>
-            <path d="m31.61 27.22-7.62-7.6-4.38.01v4.33l7.24 7.67h4.76z"/>
-            <path d="M18 25.18c-.68.16-1.17.2-1.9.2a9.77 9.77 0 0 1-9.68-9.88c0-5.57 4.4-9.78 9.68-9.78s9.48 4.2 9.48 9.78c0 .91-.15 1.96-.36 2.8l4.88 4.65a15 15 0 0 0 1.95-7.48C32.05 6.87 25.19.44 16 .44 6.86.44 0 6.84 0 15.47c0 8.68 6.86 15.2 16 15.2 2.36 0 4.23-.3 6.2-1.1L18 25.18z"/>
+          <svg xmlns = "http://www.w3.org/2000/svg" xml:space = "preserve" viewBox = "0 0 32 32" style = "height: 14px; vertical-align: -1.5px; fill: currentColor;">
+            <path d = "m17.61 17.63 4.36-.02-4-3.98h-4.36v4l4 4.45z"/>
+            <path d = "m31.61 27.22-7.62-7.6-4.38.01v4.33l7.24 7.67h4.76z"/>
+            <path d = "M18 25.18c-.68.16-1.17.2-1.9.2a9.77 9.77 0 0 1-9.68-9.88c0-5.57 4.4-9.78 9.68-9.78s9.48 4.2 9.48 9.78c0 .91-.15 1.96-.36 2.8l4.88 4.65a15 15 0 0 0 1.95-7.48C32.05 6.87 25.19.44 16 .44 6.86.44 0 6.84 0 15.47c0 8.68 6.86 15.2 16 15.2 2.36 0 4.23-.3 6.2-1.1L18 25.18z"/>
           </svg>
         </i>
         Layers settings
-        <i :class = "$fa('external-link')" style  = "position: absolute; right: 0; margin-top: 3px"></i>
+        <i :class = "$fa('external-link')" style = "position: absolute; right: 0; margin-top: 3px"></i>
       </a>
     </li>
 
@@ -346,14 +346,14 @@
       <a :href = "edit_url" @click.stop = "closeMenu" target = "_blank" style = "color: initial">
         <!-- TODO: g3wtemplate.getFontClass('qgis') -->
         <i>
-          <svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 32 32" style="height: 14px; vertical-align: -1.5px; fill: currentColor;">
-            <path d="m17.61 17.63 4.36-.02-4-3.98h-4.36v4l4 4.45z"/>
-            <path d="m31.61 27.22-7.62-7.6-4.38.01v4.33l7.24 7.67h4.76z"/>
-            <path d="M18 25.18c-.68.16-1.17.2-1.9.2a9.77 9.77 0 0 1-9.68-9.88c0-5.57 4.4-9.78 9.68-9.78s9.48 4.2 9.48 9.78c0 .91-.15 1.96-.36 2.8l4.88 4.65a15 15 0 0 0 1.95-7.48C32.05 6.87 25.19.44 16 .44 6.86.44 0 6.84 0 15.47c0 8.68 6.86 15.2 16 15.2 2.36 0 4.23-.3 6.2-1.1L18 25.18z"/>
+          <svg xmlns="http://www.w3.org/2000/svg" xml:space = "preserve" viewBox = "0 0 32 32" style = "height: 14px; vertical-align: -1.5px; fill: currentColor;">
+            <path d = "m17.61 17.63 4.36-.02-4-3.98h-4.36v4l4 4.45z"/>
+            <path d = "m31.61 27.22-7.62-7.6-4.38.01v4.33l7.24 7.67h4.76z"/>
+            <path d = "M18 25.18c-.68.16-1.17.2-1.9.2a9.77 9.77 0 0 1-9.68-9.88c0-5.57 4.4-9.78 9.68-9.78s9.48 4.2 9.48 9.78c0 .91-.15 1.96-.36 2.8l4.88 4.65a15 15 0 0 0 1.95-7.48C32.05 6.87 25.19.44 16 .44 6.86.44 0 6.84 0 15.47c0 8.68 6.86 15.2 16 15.2 2.36 0 4.23-.3 6.2-1.1L18 25.18z"/>
           </svg>
         </i>
         Project settings
-        <i :class = "$fa('external-link')" style  = "position: absolute; right: 0; margin-top: 3px"></i>
+        <i :class = "$fa('external-link')" style = "position: absolute; right: 0; margin-top: 3px"></i>
       </a>
   </li>
 
@@ -456,11 +456,11 @@
             }
             e.stopPropagation();
             vnode.context[binding.expression](e);
-          };
-          document.body.addEventListener('click', this.event, true)
+          }
+          document.body.addEventListener('click', this.event, true);
         },
         unbind() {
-          document.body.removeEventListener('click', this.event, true)
+          document.body.removeEventListener('click', this.event, true);
         }
       }
     },
@@ -509,7 +509,7 @@
       },
 
       canShowWmsUrl(layerId) {
-        const layer = getCatalogLayerById(layerId);
+        const layer   = getCatalogLayerById(layerId);
         const wms_url = ApplicationState.project.state.metadata.wms_url;
         return layer && !layer.isType('table') && !!(wms_url && !layer.isExternalWMS()
           ? wms_url
@@ -560,10 +560,10 @@
        * @param { HTMLElement } el
        */
       copyUrl(format, el) {
-        const url = this[`get${format}Url`](this.layer.id);
-        const a = document.createElement('a');
+        const url   = this[`get${format}Url`](this.layer.id);
+        const a     = document.createElement('a');
         const input = document.createElement('input');
-        a.href = url;
+        a.href      = url;
         input.value = a.href;
         document.body.appendChild(input);
         input.select();
@@ -584,7 +584,7 @@
       setLayerPosition(position) {
         if (position !== this.layer.position) {
           this.layer.position = position;
-          const map = GUI.getService('map');
+          const map           = GUI.getService('map');
           map.getLayerById(this.layer.id).setZIndex(({ top: map.layersCount, bottom: 0 })[position]);
           map.emit('change-layer-position-map', { id: this.layer.id, position });
           this.closeMenu();
@@ -650,7 +650,7 @@
       },
 
       getGeometryType(layerId, external=false) {
-        const layer = external ? GUI.getService('catalog').state.external.vector.find(l => l.id === layerId) : getCatalogLayerById(layerId);
+        const layer = external ? GUI.getService('catalog').state.external.vector.find(l => layerId === l.id) : getCatalogLayerById(layerId);
         if (layer) {
           const type = external ? layer.geometryType : layer.config.geometrytype;
           return layer && 'NoGeometry' !== type && type || '';
@@ -675,10 +675,9 @@
       },
 
       setLayerStyle(index) {
-
         this.layer_style = this.layer.styles[index].name;
         //change layer style
-        getCatalogLayerById(this.layer.id).changeCurrentStyle(this.layer_style)
+        getCatalogLayerById(this.layer.id).changeCurrentStyle(this.layer_style);
         this.closeMenu();
       },
 
@@ -692,7 +691,7 @@
       async setLayerFilter(filter) {
         const changed = (
           null === this.layer.filter.current ||
-          this.layer.filter.current.fid !== filter.fid
+          filter.fid !== this.layer.filter.current.fid 
         );
         const layer = getCatalogLayerById(this.layer.id);
         if (changed) {
@@ -720,7 +719,6 @@
         const change = fid === this.layer.fid;
         await layer.deleteFilterToken(fid);
         if (change) { layer.change() }
-
         this.closeMenu();
       },
 
@@ -734,7 +732,7 @@
         const li = e.target.closest('li');
         const ul = li && li.querySelector('ul');
         if (ul) {
-          const overflowY = (ul.offsetHeight + ul.getBoundingClientRect().top) >= (this.$refs['menu'].offsetHeight + this.$refs['menu'].getBoundingClientRect().top);
+          const overflowY    = (ul.offsetHeight + ul.getBoundingClientRect().top) >= (this.$refs['menu'].offsetHeight + this.$refs['menu'].getBoundingClientRect().top);
           ul.style.top       = ul.offsetHeight > this.$refs['menu'].offsetHeight ? 0 : undefined;
           ul.style.left      = this.$refs['menu'].offsetWidth -2 + 'px';
           ul.style.maxHeight = this.$refs['menu'].offsetHeight + 'px';
@@ -755,7 +753,7 @@
        * @since 3.10.0
        */
       isExternalLayer(layer) {
-        return !layer.projectLayer
+        return !layer.projectLayer;
       },
 
       /**

--- a/src/components/ModalLogin.vue
+++ b/src/components/ModalLogin.vue
@@ -41,7 +41,7 @@ export default {
   name: 'modal-login',
   data() {
     return {
-      show: true,
+      show: false,
     }
   },
 
@@ -64,6 +64,11 @@ export default {
     },
 
   },
+
+  async mounted() {
+    await this.$nextTick();
+    this.show = true;
+  }
 
 };
 </script>

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -698,6 +698,7 @@
         return (
           GUI.getService('queryresults').getActionLayerById({ layer, id: 'selection' })
           && (!this.canPaginate(layer) || (layer.selection.active && layer.filter.active))
+          && layer.features.length > 1
         );
       },
 

--- a/src/components/QueryResultsAction.vue
+++ b/src/components/QueryResultsAction.vue
@@ -76,7 +76,7 @@
     },
     beforeDestroy() {
       if (typeof this.action.clear === 'function') {
-        this.action.clear({ layer: this.layer, feature: this.feature });
+        this.action.clear({ action: this.action, layer: this.layer, feature: this.feature });
       }
     }
   }

--- a/src/components/Relation.vue
+++ b/src/components/Relation.vue
@@ -645,6 +645,10 @@
         this.$table.destroy();
         this.$table = null;
       }
+      //In case of chart open, need to hide chart
+      if (this.chart.toggled) {
+         GUI.getService('queryresults').hideChart(this.chart.container);
+      }
       if (this.chart.container) {
         this.$emit('hide-chart', this.chart.container);
         this.chart.container = null;

--- a/src/directives/v-select2.js
+++ b/src/directives/v-select2.js
@@ -3,8 +3,10 @@
  * @since v3.7
  */
 
-import ApplicationState   from 'store/application';
-import { watch, unwatch } from 'directives/utils';
+import ApplicationState    from 'store/application';
+import { watch, unwatch }  from 'directives/utils';
+import { languageIsReady } from 'g3w-i18n';
+
 
 const attr = 'g3w-v-select2-id';
 
@@ -125,7 +127,10 @@ export default {
       attr,
       watcher: [
         () => ApplicationState.language,
-        () => createSelect2()
+        async (lang) => {
+          await languageIsReady(lang);
+          createSelect2();
+        }
       ],
       immediate: false,
     });

--- a/src/directives/v-t-html.js
+++ b/src/directives/v-t-html.js
@@ -3,9 +3,10 @@
  * @since v3.7
  */
 
-import ApplicationState   from 'store/application';
-import { watch, unwatch } from 'directives/utils';
-import { t }              from 'g3w-i18n';
+import ApplicationState       from 'store/application';
+import { watch, unwatch }     from 'directives/utils';
+import { t, languageIsReady } from 'g3w-i18n';
+
 
 const attr = 'g3w-v-t-html-id';
 
@@ -16,7 +17,7 @@ export default {
       attr,
       watcher: [
         () => ApplicationState.language,
-        () => { el.innerHTML = `${t(binding.value)}`; }
+        async (lang) => { await languageIsReady(lang); el.innerHTML = `${t(binding.value)}`; }
       ]
     });
   },

--- a/src/directives/v-t-plugin.js
+++ b/src/directives/v-t-plugin.js
@@ -3,9 +3,9 @@
  * @since v3.7
  */
 
-import ApplicationState   from 'store/application';
-import { watch, unwatch } from 'directives/utils';
-import { tPlugin }        from 'g3w-i18n';
+import ApplicationState             from 'store/application';
+import { watch, unwatch }           from 'directives/utils';
+import { tPlugin, languageIsReady } from 'g3w-i18n';
 
 const attr = 'g3w-v-t-plugin-id';
 
@@ -17,8 +17,9 @@ export default {
       attr,
       watcher: [
         () => ApplicationState.language,
-        () => {
-          const value = null !== binding.value ? tPlugin(binding.value) : '';
+        async (lang) => {
+          await languageIsReady(lang);
+          const value = null === binding.value ? '' : tPlugin(binding.value);
           switch(binding.arg ? binding.arg : 'post') {
             case 'pre':  el.innerHTML = `${value} ${innerHTML}`; break;
             case 'post': el.innerHTML = `${innerHTML} ${value}`; break;

--- a/src/directives/v-t-tooltip.js
+++ b/src/directives/v-t-tooltip.js
@@ -3,9 +3,9 @@
  * @since v3.7
  */
 
-import ApplicationState            from 'store/application';
-import { watch, unwatch, trigger } from 'directives/utils';
-import { t, tPlugin }              from 'g3w-i18n';
+import ApplicationState                 from 'store/application';
+import { watch, unwatch, trigger }      from 'directives/utils';
+import { t, tPlugin , languageIsReady } from 'g3w-i18n';
 
 const attr = 'g3w-v-t-tooltip-id';
 
@@ -40,7 +40,8 @@ export default {
       attr,
       watcher: [
         () => ApplicationState.language,
-        ({el = _el}) => {
+        async ({ el = _el }) => {
+          await languageIsReady(ApplicationState.language);
           let value = el.getAttribute('current-tooltip');
           if (null === value) { value = binding.value; }
           el.setAttribute('data-original-title', binding.modifiers.text ? value : ('plugin' === binding.arg ? tPlugin : t)(value));

--- a/src/directives/v-t.js
+++ b/src/directives/v-t.js
@@ -5,7 +5,6 @@
 
 import ApplicationState       from 'store/application';
 import { watch, unwatch }     from 'directives/utils';
-import { waitFor }            from 'utils/waitFor';
 import { t, languageIsReady } from 'g3w-i18n';
 
 const attr = 'g3w-v-t-id';
@@ -30,6 +29,7 @@ export default {
     el.__innerHTML = el.innerHTML;
     //set current binging
     el.__currentBinding = binding;
+    handleInnerHTML({ el });
     watch({
       el,
       attr,

--- a/src/directives/v-t.js
+++ b/src/directives/v-t.js
@@ -3,9 +3,10 @@
  * @since v3.7
  */
 
-import ApplicationState   from 'store/application';
-import { watch, unwatch } from 'directives/utils';
-import { t }              from 'g3w-i18n';
+import ApplicationState       from 'store/application';
+import { watch, unwatch }     from 'directives/utils';
+import { waitFor }            from 'utils/waitFor';
+import { t, languageIsReady } from 'g3w-i18n';
 
 const attr = 'g3w-v-t-id';
 
@@ -34,7 +35,11 @@ export default {
       attr,
       watcher: [
         () => ApplicationState.language,
-        () => handleInnerHTML({ el })
+        async lang => {
+          //need to wait language set plugins and core client
+          await languageIsReady(lang);
+          handleInnerHTML({ el });
+        }
       ]
     });
   },

--- a/src/g3w-component.js
+++ b/src/g3w-component.js
@@ -304,12 +304,14 @@ export default class Component extends G3WObject {
    * @fires internalComponent~resize-component
    * @fires layout
    */
-  layout(width, height) {
+  async layout(width, height) {
     if (this.state.resizable && this._firstLayout) {
       this.internalComponent.$on('resize-component', this.internalComponent.layout);
       this._firstLayout = false;
     }
-    this.internalComponent.$nextTick(() => { this.internalComponent.$emit('resize-component', { width, height }); });
+    await this.internalComponent.$nextTick();
+    //need to check if internal component exist becouse wehn unmount, internalcomponent is set to nul
+    this.internalComponent?.$emit('resize-component', { width, height });
     this.emit('layout');
   }
 

--- a/src/g3w-i18n.js
+++ b/src/g3w-i18n.js
@@ -1,4 +1,6 @@
 import ApplicationState from 'store/application';
+import { waitFor }      from 'utils/waitFor';
+
 
 export const i18next = require('i18next');
 
@@ -30,10 +32,23 @@ export const addI18nPlugin = ({ name, config }) =>  {
   }
 };
 
+/**
+ * @since 4.0.0 check if bundle resource language is ready
+ * @param { String } lang 
+ */
+export const languageIsReady = async (lang) => {
+  await waitFor(() => {
+    const resources = i18next.getResourceBundle(lang);
+    //Check if ready client translation and all pluglins are ready
+    return Object.keys(resources).length > 1 && Object.keys(initConfig.plugins).length === Object.keys(resources.plugins).length;
+  })
+}
+
 export default {
   getAppLanguage,
   t,
   tPlugin,
   addI18n,
   addI18nPlugin,
+  languageIsReady,
 };

--- a/src/g3w-vendors.js
+++ b/src/g3w-vendors.js
@@ -5,6 +5,7 @@
 
 // polyfills
 import '@ungap/with-resolvers';
+import 'invokers-polyfill';
 
 import * as ol              from 'ol';
 import * as array           from 'ol/array';

--- a/src/index.prod.js
+++ b/src/index.prod.js
@@ -273,7 +273,8 @@ $.ajaxSetup({
   i18next
     .init({
         lng:         initConfig.user.i18n,
-        ns:          'app',
+        ns:          'translation',
+        partialBundledLanguages: true,
         fallbackLng: 'en',
         resources:    {
           en:                     (await import(`${initConfig.urls.clienturl}locales/en.js`)).default,
@@ -283,18 +284,18 @@ $.ajaxSetup({
 
   addI18n(ApplicationState.i18n.plugins);
 
-  (new Vue).$watch(() => ApplicationState.language, async () => {
+  (new Vue).$watch(() => ApplicationState.language, async (lang) => {
 
     // lazy load i18n translations
     try {
       i18next.addResourceBundle(
-        ApplicationState.language,
+        lang,
         'translation',
-        (await import(`${initConfig.urls.clienturl}locales/${ApplicationState.language}.js`)).default,
+        (await import(`${initConfig.urls.clienturl}locales/${lang}.js`)).default?.translation,
         false,
         true
       );
-    } catch (e) {
+    } catch(e) {
       GUI.showUserMessage({ type: 'warning', message: e.toString(), autoclose: true });
     }
 

--- a/src/map/controls/geocoding.js
+++ b/src/map/controls/geocoding.js
@@ -19,7 +19,7 @@ import { addZValue }                  from 'utils/addZValue';
 import { convertSingleMultiGeometry } from 'utils/convertSingleMultiGeometry';
 import { getCatalogLayerById }        from 'utils/getCatalogLayerById';
 import { debounce }                   from 'utils/debounce';
-import { t }                          from 'g3w-i18n';
+import { t, languageIsReady }         from 'g3w-i18n';
 
 /**
  * Provider definitions.
@@ -126,7 +126,8 @@ class GeocodingControl extends ol.control.Control {
     const queryresults = GUI.getService('queryresults');
     const VM           = new Vue;
   
-    VM.$watch(() => ApplicationState.language, () => {
+    VM.$watch(() => ApplicationState.language, async (lang) => {
+      await languageIsReady(lang);
       this.element.querySelector('ul').innerHTML = '';
       this.element.querySelector('input[type="search"]').placeholder = t('mapcontrols.geocoding.placeholder');
     }, { immediate: true });

--- a/src/map/controls/zoomhistory.js
+++ b/src/map/controls/zoomhistory.js
@@ -3,9 +3,10 @@
  * @since 4.0.0
  */
 
-import ApplicationState                     from 'store/application';
-import GUI                                  from 'services/gui';
-import { debounce }                         from 'utils/debounce';
+import ApplicationState    from 'store/application';
+import GUI                 from 'services/gui';
+import { debounce }        from 'utils/debounce';
+import { languageIsReady } from 'g3w-i18n';
 
 // wait for map ready
 GUI.once('ready', async () => {
@@ -30,7 +31,15 @@ GUI.once('ready', async () => {
               <div><button type="button" value="last" class="fas fa-reply g3w-disabled" style="font-weight: 900;"></button></div>
               <div><button type="button" value="next" class="fas fa-share g3w-disabled" style="font-weight: 900;"></button></div>
             `;
-            (new Vue).$watch(() => ApplicationState.language, () => this.element.querySelectorAll('button').forEach(btn => btn.parentElement.title = btn.parentElement.dataset.originalTitle = g3wsdk.core.i18n.t('last' === btn.value ? 'sdk.mapcontrols.zoomhistory.zoom_last' : 'sdk.mapcontrols.zoomhistory.zoom_next')), { immediate: true });
+            (new Vue).$watch(
+              () => ApplicationState.language, 
+              async (lang) => { 
+                await languageIsReady(lang); 
+                this.element.querySelectorAll('button')
+                  .forEach(btn => btn.parentElement.title = btn.parentElement.dataset.originalTitle = g3wsdk.core.i18n.t('last' === btn.value ? 'sdk.mapcontrols.zoomhistory.zoom_last' : 'sdk.mapcontrols.zoomhistory.zoom_next'))
+                }, 
+              { immediate: true } 
+            );
             this.element.querySelectorAll('button').forEach(btn => {
               $(btn.parentElement).tooltip({ placement: 'top', container: 'body' });
               btn.addEventListener('click', e => {

--- a/src/map/layers/layer.js
+++ b/src/map/layers/layer.js
@@ -1371,7 +1371,7 @@ class Layer extends G3WObject {
           filtertoken = response.data.filtertoken;
         }
       } catch(e) {
-        console.warn(e)
+        console.warn(e);
       }
 
       // remove it from filters list when deleting a saved filter (since v3.9.0)
@@ -2583,7 +2583,7 @@ class Layer extends G3WObject {
         //set as current the style passed
         this.config.styles.forEach(s => s.current = style === s.name);
         //In case of change need to call change function
-        this.change() 
+        this.change();
       } catch(e) {
         console.warn(e);    
       }

--- a/src/services/gui.js
+++ b/src/services/gui.js
@@ -634,10 +634,10 @@ export default new (class GUI extends G3WObject {
   }
 
   //  (100%) content
-  showContent(options = {}) {
+  async showContent(options = {}) {
     this.setLoadingContent(false);
     options.perc = isMobile.any ? 100 : options.perc;
-    this.setContent(options);
+    await this.setContent(options);
     return true;
   }
 
@@ -646,10 +646,10 @@ export default new (class GUI extends G3WObject {
   //  - push every component is added, set is refreshed
   //  - pushContent has a new parameter (backonclose) when is clicked x
   //  - the contentComponent is close all stacks are closed
-  pushContent(options = {}) {
+  async pushContent(options = {}) {
     options.perc = isMobile.any ? 100 : options.perc;
     options.push = true;
-    this.setContent(options);
+    await this.setContent(options);
   }
 
   //return number of a component of stack
@@ -819,7 +819,7 @@ export default new (class GUI extends G3WObject {
 
     contents.setOpen(true);
 
-    this._layout(true);
+    await this._layout(true);
   }
 
   // hide content
@@ -1077,7 +1077,7 @@ export default new (class GUI extends G3WObject {
    * 
    * ORIGINAL SOURCE: src/services/viewport.js@v3.10.2
    */
-  _layout(param) {
+  async _layout(param) {
 
     // whether to show secondary (content)
     if ('boolean' === typeof param) {
@@ -1126,26 +1126,25 @@ export default new (class GUI extends G3WObject {
     });
 
     // resize "content" (after vue state is updated)
-    Vue.nextTick().then(() => {
+    await Vue.nextTick();
 
-      // resize "map"
-      this.getService('map').layout({
-        width:  state.map.sizes.width,
-        height: state.map.sizes.height
-      });
-
-      ApplicationState.contentsdata.forEach(d => {                           // re-layout each component stored into the stack
-        try {
-          if ('function' == typeof d.content.layout) {
-            d.content.layout(state.content.sizes.width, contents.style.height.replace('px',''));
-          }
-        } catch (e) {
-          this.showUserMessage({ type: 'warning', message: e.toString(), autoclose: true });
-          setTimeout(() => this._layout(), 1000);
-        }
-      });
+    // resize "map"
+    this.getService('map').layout({
+      width:  state.map.sizes.width,
+      height: state.map.sizes.height
     });
 
+    ApplicationState.contentsdata.forEach(d => {                           // re-layout each component stored into the stack
+      try {
+        if ('function' == typeof d.content.layout) {
+          d.content.layout(state.content.sizes.width, contents.style.height.replace('px',''));
+        }
+      } catch(e) {
+        this.showUserMessage({ type: 'warning', message: e.toString(), autoclose: true });
+        setTimeout(() => this._layout(), 1000);
+      }
+    });
+    
     this.emit('resize');
 
     window.localStorage.setItem('SIDEBAR', JSON.stringify(panel));

--- a/src/services/gui.js
+++ b/src/services/gui.js
@@ -889,7 +889,7 @@ export default new (class GUI extends G3WObject {
     if (content instanceof Component || content instanceof Panel) {
       await promisify(content.unmount());
     } else {
-      $(this.getComponent('contents').parent).empty();
+      content.remove();
     }
 
     ApplicationState.contentsdata.pop();

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -759,8 +759,6 @@ export default new (class QueryResultsService extends G3WObject {
       this.state.currentactiontools[layer.id]        = Vue.observable({ ...Array((layer.features || []).length).fill(null) });
       this.state.currentactionfeaturelayer[layer.id] = Vue.observable({ ...Array((layer.features || []).length).fill(null) });
       this.state.layersactions[layer.id]             = this.state.layersactions[layer.id] || [];
-      const relations        = (this._relations[layer.id] || []).filter(r => 'MANY' === r.type);
-      const chartRelationIds = relations.map(r => this.plotLayerIds.find(id => id === r.referencingLayer)).filter(Boolean);
 
       this.state.layersactions[layer.id].push(...([
 
@@ -774,7 +772,7 @@ export default new (class QueryResultsService extends G3WObject {
         },
 
         // show relations (query)
-        relations.length && {
+        (this._relations[layer.id] || []).some(r => 'MANY' === r.type) && {
           id:       'show-query-relations',
           class:    GUI.getFontClass('relation'),
           hint:     'sdk.mapcontrols.query.actions.relations.hint',
@@ -784,7 +782,7 @@ export default new (class QueryResultsService extends G3WObject {
               content: new Component({
                 internalComponent: new (Vue.extend(require('components/RelationsPage.vue').default))({
                   relations:        action.relations,
-                  chartRelationIds: action.chartRelationIds,
+                  chartRelationIds: action.relations.map(r => GUI.getService('queryresults').plotLayerIds.find(id => id === r.referencingLayer)).filter(Boolean),
                   feature,
                   layer,
                 })
@@ -799,29 +797,7 @@ export default new (class QueryResultsService extends G3WObject {
               closable: false
             });
           },
-          relations,
-          chartRelationIds
-        },
-
-        // show relations (plot)
-        chartRelationIds.length && {
-          id:       'show-plots-relations',
-          opened:   true,
-          class:    GUI.getFontClass('chart'),
-          state:    Vue.observable({ toggled: layer.features.reduce((a, _ , i ) => { a[i] = null; return a; }, {}) }),
-          hint:     'sdk.mapcontrols.query.actions.relations_charts.hint',
-          cbk: throttle((layer, feature, action, index, container) => {
-            action.state.toggled[index] = !action.state.toggled[index];
-            if (action.state.toggled[index]) {
-              this.emit('show-chart', chartRelationIds, container, {
-                relations: this._relations[layer.id],
-                fid:       feature.attributes[G3W_FID],
-                height:    400
-              });
-            } else {
-              this.hideChart(container);
-            }
-          }),
+          relations: (this._relations[layer.id] || []).filter(r => 'MANY' === r.type),
         },
 
         // print (atlas)

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -1172,8 +1172,6 @@ export default new (class QueryResultsService extends G3WObject {
     this.state.query               = null;
     this.state.querytitle          = "";
     this.state.changed             = false;
-    // clear actions
-    Object.values(this.state.layersactions).forEach(l => l.forEach(a => a.clear && a.clear()));
     this.state.layersactions       = {};
     this.state.actiontools         = {};
     this.state.layeractiontool     = {};


### PR DESCRIPTION
## Depends on: https://github.com/g3w-suite/g3w-admin/pull/1134

## Motivation

Since **g3w-admin@v3.11.0** qplotly plugin is converted into from a [dedicated repo](https://github.com/g3w-suite/g3w-client-plugin-qplotly) into a ["static" plugin.js](https://github.com/g3w-suite/g3w-admin/pull/1134) file.

 
## Changes

No much changes in here, essentially it removes the following from core:

```js
// show relations (plot)
chartRelationIds.length && {
  id:       'show-plots-relations',
  opened:   true,
  class:    GUI.getFontClass('chart'),
  state:    Vue.observable({ toggled: layer.features.reduce((a, _ , i ) => { a[i] = null; return a; }, {}) }),
  hint:     'sdk.mapcontrols.query.actions.relations_charts.hint',
  cbk: throttle((layer, feature, action, index, container) => {
  action.state.toggled[index] = !action.state.toggled[index];
    if (action.state.toggled[index]) {
      this.emit('show-chart', chartRelationIds, container, {
        relations: this._relations[layer.id],
        fid:       feature.attributes[G3W_FID],
        height:    400
      });
     } else {
       this.hideChart(container);
      }
    }),
```