### PR TITLE
Unable to load external layers with EPSGs unregistered for current project

### DIFF
--- a/src/components/ModalAddLayer.vue
+++ b/src/components/ModalAddLayer.vue
@@ -648,6 +648,10 @@ export default {
         }
 
         this.layer_crs  = ['kml','kmz'].includes(this.file_type) ? 'EPSG:4326' : this.layer_crs;
+
+        // register EPSG
+        await Projections.registerProjection(this.layer_crs);
+
         this.layer_data = data;
 
         // parse features
@@ -687,7 +691,7 @@ export default {
 
       } catch(e) {
         console.warn(e);
-        this.error_message = 'Load layer error';
+        this.error_message = `${e}`;
       }
     },
 
@@ -740,14 +744,6 @@ export default {
       }
 
       if ('file' === this.layer_type) {
-        // register EPSG
-        try {
-          await Projections.registerProjection(this.layer_crs);
-        } catch(e) {
-          console.warn(e);
-          this.error_message = `${e}`;
-          return;
-        }
         try {
           await GUI.getService('map').addExternalLayer(this.olLayer, {
             crs:        this.layer_crs,
@@ -761,7 +757,7 @@ export default {
           this.unloadFile();
         } catch(e) {
           console.warn(e);
-          this.error_message = 'Load layer error';
+          this.error_message = `${e}`;
         }
       }
       this.loading = false;
@@ -922,7 +918,7 @@ export default {
         this.name  = config.title + suffix;
 
         // register projections
-        config.layers.forEach(({ crss }) => crss.forEach(crs => Projections.get(crs)));
+        config.layers.forEach(({ crss }) => crss.forEach(crs => Projections.registerProjection(crs)));
 
         /** Layers of wms */
         this.layers = config.layers;

--- a/src/components/ModalAddLayer.vue
+++ b/src/components/ModalAddLayer.vue
@@ -918,7 +918,7 @@ export default {
         this.name  = config.title + suffix;
 
         // register projections
-        config.layers.forEach(({ crss }) => crss.forEach(crs => Projections.registerProjection(crs)));
+        config.layers.forEach(({ crss }) => crss.forEach(crs => Projections.registerProjection(crs.epsg)));
 
         /** Layers of wms */
         this.layers = config.layers;

--- a/src/store/projections.js
+++ b/src/store/projections.js
@@ -52,6 +52,7 @@ export default {
    * @since v3.8
    */
   async registerProjection(epsg) {
+    epsg = normalizeEpsg(epsg);
     let p = ol.proj.get(epsg) || undefined;
 
     // check if already registered

--- a/src/store/projections.js
+++ b/src/store/projections.js
@@ -52,7 +52,6 @@ export default {
    * @since v3.8
    */
   async registerProjection(epsg) {
-    epsg = normalizeEpsg(epsg);
     let p = ol.proj.get(epsg) || undefined;
 
     // check if already registered


### PR DESCRIPTION
Fixes regression introduced by: https://github.com/g3w-suite/g3w-client/pull/737

## How to test

1. go to: https://dev.g3wsuite.it/it/map/demo-310/ (EPSG:3857)
2. try to add a new WMS layer with a different (eg. EPSG:3003): https://www502.regione.toscana.it/wmsraster/com.rt.wms.RTmap/wms?map=wmsofc&map_resolution=91&language=ita&

The same happens for local files.

## Before

![image](https://github.com/user-attachments/assets/c4851518-3ac9-4b01-ba16-5bf76c0f64e1)

## After

![image](https://github.com/user-attachments/assets/cc858a9f-ab26-429f-8a6e-320b4053e609)
