### PR TITLE
Sidebar toggler overlaps geocoding control when application runs within an iframe

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -976,11 +976,13 @@ export default {
     await this.$nextTick();
 
     $('#startingspinner').remove();
-   
-    document.body.classList.add('sidebar-mini');
-    
+
     document.body.classList.toggle('is-mobile', this.isMobile());
     document.body.classList.toggle('is-iframe', ApplicationState.iframe);
+
+    if (!ApplicationState.iframe) {
+      document.body.classList.add('sidebar-mini');
+    }
   },
 
 };

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -976,15 +976,11 @@ export default {
     await this.$nextTick();
 
     $('#startingspinner').remove();
-
-    this.iframe = ApplicationState.iframe;
-
-    if (!this.iframe) {
-      document.body.classList.add('sidebar-mini');
-    }
-
+   
+    document.body.classList.add('sidebar-mini');
+    
     document.body.classList.toggle('is-mobile', this.isMobile());
-    document.body.classList.toggle('is-iframe', this.iframe);
+    document.body.classList.toggle('is-iframe', ApplicationState.iframe);
   },
 
 };

--- a/src/map/controls/geocoding.js
+++ b/src/map/controls/geocoding.js
@@ -790,7 +790,8 @@ document.head.insertAdjacentHTML(
   /* css */`
 <style>
   .ol-geocoder                                                         { width: 300px; margin-top: 3px; margin-left: 5px; --skin-color: #374146; }
-  body:not(.sidebar-collapse) .ol-geocoder                             { margin-left: 40px; }
+  body:not(.sidebar-collapse) .ol-geocoder,
+  body.is-iframe:not(.sidebar-mini).sidebar-collapse .ol-geocoder      { margin-left: 40px; }
   .ol-geocoder > ul                                                    { max-height: 400px; overflow-x: hidden; overflow-y: auto; transition: max-height 300ms ease-in; padding: 0; margin:unset; inset:unset; background: #fff;border: 1px solid #ccc; width: 300px; min-width: 215px; }
   .ol-geocoder > ul:not([style*="left"])                               { position-anchor: --ol-geocoder-form; position-area: bottom; }
   .ol-geocoder > ul > li                                               { width: 100%; overflow: hidden; padding: 0; min-height: 30px; padding-left: 3px; border-bottom: 2px solid var(--skin-color); min-height: 20px; padding: 10px; }


### PR DESCRIPTION
## Before

<img width="1001" height="535" alt="Screenshot_20250723_143236" src="https://github.com/user-attachments/assets/bf30697a-01c9-4509-a690-158eb6444de3" />

## After

<img width="1919" height="943" alt="image" src="https://github.com/user-attachments/assets/2c1d827e-b833-425d-9a9d-65e52a86bb16" />
