### PR TITLE
Simplify mobile menu (top/left sidebar)

### DIFF
--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -705,9 +705,11 @@ table.dataTable th.sorting_desc::after                         { color:#7a80dd; 
   .sidebar-open .nav-links                                    { --bgcolor: #212c31; background-color: var(--bgcolor)!important; flex-direction: column !important; }
   .sidebar-open :is(.project_title, .main-sidebar)            { position: relative !important; inset: 0 !important; }
   .sidebar-open, .sidebar-open .wrapper                       { overflow-y: visible; }
-  .sidebar-open :is(.g3w-sidebarpanel, .main-sidebar, .content-wrapper)         { height: auto !important; }
+  .sidebar-open:has(#g3w-sidebarcomponents:not([hidden])) .g3w-sidebarpanel:not([hidden]),
+  .sidebar-open :is(.main-sidebar, .content-wrapper)          { height: auto !important; }
   .sidebar-open .navbar                                       { display: block !important; height: auto !important; }
-  .sidebar-open .nav-links :is(.nav-changemap, .nav-addlayer) { display: none !important; }
+  .sidebar-open .nav-links :is(.nav-changemap, .nav-addlayer),
+  .sidebar-open:has(#g3w-sidebarcomponents[hidden]) .nav-links { display: none !important; }
 }
 
 

--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -705,13 +705,14 @@ table.dataTable th.sorting_desc::after                         { color:#7a80dd; 
 
 /** mobile menu */
 @media (max-width: 767px) {
-  .navbar-toggler                                     { color: #fff; margin: 12px; font-size: 1.3em; position: absolute; z-index: 101; right: 0; top: 0; display: block; border: 0;background: none;}
-  .sidebar-open .nav-links                            { --bgcolor: #212c31; background-color: var(--bgcolor)!important; flex-direction: column !important; }
-  .sidebar-open :is(.project_title, .main-sidebar)    { position: relative !important; inset: 0 !important; }
-  .sidebar-open, .sidebar-open .wrapper               { overflow-y: visible; }
-  .sidebar-open :is(.g3w-sidebarpanel, .main-sidebar) { height: auto !important; }
-  .sidebar-open .content-wrapper                      { display: none; }
-  .sidebar-open .navbar                               { display: block !important; height: auto !important; }
+  .navbar-toggler                                             { color: #fff; margin: 12px; font-size: 1.3em; position: absolute; z-index: 101; right: 0; top: 0; display: block; border: 0;background: none;}
+  .sidebar-open .nav-links                                    { --bgcolor: #212c31; background-color: var(--bgcolor)!important; flex-direction: column !important; }
+  .sidebar-open :is(.project_title, .main-sidebar)            { position: relative !important; inset: 0 !important; }
+  .sidebar-open, .sidebar-open .wrapper                       { overflow-y: visible; }
+  .sidebar-open :is(.g3w-sidebarpanel, .main-sidebar)         { height: auto !important; }
+  .sidebar-open .content-wrapper                              { display: none; }
+  .sidebar-open .navbar                                       { display: block !important; height: auto !important; }
+  .sidebar-open .nav-links :is(.nav-changemap, .nav-addlayer) { display: none !important; }
 }
 
 

--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -706,7 +706,7 @@ table.dataTable th.sorting_desc::after                         { color:#7a80dd; 
 /** mobile menu */
 @media (max-width: 767px) {
   .navbar-toggler                                     { color: #fff; margin: 12px; font-size: 1.3em; position: absolute; z-index: 101; right: 0; top: 0; display: block; border: 0;background: none;}
-  .sidebar-open .nav-links                            { --bgcolor: #212c31; background-color: var(--bgcolor)!important; flex-direction: column !important; border-top: 1px solid #fff !important; }
+  .sidebar-open .nav-links                            { --bgcolor: #212c31; background-color: var(--bgcolor)!important; flex-direction: column !important; }
   .sidebar-open :is(.project_title, .main-sidebar)    { position: relative !important; inset: 0 !important; }
   .sidebar-open, .sidebar-open .wrapper               { overflow-y: visible; }
   .sidebar-open :is(.g3w-sidebarpanel, .main-sidebar) { height: auto !important; }

--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -230,6 +230,10 @@ button.close                { padding: 0; cursor: pointer; background: transpare
   .sidebar-collapse .content-wrapper { margin-left: 0; }
 }
 
+@media (max-width: 767px) { 
+ #g3w-sidebarcomponents { margin-top: 50px; }
+}
+
 /**************************************************************************************
 * boxes.less
 **************************************************************************************/
@@ -681,7 +685,10 @@ table.dataTable th.sorting_desc::after                         { color:#7a80dd; 
 /** Add "sidebar-mini" class to the body tag to activate this feature */
 
 @media (max-width: 767px) {
-  a.sidebar-aside-toggle                          { display: none !important; }
+  a.sidebar-aside-toggle {
+    display: block !important;
+    left: 0;
+  }  
   .main-sidebar                                   { left: -100%; width: 100%; }
   .sidebar-open .main-sidebar                     { left: 0; }
 }
@@ -699,7 +706,7 @@ table.dataTable th.sorting_desc::after                         { color:#7a80dd; 
 .sidebar-mini.sidebar-collapse #catalog > *                                                   { display: none; }
 .sidebar-mini.sidebar-collapse #catalog > a                                                   { display: block !important; }
 .sidebar-mini.sidebar-collapse #g3w-sidebarcomponents                                         { padding-top: 50px; overflow: hidden; }
-.sidebar-mini.sidebar-collapse .ol-geocoder                                                   { left: 10px; }
+.sidebar-mini.sidebar-collapse .ol-geocoder                                                   { margin-left: 40px; }
 .sidebar-mini.sidebar-collapse .main-sidebar ul.sidebar-menu > li a span.treeview-label       { color:  transparent; }
 .sidebar-mini.sidebar-collapse .main-sidebar                                                  { overflow-y: hidden; }
 

--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -222,7 +222,7 @@ button.close                { padding: 0; cursor: pointer; background: transpare
 /* When opening the sidebar on small screens */
 @media (max-width: 767px) {
   .content-wrapper               { margin-left: 0; }
-  .sidebar-open .content-wrapper { transform: translate(var(--sidebar-width), 0); }
+  .sidebar-open .content-wrapper { --sidebar-width: 0; transform: translate(var(--sidebar-width), 0); position: absolute; inset: 0; z-index: -1;}
 }
 
 /* When opening the sidebar on large screens */
@@ -519,10 +519,6 @@ table.dataTable th.sorting_desc::after                         { color:#7a80dd; 
 .modal-footer button                      { font-weight: bold; min-width: 70px; }
 
 
-@media (max-width: 767px) {
-  .sidebar-open .content-wrapper        { transform: translate(300px,0); }
-}
-
 .tooltip                             { position: absolute; z-index: 1070; display: block; font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; font-style: normal; font-weight: 400; line-height: 1.42857143; line-break: auto; text-align: left; text-align: start; text-decoration: none; text-shadow: none; text-transform: none; letter-spacing: normal; word-break: normal; word-spacing: normal; word-wrap: normal; white-space: normal; font-size: 12px; opacity: 0; }
 .tooltip.in                          { opacity: 0.9; }
 .tooltip.top                         { padding: 5px 0; margin-top: -3px; }
@@ -709,8 +705,7 @@ table.dataTable th.sorting_desc::after                         { color:#7a80dd; 
   .sidebar-open .nav-links                                    { --bgcolor: #212c31; background-color: var(--bgcolor)!important; flex-direction: column !important; }
   .sidebar-open :is(.project_title, .main-sidebar)            { position: relative !important; inset: 0 !important; }
   .sidebar-open, .sidebar-open .wrapper                       { overflow-y: visible; }
-  .sidebar-open :is(.g3w-sidebarpanel, .main-sidebar)         { height: auto !important; }
-  .sidebar-open .content-wrapper                              { display: none; }
+  .sidebar-open :is(.g3w-sidebarpanel, .main-sidebar, .content-wrapper)         { height: auto !important; }
   .sidebar-open .navbar                                       { display: block !important; height: auto !important; }
   .sidebar-open .nav-links :is(.nav-changemap, .nav-addlayer) { display: none !important; }
 }

--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -230,10 +230,6 @@ button.close                { padding: 0; cursor: pointer; background: transpare
   .sidebar-collapse .content-wrapper { margin-left: 0; }
 }
 
-@media (max-width: 767px) { 
- #g3w-sidebarcomponents { margin-top: 50px; }
-}
-
 /**************************************************************************************
 * boxes.less
 **************************************************************************************/
@@ -685,10 +681,7 @@ table.dataTable th.sorting_desc::after                         { color:#7a80dd; 
 /** Add "sidebar-mini" class to the body tag to activate this feature */
 
 @media (max-width: 767px) {
-  a.sidebar-aside-toggle {
-    display: block !important;
-    left: 0;
-  }  
+  a.sidebar-aside-toggle                          { display: none !important; }  
   .main-sidebar                                   { left: -100%; width: 100%; }
   .sidebar-open .main-sidebar                     { left: 0; }
 }
@@ -706,9 +699,23 @@ table.dataTable th.sorting_desc::after                         { color:#7a80dd; 
 .sidebar-mini.sidebar-collapse #catalog > *                                                   { display: none; }
 .sidebar-mini.sidebar-collapse #catalog > a                                                   { display: block !important; }
 .sidebar-mini.sidebar-collapse #g3w-sidebarcomponents                                         { padding-top: 50px; overflow: hidden; }
-.sidebar-mini.sidebar-collapse .ol-geocoder                                                   { margin-left: 40px; }
+.sidebar-mini.sidebar-collapse .ol-geocoder                                                   { margin-left: 10px; }
 .sidebar-mini.sidebar-collapse .main-sidebar ul.sidebar-menu > li a span.treeview-label       { color:  transparent; }
 .sidebar-mini.sidebar-collapse .main-sidebar                                                  { overflow-y: hidden; }
+
+/** mobile menu */
+@media (max-width: 767px) {
+  .navbar-toggler                                                       { position: absolute; right: 0; top: 0; }
+  #menu-toggler:checked ~ ul                                            { --bgcolor: #212c31; background-color: var(--bgcolor)!important; }
+  #menu-toggler:checked ~ :is(hgroup, ul),
+  body:has(#menu-toggler:checked) .main-sidebar                         { position: relative !important; inset: 0 !important; }
+  body:has(#menu-toggler:checked),
+  body:has(#menu-toggler:checked) .wrapper                              { overflow-y: visible; }
+  body:has(#menu-toggler:checked) :is(.g3w-sidebarpanel, .main-sidebar) { height: auto !important; }
+  body:has(#menu-toggler:checked) .content-wrapper                      { display: none; }
+  body:has(#menu-toggler:checked) .navbar                               { display: block !important; height: auto !important; }
+}
+
 
 /**************************************************************************************
  * 5. Viewport
@@ -1304,6 +1311,7 @@ body .tooltip .tooltip-inner                                              { max-
 .catalog-context-menu .sub-contex-menu { border: 1px solid #eee; border-left: 0; }
 
 .tooltip .tooltip-inner             { font-weight: 700; font-size: 1.25rem; padding: 8px; background-color: #222; }
+
 
 /**************************************************************************************
  * 15. Print

--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -701,15 +701,23 @@ table.dataTable th.sorting_desc::after                         { color:#7a80dd; 
 
 /** mobile menu */
 @media (max-width: 767px) {
-  .navbar-toggler                                             { color: #fff; margin: 12px; font-size: 1.3em; position: absolute; z-index: 101; right: 0; top: 0; display: block; border: 0;background: none;}
+  .navbar-toggler                                             { color: #fff; padding: 12px; font-size: 1.3em; position: absolute; z-index: 101; right: 0; top: 0; display: block; border: 0;background: none;}
+  .sidebar-open .navbar-toggler                               { position: fixed; }
   .sidebar-open .nav-links                                    { --bgcolor: #212c31; background-color: var(--bgcolor)!important; flex-direction: column !important; }
-  .sidebar-open :is(.project_title, .main-sidebar)            { position: relative !important; inset: 0 !important; }
+  .sidebar-open .project_title                                { position: fixed !important; inset: 0 !important; background-color: var(--skin-color); padding-left: 4px; max-width: unset !important; z-index: 2; }
+  .sidebar-open .main-sidebar                                 { position: relative !important; inset: 0 !important; }
   .sidebar-open, .sidebar-open .wrapper                       { overflow-y: visible; }
   .sidebar-open:has(#g3w-sidebarcomponents:not([hidden])) .g3w-sidebarpanel:not([hidden]),
   .sidebar-open :is(.main-sidebar, .content-wrapper)          { height: auto !important; }
   .sidebar-open .navbar                                       { display: block !important; height: auto !important; }
   .sidebar-open .nav-links :is(.nav-changemap, .nav-addlayer),
   .sidebar-open:has(#g3w-sidebarcomponents[hidden]) .nav-links { display: none !important; }
+}
+
+/** handle scrollbars width (desktop small) */
+@media (max-width: 767px) and (pointer: fine) {
+  .sidebar-open .navbar-toggler { right: 18px; }
+  .sidebar-open .project_title  { max-width: calc( 100% - 18px)!important; }
 }
 
 

--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -699,7 +699,7 @@ table.dataTable th.sorting_desc::after                         { color:#7a80dd; 
 .sidebar-mini.sidebar-collapse #catalog > *                                                   { display: none; }
 .sidebar-mini.sidebar-collapse #catalog > a                                                   { display: block !important; }
 .sidebar-mini.sidebar-collapse #g3w-sidebarcomponents                                         { padding-top: 50px; overflow: hidden; }
-.sidebar-mini.sidebar-collapse .ol-geocoder                                                   { margin-left: 10px; }
+.sidebar-mini.sidebar-collapse .ol-geocoder                                                   { margin-left: 5px; }
 .sidebar-mini.sidebar-collapse .main-sidebar ul.sidebar-menu > li a span.treeview-label       { color:  transparent; }
 .sidebar-mini.sidebar-collapse .main-sidebar                                                  { overflow-y: hidden; }
 

--- a/src/assets/app.css
+++ b/src/assets/app.css
@@ -705,15 +705,13 @@ table.dataTable th.sorting_desc::after                         { color:#7a80dd; 
 
 /** mobile menu */
 @media (max-width: 767px) {
-  .navbar-toggler                                                       { position: absolute; right: 0; top: 0; }
-  #menu-toggler:checked ~ ul                                            { --bgcolor: #212c31; background-color: var(--bgcolor)!important; }
-  #menu-toggler:checked ~ :is(hgroup, ul),
-  body:has(#menu-toggler:checked) .main-sidebar                         { position: relative !important; inset: 0 !important; }
-  body:has(#menu-toggler:checked),
-  body:has(#menu-toggler:checked) .wrapper                              { overflow-y: visible; }
-  body:has(#menu-toggler:checked) :is(.g3w-sidebarpanel, .main-sidebar) { height: auto !important; }
-  body:has(#menu-toggler:checked) .content-wrapper                      { display: none; }
-  body:has(#menu-toggler:checked) .navbar                               { display: block !important; height: auto !important; }
+  .navbar-toggler                                     { color: #fff; margin: 12px; font-size: 1.3em; position: absolute; z-index: 101; right: 0; top: 0; display: block; border: 0;background: none;}
+  .sidebar-open .nav-links                            { --bgcolor: #212c31; background-color: var(--bgcolor)!important; flex-direction: column !important; border-top: 1px solid #fff !important; }
+  .sidebar-open :is(.project_title, .main-sidebar)    { position: relative !important; inset: 0 !important; }
+  .sidebar-open, .sidebar-open .wrapper               { overflow-y: visible; }
+  .sidebar-open :is(.g3w-sidebarpanel, .main-sidebar) { height: auto !important; }
+  .sidebar-open .content-wrapper                      { display: none; }
+  .sidebar-open .navbar                               { display: block !important; height: auto !important; }
 }
 
 

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -199,8 +199,8 @@
         <div id="disable-sidebar"></div>
 
         <div
-          v-show = "panels.length > 0"
-          class = "g3w-sidebarpanel"
+          :hidden = "panels.length <= 0"
+          class   = "g3w-sidebarpanel"
         >
           <div id="g3w-sidebarpanel-header-placeholder">
             <div
@@ -252,11 +252,11 @@
         </div>
 
         <ul
-          id     = "g3w-sidebarcomponents"
-          v-show = "showmainpanel"
-          class  = "sidebar-menu"
-          :class = "{ 'g3w-disabled': disabled }"
-          @click = "toggleSidebarItem"
+          id      = "g3w-sidebarcomponents"
+          :hidden = "!showmainpanel"
+          class   = "sidebar-menu"
+          :class  = "{ 'g3w-disabled': disabled }"
+          @click  = "toggleSidebarItem"
         >
 
         <li id="metadata" class="treeview sidebaritem">

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -29,11 +29,9 @@
         <img style="height: 100%;" alt = "" :src = "logo_url" />
       </a>
 
-      <input id="menu-toggler" ref="menu-toggler" type="checkbox" autocomplete="off" hidden="">
-
-      <label for="menu-toggler" class="navbar-toggler" hidden="">
-        <i :class = "$fa('bars')" ></i><span style="margin-left: 8px;">MENU</span>
-      </label>
+      <button class="navbar-toggler" hidden="" @click.prevent="toggleSidebar">
+        <i :class = "$fa('bars')" ></i><b style="margin-left: 8px;">MENU</b>
+      </button>
 
       <hgroup class  = "project_title">
         <p class = "h2">{{ main_title }}</p>
@@ -741,8 +739,8 @@ export default {
      * @since 3.11.0
      */
     showaddLayerModal() {
-      if (this.$refs['menu-toggler']) {
-        this.$refs['menu-toggler'].checked = false;
+      if (window.innerWidth < 767) {
+        GUI.hideSidebar();
       }
       $('#modal-addlayer').modal('show');
     },
@@ -751,8 +749,8 @@ export default {
      * @since 3.8.0
      */
     openChangeMapMenu() {
-      if (this.$refs['menu-toggler']) {
-        this.$refs['menu-toggler'].checked = false;
+      if (window.innerWidth < 767) {
+        GUI.hideSidebar();
       }
       $('#modal-changemap').modal('show');
     },
@@ -871,9 +869,6 @@ export default {
      * @since 3.11.0
      */
     toggleSidebar() {
-      if (this.$refs['menu-toggler']) {
-        this.$refs['menu-toggler'].checked = false;
-      }
       GUI.toggleSidebar();
     },
 
@@ -1006,19 +1001,13 @@ export default {
   i.triangle                            { border-color: #fff transparent transparent transparent; border-style: solid; border-width: 5px 4px 0 4px; display: inline-block; margin: 3px; }
   .open i.triangle                      { border-color: transparent transparent #fff transparent; border-width: 0 4px 5px 4px; }
 
-  #menu-toggler                         { display:none }
-  .navbar-toggler                       { color: #fff; margin: 12px; font-size: 1.3em; position: absolute; z-index: 101; right: 0; }
-
   @media (min-width: 767px) {
     .user-footer :is(.nav-sidebar, .nav-addlayer).btn-default { display: none; }
     .project_title                                            { margin-right: auto; }
   }
 
   @media (max-width: 767px) {
-    .navbar-toggler                     { display: block; cursor: pointer; user-select: none;}
-    #menu-toggler:checked ~ hgroup      { position: fixed; top: 0; background: var(--skin-color); padding-left: 8px; }
-    #menu-toggler:checked ~ ul          { position: fixed; inset: 50px 0 0 0; background: var(--skin-color); z-index: 100; flex-direction: column; border-top: 1px solid #fff;}
-    #menu-toggler:not(:checked)~*:not(.navbar-toggler),
+    body:not(.sidebar-open) .navbar-toggler ~ *,
     .nav-user > .dropdown-toggle,
     .user-header                        { display: none !important; }
     .navbar-nav                         { flex-direction: column; }

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -157,16 +157,6 @@
               >
                 <b v-t="'mapcontrols.add_layer_control.header'"></b><i :class="$fa('layers')"></i> 
               </a>
-
-              <!-- SIDEBAR MENU -->
-              <a
-                href   = "#"
-                @click = "toggleSidebar"
-                class  = "nav-sidebar btn btn-default btn-flat"
-              >
-                <b v-t="'sidebar_menu'"></b><i class = "fa fa-toggle-on"></i>
-              </a>
-              
             </li>
           </ul>
         </li>

--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -266,16 +266,16 @@
       "
     >
       <a
-        v-if   = "'legend' !== activeTab"
-        href   = "#"
-        @click = "showaddLayerModal"
+        v-if           = "'legend' !== activeTab"
+        href           = "#"
+        @click.stop = "showaddLayerModal"
       >
         <i :class="$fa('layers')"></i> <b v-t="'mapcontrols.add_layer_control.header'"></b>
       </a>
       <a
-        v-if   = "hasRelatedMaps && 'legend' !== activeTab && !iframe"
-        href   = "#"
-        @click = "openChangeMapMenu"
+        v-if           = "hasRelatedMaps && 'legend' !== activeTab && !iframe"
+        href           = "#"
+        @click.stop = "openChangeMapMenu"
       >
         <i :class = "$fa('refresh')"></i> <b v-t="'changemap'"></b>
       </a>
@@ -754,6 +754,9 @@ export default {
      * @since 3.11.0
      */
     showaddLayerModal() {
+      if (window.innerWidth < 767) {
+        GUI.hideSidebar();
+      }
       $('#modal-addlayer').modal('show');
     },
 
@@ -761,6 +764,9 @@ export default {
      * @since 3.11.0
      */
     openChangeMapMenu() {
+      if (window.innerWidth < 767) {
+        GUI.hideSidebar();
+      }
       $('#modal-changemap').modal('show');
     },
     

--- a/src/components/CatalogContextMenu.vue
+++ b/src/components/CatalogContextMenu.vue
@@ -480,6 +480,11 @@
         this.project_menu = !layer;
         await this.$nextTick();
         this.top = e.target.getBoundingClientRect().top - this.$refs['menu'].clientHeight + (e.target.clientHeight / 2);
+        // handle context menu on mobile
+        if (window.innerWidth < 767) {
+          this.left = (window.innerWidth / 2) - (this.$refs['menu'].clientWidth / 2);
+          this.top  = (window.innerHeight / 2) - (this.$refs['menu'].clientHeight / 2);
+        }
         $('.click-to-copy[data-toggle="tooltip"]').tooltip();
         // conditionally inline "ogc_menu" when they contain a single item
         [this.$refs.ogc_menu].forEach(li => li && li.classList.toggle('inline-submenu', 1 === li.querySelector('ul').children.length));

--- a/src/components/SpatialBookMarks.vue
+++ b/src/components/SpatialBookMarks.vue
@@ -44,8 +44,9 @@
     <template v-else>
 
       <div v-if = "is_staff" class = "content-bookmarks">
-        <span v-t = "'sdk.spatialbookmarks.sections.project.title'"></span>
+        <span :hidden = "is_mobile" v-t = "'sdk.spatialbookmarks.sections.project.title'"></span>
         <a
+          :hidden = "is_mobile"
           :href  = "`https://docs.qgis.org/3.34/${lang}/docs/user_manual/map_views/map_view.html#bookmarking-extents-on-the-map`"
           target = "_blank"
           style  = "float: right;"
@@ -96,8 +97,9 @@
         class = "content-bookmarks"
         style = "display: flex; justify-content: space-between; align-items: center; margin-top: 10px;"
       >
-        <span v-t="'sdk.spatialbookmarks.sections.user.title'"></span>
+        <span :hidden = "is_mobile" v-t="'sdk.spatialbookmarks.sections.user.title'"></span>
         <span
+          :hidden                 = "is_mobile"
           v-t-tooltip:left.create = "'add'"
           @click.stop             = "showAddForm"
           style                   = "padding: 5px; cursor: pointer;"
@@ -202,6 +204,11 @@
       lang() {
         return ApplicationState.language;
       },
+
+      /** @since 4.0.0 */
+      is_mobile() {
+        return window.innerWidth < 767;
+      }
 
     },
 

--- a/src/components/SpatialBookMarks.vue
+++ b/src/components/SpatialBookMarks.vue
@@ -238,6 +238,10 @@
       },
 
       async gotoSpatialBookmark({ extent, crs }) {
+        // automatically hide sidebar on mobile
+        if (window.innerWidth < 767) {
+          GUI.hideSidebar();
+        }
         if (crs.epsg !== GUI.getService('map').getEpsg().split('EPSG:')[1]) {
           const projection = await Projections.registerProjection(`EPSG:${crs.epsg}`);
           extent = ol.proj.transformExtent(extent, projection, GUI.getService('map').getProjection())

--- a/src/map/controls/geocoding.js
+++ b/src/map/controls/geocoding.js
@@ -807,7 +807,7 @@ document.head.insertAdjacentHTML(
   .ol-geocoder input[type="search"]:focus                              { outline: none; }
   .ol-geocoder input[type="search"]                                    { border: 0; width: 100%; height: 100%; padding: 5px 5px 5px 5px; text-indent: 6px; background-color: transparent; font-family: inherit; font-size: 1em; }
   .ol-geocoder input[type="search"]::-webkit-search-cancel-button      { display: none; }
-  .ol-geocoder form                                                    { display: flex; justify-content: flex-end; height: 41px; background-color: #fff; overflow: hidden; width: 100%; border: 1px solid var(--skin-color); border-radius: 0 3px 3px 0; anchor-name: --ol-geocoder-form; }
+  .ol-geocoder form                                                    { display: flex; justify-content: flex-end; height: 40px; background-color: #fff; overflow: hidden; width: 100%; border: 1px solid var(--skin-color); border-radius: 0 3px 3px 0; anchor-name: --ol-geocoder-form; }
   .ol-geocoder .gcd-road                                               { font-size: 0.875em; font-weight: 500; }
   .ol-geocoder .gcd-city                                               { font-size: 1em; font-weight: bold; }
   .ol-geocoder .gcd-country                                            { font-size: 0.75em; }

--- a/src/services/gui.js
+++ b/src/services/gui.js
@@ -820,6 +820,11 @@ export default new (class GUI extends G3WObject {
     contents.setOpen(true);
 
     await this._layout(true);
+
+    //In case of mobile, hide sidebar
+    if (isMobile.any) {
+      this.hideSidebar();
+    }  
   }
 
   // hide content

--- a/src/services/gui.js
+++ b/src/services/gui.js
@@ -1112,6 +1112,7 @@ export default new (class GUI extends G3WObject {
     const scale = is_full ? 1 : ((h_split ? panel.width: panel.height) /100);
 
     contents.parentElement.classList.toggle('full-size', is_full);
+    
 
     // size "content"
     Object.assign(state.content.sizes, {
@@ -1124,6 +1125,13 @@ export default new (class GUI extends G3WObject {
       width:  viewW - (h_split ? state.content.sizes.width : 0),
       height: viewH - (v_split ? state.content.sizes.height : 0),
     });
+
+    if (window.innerWidth < 767) {
+      Object.assign(state.map.sizes, {
+        width:  window.innerWidth,
+        height: window.innerHeight,
+      });
+    }
 
     // resize "content" (after vue state is updated)
     await Vue.nextTick();

--- a/src/services/gui.js
+++ b/src/services/gui.js
@@ -821,8 +821,8 @@ export default new (class GUI extends G3WObject {
 
     await this._layout(true);
 
-    //In case of mobile, hide sidebar
-    if (isMobile.any) {
+    // automatically hide sidebar on mobile
+    if (window.innerWidth < 767) {
       this.hideSidebar();
     }  
   }

--- a/src/services/gui.js
+++ b/src/services/gui.js
@@ -1126,7 +1126,8 @@ export default new (class GUI extends G3WObject {
       height: viewH - (v_split ? state.content.sizes.height : 0),
     });
 
-    if (window.innerWidth < 767) {
+    // size full (when mobile menu is open) 
+    if (document.body.classList.contains('sidebar-open') && window.innerWidth < 767) {
       Object.assign(state.map.sizes, {
         width:  window.innerWidth,
         height: window.innerHeight,


### PR DESCRIPTION
## Closes: #807 

## Before

Left menu (sidebar) was nested as "top menu" entry.

![image](https://github.com/user-attachments/assets/7d422d9b-7460-44b2-baea-3ea9c0d329ba)


## After

Display top and left menu entries into single "full size" (scrollable) menu on mobile.

![image](https://github.com/user-attachments/assets/d085798b-baf7-425e-9809-3b8509093f01)
