### PR TITLE
Conditionally show form labels (query, search and editing)

### DIFF
--- a/src/components/Field.vue
+++ b/src/components/Field.vue
@@ -6,7 +6,7 @@
 <template>
   <div class = "field">
     <div
-      v-if  = "state.label"
+      v-if  = "state.showlabel"
       class = "field_label"
     >
       <slot name = "label">{{state.label}}</slot>

--- a/src/components/GlobalTabsNode.vue
+++ b/src/components/GlobalTabsNode.vue
@@ -219,7 +219,7 @@
       getField(node) {
         if (node.relation) { return node }
         //get field of layer
-        const field = this.fields.find(f => (node.field_name ? node.field_name.replace(/ /g,"_") : node.field_name) === f.name);
+        let field = this.fields.find(f => (node.field_name ? node.field_name.replace(/ /g,"_") : node.field_name) === f.name);
         //in case of showlabel is true, set label to alias
         if (node.showlabel) {
           field = {...field, label: node.alias,};

--- a/src/components/GlobalTabsNode.vue
+++ b/src/components/GlobalTabsNode.vue
@@ -218,7 +218,13 @@
        */
       getField(node) {
         if (node.relation) { return node }
-        return this.fields.find(f => (node.field_name ? node.field_name.replace(/ /g,"_") : node.field_name) === f.name);
+        //get field of layer
+        const field = this.fields.find(f => (node.field_name ? node.field_name.replace(/ /g,"_") : node.field_name) === f.name);
+        //in case of showlabel is true, set label to alias
+        if (node.showlabel) {
+          field.label = node.alias;
+        }
+        return field;
       },
       /**
        *

--- a/src/components/GlobalTabsNode.vue
+++ b/src/components/GlobalTabsNode.vue
@@ -219,11 +219,9 @@
       getField(node) {
         if (node.relation) { return node }
         //get field of layer
-        let field = this.fields.find(f => (node.field_name ? node.field_name.replace(/ /g,"_") : node.field_name) === f.name);
-        //in case of showlabel is true, set label to alias
-        if (node.showlabel) {
-          field = {...field, label: node.alias,};
-        }
+        const field = this.fields.find(f => (node.field_name ? node.field_name.replace(/ /g,"_") : node.field_name) === f.name);
+        //set showlabel
+        field.showlabel = node.showlabel;
         return field;
       },
       /**

--- a/src/components/GlobalTabsNode.vue
+++ b/src/components/GlobalTabsNode.vue
@@ -222,7 +222,7 @@
         const field = this.fields.find(f => (node.field_name ? node.field_name.replace(/ /g,"_") : node.field_name) === f.name);
         //in case of showlabel is true, set label to alias
         if (node.showlabel) {
-          field.label = node.alias;
+          field = {...field, label: node.alias,};
         }
         return field;
       },

--- a/src/components/InputBase.vue
+++ b/src/components/InputBase.vue
@@ -9,26 +9,29 @@
     class = "form-group"
   >
     <!-- SLOT LABEL -->
-    <slot name = "label">
-      <!-- @since 3.10.0 -->
-      <label
-        :for       = "state.name"
-        v-disabled = "!editable"
-        class      = "control-label"
-      >
-        <span v-if = "state.i18nLabel" v-t = "state.label"></span>
-        <span v-else>{{ state.label }}</span>
-        <span v-if = "state.validate && state.validate.required">*</span>
-        <i
-          v-if        = "showhelpicon"
-          :class      = "g3wtemplate.font['info']"
-          class       = "skin-color"
-          style       = "margin-left: 3px; cursor: pointer"
-          @click.stop = "showHideHelp">
-        </i>
-        <slot name = "label-action"></slot>
-      </label>
-    </slot>
+    <!--- @since 4.0.1 If showlabel is defined by editor form structure by GlobalTabsNode.vue in getField method--> 
+    <template v-if = "undefined === state.showlabel || state.showlabel">
+      <slot name="label">
+        <!-- @since 3.10.0 -->
+        <label
+          :for       = "state.name"
+          v-disabled = "!editable"
+          class      = "control-label"
+        >
+          <span v-if = "state.i18nLabel" v-t = "state.label"></span>
+          <span v-else>{{ state.label }}</span>
+          <span v-if = "state.validate && state.validate.required">*</span>
+          <i
+            v-if        = "showhelpicon"
+            :class      = "g3wtemplate.font['info']"
+            class       = "skin-color"
+            style       = "margin-left: 3px; cursor: pointer"
+            @click.stop = "showHideHelp">
+          </i>
+          <slot name = "label-action"></slot>
+        </label>
+      </slot>
+    </template>
 
     <!-- @since 3.11.0 RELATION FIELD -->
     <div

--- a/src/map/layers/layer.js
+++ b/src/map/layers/layer.js
@@ -2605,6 +2605,9 @@ class Layer extends G3WObject {
       if (result) {
         //set form structure
         this.config.editor_form_structure = data?.editor_form_structure;
+        //@since 4.0.1 get fields from server (maybe are changed)
+        this.config.fields = data?.fields || this.config.fields;
+        
         //@since 4.0.0 set scale visibility on change style
         this.state.scalebasedvisibility   = data?.scalebasedvisibility;
         this.state.minscale               = data?.minscale;


### PR DESCRIPTION
## Depends on https://github.com/g3w-suite/g3w-admin/pull/1181

Add support for `showlabel` attribute within `editor_form_structure` config:

## Before

<img width="622" height="156" alt="Screenshot_20250811_171356" src="https://github.com/user-attachments/assets/145fd56d-6f1d-48cb-8fac-a4b169cdbc33" />

## After

<img width="464" height="303" alt="Screenshot_20250812_111912" src="https://github.com/user-attachments/assets/7d2fe3e1-c65c-4b9b-b4be-d94b3c096c71" />

No label is show for address field:

**Query** 

<img width="459" height="361" alt="Screenshot_20250812_112011" src="https://github.com/user-attachments/assets/eed2b23b-198b-43a0-ab08-34a95d6f7a70" />

**Editing Form**

<img width="459" height="621" alt="Screenshot_20250812_112127" src="https://github.com/user-attachments/assets/681e1313-2863-4574-a6b2-f7f8194eefe6" />