### PR TITLE
Unable to switch base layer when current project contains a Bing base layer without a vendorkey

### DIFF
--- a/src/utils/getProject.js
+++ b/src/utils/getProject.js
@@ -119,9 +119,13 @@ export async function getProject(gid, options = {}) {
   const project = Object.assign(new G3WObject, {
     setters: {
       setBaseLayer(id) {
-        window.initConfig.baselayers.forEach(l => {
-          this._layersStore.getLayerById(l.id).setVisible(id === l.id);
-          l.visible = (id === l.id);
+        this.state.baselayers.forEach(l => {
+          const layer  = this._layersStore.getLayerById(l.id);
+          //check if layer exist and has a setVisible method
+          if (layer && layer.setVisible) {
+            layer.setVisible(id === l.id);
+            l.visible = (id === l.id);
+          }
         })
       },
     },


### PR DESCRIPTION
Ref: https://v39.g3wsuite.it/en/map/g3w-suite-demo/qdjango/97/

Try to change base layer, you get get a javascript error:

![Screenshot_20250709_094132](https://github.com/user-attachments/assets/c5c94e93-a144-475d-b47b-5823a787361e)

This is due a base layers server configuration having Bing base layer without vendorkey

```json
[
    {
        "id": 3,
        "name": "OpenStreetMap",
        "title": "OSM",
        "icon": null,
        "crs": {
            "epsg": "EPSG:3857",
            "proj4": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs",
            "geographic": false,
            "axisinverted": false
        },
        "scalebasedvisibility": false,
        "minscale": 100000000,
        "maxscale": 0,
        "servertype": "OSM",
        "attribution": "<a href='https://www.openstreetmap.org/copyright'>OpenStreetMap contributors</a>",
        "visible": false,
        "baselayer": true,
        "projection": {
            "code_": "EPSG:3857",
            "units_": "m",
            "extent_": [
                -20037508.342789244,
                -20037508.342789244,
                20037508.342789244,
                20037508.342789244
            ],
            "worldExtent_": [
                -180,
                -85,
                180,
                85
            ],
            "axisOrientation_": "enu",
            "global_": true,
            "canWrapX_": true,
            "defaultTileGrid_": null
        },
        "ows_method": "GET",
        "wms_use_layer_ids": true,
        "download": false,
        "geolayer": false,
        "fields": {},
        "urls": {},
        "search_endpoint": "api",
        "map_crs": "EPSG:3857"
    },
    {
        "id": 4,
        "name": "Bing Streets",
        "title": "Bing Strade",
        "icon": null,
        "crs": {
            "epsg": 3857,
            "proj4": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs",
            "geographic": false,
            "axisinverted": false
        },
        "scalebasedvisibility": false,
        "minscale": 100000000,
        "maxscale": 0,
        "servertype": "Bing",
        "source": {
            "subtype": "streets"
        }
    },
    {
        "id": 6,
        "name": "Bing Aerial",
        "title": "Bing Aerial",
        "icon": null,
        "crs": {
            "epsg": 3857,
            "proj4": "+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext +no_defs",
            "geographic": false,
            "axisinverted": false
        },
        "scalebasedvisibility": false,
        "minscale": 100000000,
        "maxscale": 0,
        "servertype": "Bing",
        "source": {
            "subtype": "aerial"
        }
    }
]
```