### PR TITLE
🐛 Legend TOC  Icon layer change size when set  dynamic map content

### DIFF
--- a/src/components/CatalogLayerLegend.vue
+++ b/src/components/CatalogLayerLegend.vue
@@ -312,6 +312,8 @@
               const findSymbol  = symbols.find(s => s.icon === c.icon && s.title === c.title);
               const disabled    = undefined === c.checked  || c.checked;
               c.disabled        = disabled && undefined === findSymbol;
+              //@since 4.0.x In case of icon change base on map. Check icon in case of same title
+              c.icon            = (symbols.find(s => s.title === c.title && s.icon !== c.icon) || { icon: c.icon }).icon;
             });
           })
         } else {


### PR DESCRIPTION
Setting on QGIS

<img width="633" height="275" alt="Screenshot_20250718_142939" src="https://github.com/user-attachments/assets/5c97512e-cb4d-4b7e-8780-60ce93f5d0ce" />

zoom in and out on map icon legend doesn't change:

**Before**

<img width="1920" height="833" alt="Screenshot_20250718_143150" src="https://github.com/user-attachments/assets/0613997d-1d02-4f90-a846-d0976c823cfb" />

<img width="1920" height="833" alt="Screenshot_20250718_143307" src="https://github.com/user-attachments/assets/e96b3016-f5dc-4249-816a-fb1b297b9846" />

**After**

<img width="1920" height="833" alt="Screenshot_20250718_143454" src="https://github.com/user-attachments/assets/17ff6d5e-aa1e-4e62-8edf-3df5a3a3edf2" />

<img width="1920" height="833" alt="Screenshot_20250718_143529" src="https://github.com/user-attachments/assets/2f56f7b6-cc09-4b60-817a-d8266525c103" />

