### PR TITLE
Handle searches that returns another search configuration instead of values (hotfix for cadastre plugin)

### DIFF
--- a/src/components/g3w-search.js
+++ b/src/components/g3w-search.js
@@ -121,6 +121,11 @@ export function SearchPanel(opts = {}, show = false) {
           ]
         ).map(value => 'Object' === toRawType(value) ? value : ({ key: value, value })) : [];
 
+      //In case of search with autofilter that return no data, need to setup select input to all
+      if (1 === input.values.length && SEARCH_ALLVALUE === input.values[0].value && ['selectfield', 'autocompletefield'].includes(input.type)) {
+        input.value = 'in' === input.operator ? [SEARCH_ALLVALUE] : SEARCH_ALLVALUE; // set default value for select
+      };
+      
       // there is a dependance
       if (input.dependance) {
         state.loading[input.dependance] = false;

--- a/src/components/g3w-search.js
+++ b/src/components/g3w-search.js
@@ -112,19 +112,14 @@ export function SearchPanel(opts = {}, show = false) {
 
       const no_value = input.dependance_strict && [].concat(state.forminputs.find(i => input.dependance === i.attribute).value).find(v => [SEARCH_ALLVALUE, '', null, undefined].includes(v));
       // set key-values for select
-      input.values = [
-        ...('selectfield' === input.type 
-            // set `SEARCH_ALLVALUE` as first element and retrive input values from server (set empty in case of strict dependance)
-            ? [SEARCH_ALLVALUE].concat(no_value ? [] : await getDataForSearchInput({ state, layerid: input.alternativeuniquelayer, field: input.attribute })) 
-            : []
-          ), 
-
-      ].map(value => 'Object' === toRawType(value) ? value : ({ key: value, value }));
-
-      //In case of search with autofilter that return no data, need to setup select input to all
-      if (1 === input.values.length && SEARCH_ALLVALUE === input.values[0].value && ['selectfield', 'autocompletefield'].includes(input.type)) {
-        input.value = 'in' === input.operator ? [SEARCH_ALLVALUE] : SEARCH_ALLVALUE; // set default value for select
-      };
+      input.values = 'selectfield' === input.type  ? (
+         [
+          SEARCH_ALLVALUE, // set `SEARCH_ALLVALUE` as first element
+          ...(no_value 
+              ? [] //set empty in case of strict dependance
+              : (Array.isArray(input.options.values) && input.options.values.length > 0) && input.options.values || await getDataForSearchInput({ state, field: input.attribute })) // if values is array and provide by search config input (case of serarch that return type is a search) othrewise get values from server
+          ]
+        ).map(value => 'Object' === toRawType(value) ? value : ({ key: value, value })) : [];
 
       // there is a dependance
       if (input.dependance) {

--- a/src/components/g3w-search.js
+++ b/src/components/g3w-search.js
@@ -110,14 +110,16 @@ export function SearchPanel(opts = {}, show = false) {
         input.value = [].concat(input.value);
       }
 
-      const no_value = input.dependance_strict && [].concat(state.forminputs.find(i => input.dependance === i.attribute).value).find(v => [SEARCH_ALLVALUE, '', null, undefined].includes(v));
+      const no_value    = input.dependance_strict && [].concat(state.forminputs.find(i => input.dependance === i.attribute).value).find(v => [SEARCH_ALLVALUE, '', null, undefined].includes(v));
+      const has_value   = !no_value;
+      const is_cadastre = Array.isArray(input.options.values) && input.options.values.length > 0;              // HOTFIX for cadastre plugin
+
       // set key-values for select
       input.values = 'selectfield' === input.type  ? (
          [
-          SEARCH_ALLVALUE, // set `SEARCH_ALLVALUE` as first element
-          ...(no_value 
-              ? [] //set empty in case of strict dependance
-              : (Array.isArray(input.options.values) && input.options.values.length > 0) && input.options.values || await getDataForSearchInput({ state, field: input.attribute })) // if values is array and provide by search config input (case of serarch that return type is a search) othrewise get values from server
+          SEARCH_ALLVALUE,                                                                                     // set `SEARCH_ALLVALUE` as first element
+          ...(has_value && is_cadastre ? input.options.values : []),                                           // ref: https://github.com/g3w-suite/g3w-client/pull/834
+          ...(has_value && !is_cadastre ? await getDataForSearchInput({ state, field: input.attribute }) : []) // get values from server
           ]
         ).map(value => 'Object' === toRawType(value) ? value : ({ key: value, value })) : [];
 


### PR DESCRIPTION
## Same as: #833 

In case of search that return another search configuration, this configuration may be contain a selectfield input with already values options. In the case we need to take these values instead of getting values from server

Search with return type search:


<img width="706" height="215" alt="Screenshot_20250721_122939" src="https://github.com/user-attachments/assets/5eb0e3ef-b654-4660-bcc7-5abf3e9b5272" />


Response from server

<img width="686" height="395" alt="Screenshot_20250721_123123" src="https://github.com/user-attachments/assets/ce73c5b5-fbc8-4a78-8e0f-59067e382d07" />
