### PR TITLE
Seach return type search with input selectfield with values

### DIFF
--- a/src/components/g3w-search.js
+++ b/src/components/g3w-search.js
@@ -103,13 +103,15 @@ export function SearchPanel(opts = {}, show = false) {
       const input = state.forminputs[i];
 
       const no_value = input.dependance_strict && [SEARCH_ALLVALUE, '', null, undefined].includes(state.forminputs.find(i => input.dependance === i.attribute).value);
-
       // set key-values for select
-      input.values = [
-        ...('selectfield' === input.type ? [SEARCH_ALLVALUE] : []),                        // set `SEARCH_ALLVALUE` as first element
-        ...(no_value ? [] : await getDataForSearchInput({ state, field: input.attribute }) // retrieve input values from server (set empty in case of strict dependance)
-          )
-      ].map(value => 'Object' === toRawType(value) ? value : ({ key: value, value }));
+      input.values = 'selectfield' === input.type  ? (
+         [
+          SEARCH_ALLVALUE, // set `SEARCH_ALLVALUE` as first element
+          ...(no_value 
+              ? [] //set empty in case of strict dependance
+              : (Array.isArray(input.options.values) && input.options.values.length > 0) && input.options.values || await getDataForSearchInput({ state, field: input.attribute })) // if values is array and provide by search config input (case of serarch that return type is a search) othrewise get values from server
+          ]
+        ).map(value => 'Object' === toRawType(value) ? value : ({ key: value, value })) : [];
 
       // there is a dependance
       if (input.dependance) {


### PR DESCRIPTION
In case of search that return another search configuration, this configuration may be contain a selectfield input with already values options. In the case we need to take these values instead of getting values from server

Search with return type search:


<img width="706" height="215" alt="Screenshot_20250721_122939" src="https://github.com/user-attachments/assets/5eb0e3ef-b654-4660-bcc7-5abf3e9b5272" />


Response from server

<img width="686" height="395" alt="Screenshot_20250721_123123" src="https://github.com/user-attachments/assets/ce73c5b5-fbc8-4a78-8e0f-59067e382d07" />
