### PR TITLE
Show any invalid expression field values within parenthesis (ie. while editing a select field)

### DIFF
--- a/src/assets/locales/de.js
+++ b/src/assets/locales/de.js
@@ -251,6 +251,7 @@ export default {
   'Filter results': 'Filtern Sie die Ergebnisse',
   'Loading ...': 'Laden ...',
   'sdk.form.inputs.messages.errors.picklayer': 'Kein Feature ausgewählt. Prüfen, ob der Layer in Bearbeitung oder im aktuellen Maßstab sichtbar ist',
+  'sdk.form.inputs.messages.warning.picklayer': 'Die Feature ausgewählte ist ungültig',
   'sdk.form.inputs.tooltips.picklayer': 'Wert aus dem Layer abrufen',
   'sdk.form.inputs.tooltips.lonlat': 'Zum Abrufen der Koordinaten auf die Karte klicken',
   'sdk.form.inputs.input_validation_mutually_exclusive': 'Feld schließt sich gegenseitig aus mit ',

--- a/src/assets/locales/en.js
+++ b/src/assets/locales/en.js
@@ -151,7 +151,7 @@ export default {
   'download_types.pdf': 'Download PDF',
   'sdk.search.all': 'ALL',
   'sdk.form.inputs.messages.errors.picklayer': 'No feature selected. Check if layer is on editing or visible at current scale',
-  'sdk.form.inputs.tooltips.picklayer': 'Get value from ma layer',
+  'sdk.form.inputs.tooltips.picklayer': 'Get value from map layer',
   'sdk.form.inputs.tooltips.lonlat': 'Click on map to get coordinates',
   'sdk.form.inputs.input_validation_mutually_exclusive': 'Field mutually exclusive with ',
   'sdk.form.inputs.input_validation_error': 'Mandatory Field or wrong data type',

--- a/src/assets/locales/en.js
+++ b/src/assets/locales/en.js
@@ -151,6 +151,7 @@ export default {
   'download_types.pdf': 'Download PDF',
   'sdk.search.all': 'ALL',
   'sdk.form.inputs.messages.errors.picklayer': 'No feature selected. Check if layer is on editing or visible at current scale',
+  'sdk.form.inputs.messages.warning.picklayer': 'Feature selected is not valid',
   'sdk.form.inputs.tooltips.picklayer': 'Get value from map layer',
   'sdk.form.inputs.tooltips.lonlat': 'Click on map to get coordinates',
   'sdk.form.inputs.input_validation_mutually_exclusive': 'Field mutually exclusive with ',

--- a/src/assets/locales/fi.js
+++ b/src/assets/locales/fi.js
@@ -242,6 +242,7 @@ export default {
   'Filter results': 'Suodata tulokset',
   'Loading ...': 'Ladataan...',
   'sdk.form.inputs.messages.errors.picklayer': 'Ominaisuuksia ei valiitu. Tarkista, että taso on muokattavissa tai näkyvissä nykyisellä mittakaavalla.',
+  'sdk.form.inputs.messages.warning.picklayer': 'Feature selected is not valid',
   'sdk.form.inputs.tooltips.picklayer': 'Valitse arvo karttatasolta',
   'sdk.form.inputs.tooltips.lonlat': 'Click on map to get coordinates',
   'sdk.form.inputs.input_validation_mutually_exclusive': 'Kenttä toisensa poissulkeva.',

--- a/src/assets/locales/fr.js
+++ b/src/assets/locales/fr.js
@@ -253,6 +253,7 @@ export default {
   'Filter results': 'Filtrer les résultats',
   'Loading ...': 'Chargement...',
   'sdk.form.inputs.messages.errors.picklayer': "Aucune entité sélectionnée. Vérifier si la couche est en édition ou non visible à l'échelle actuelle",
+  'sdk.form.inputs.messages.warning.picklayer': "La entité sélectionnée n'est pas valide",
   'sdk.form.inputs.tooltips.picklayer': 'Obtenir la valeur de la carte',
   'sdk.form.inputs.tooltips.lonlat': 'Cliquez sur la carte pour obtenir les coordonnées',
   'sdk.form.inputs.input_validation_mutually_exclusive': 'Champ mutuellement exclusif avec ',

--- a/src/assets/locales/it.js
+++ b/src/assets/locales/it.js
@@ -355,6 +355,7 @@ export default {
   'Whether automatically filter geometries displayed within the map<br>in order to show only those related to current search results.': 'Filtra automaticamente le geometrie visualizzate nella mappa<br>per mostrare solo quelle relative ai risultati della ricerca corrente.',
   'Loading ...': 'Caricamento ...',
   'sdk.form.inputs.messages.errors.picklayer': 'Nessuna feature selezionata. Verificare se il layer è in editing o non visibile alla scala attuale',
+  'sdk.form.inputs.messages.warning.picklayer': "L'oggetto selezionato non è valido",
   'sdk.form.inputs.tooltips.picklayer': 'Prendi valore dalla mappa',
   'sdk.form.inputs.tooltips.lonlat': 'Clicca sulla mappa per prendere le coordinate',
   'sdk.form.inputs.input_validation_mutually_exclusive': 'Campo mutualmente esclusivo con ',

--- a/src/assets/locales/pl.js
+++ b/src/assets/locales/pl.js
@@ -249,6 +249,7 @@ export default {
   'Filter results': 'Filtruj wyniki',
   'Loading ...': 'Ładowanie ...',
   'sdk.form.inputs.messages.errors.picklayer': 'Brak wybranej funkcji. Sprawdź, czy warstwa jest w edycji lub widoczna w bieżącej skali',
+  'sdk.form.inputs.messages.warning.picklayer': 'Wybrany obiekt jest nieprawidłowy',
   'sdk.form.inputs.tooltips.picklayer': 'Uzyskaj wartość z warstwy MA',
   'sdk.form.inputs.tooltips.lonlat': 'Kliknij mapę, aby uzyskać współrzędne',
   'sdk.form.inputs.input_validation_mutually_exclusive': 'Pole wzajemnie wykluczające się z',

--- a/src/assets/locales/pt.js
+++ b/src/assets/locales/pt.js
@@ -314,6 +314,7 @@ export default {
   'Filter results': 'Filtrar resultados',
   'Loading ...': 'A carregar ...',
   'sdk.form.inputs.messages.errors.picklayer': 'Sem camadas selecionadas. Verifique se a camada está em edição ou visível na escala atual.',
+  'sdk.form.inputs.messages.warning.picklayer': 'O objeto selecionado é inválido',
   'sdk.form.inputs.tooltips.picklayer': 'Obter atributo da camada',
   'sdk.form.inputs.tooltips.lonlat': 'Clique no mapa para obter as coordenadas',
   'sdk.form.inputs.input_validation_mutually_exclusive': 'Atributo mutuamente exclusivo com ',

--- a/src/assets/locales/ro.js
+++ b/src/assets/locales/ro.js
@@ -258,6 +258,7 @@ export default {
   'Filter results': 'Filtrați rezultatele',
   'Loading ...': 'Se încarcă ...',
   'sdk.form.inputs.messages.errors.picklayer': 'Nu avem entitate selectată. Verifică dacă stratul este în editare sau vizibil la scara curentă if layer is on editing or visible at current scale',
+  'sdk.form.inputs.messages.warning.picklayer': 'Obiectul selectat este invalid',
   'sdk.form.inputs.tooltips.picklayer': 'Ia valoare din strat',
   'sdk.form.inputs.tooltips.lonlat': 'Click pe hartă pentru a prelua coordonate',
   'sdk.form.inputs.input_validation_mutually_exclusive': 'Câmp ce se exclude mutual cu ',

--- a/src/assets/locales/se.js
+++ b/src/assets/locales/se.js
@@ -242,6 +242,7 @@ export default {
   'Filter results': 'Filtrera resultaten',
   'Loading ...': 'Laddning...',
   'sdk.form.inputs.messages.errors.picklayer': 'Inga egenskaper har valts. Kontroller att nivån kan redigeras eller att den syns med nuvarande skala.',
+  'sdk.form.inputs.messages.warning.picklayer': 'Det valda objektet är ogiltigt',
   'sdk.form.inputs.tooltips.picklayer': 'Välj värde på kartnivå',
   'sdk.form.inputs.tooltips.lonlat': 'Click on map to get coordinates',
   'sdk.form.inputs.input_validation_mutually_exclusive': 'Fälten utesluter varandra.',

--- a/src/assets/locales/uk.js
+++ b/src/assets/locales/uk.js
@@ -310,6 +310,7 @@ export default {
   'Filter results': 'Фільтрувати за результатами',
   'Loading ...': 'Завантаження…',
   'sdk.form.inputs.messages.errors.picklayer': "Жодного об'єкта не вибрано. Перевірте що шар у режимі редагування та видимий за поточного масштабу", 
+  'sdk.form.inputs.messages.warning.picklayer': "Вибраний об'єкт недійсний",
   'sdk.form.inputs.tooltips.picklayer': 'Отримати значення з мапи',
   'sdk.form.inputs.tooltips.lonlat': 'Клацніть по мапі щоб отримати координати',
   'sdk.form.inputs.input_validation_mutually_exclusive': 'Поле взаємовиключне з ',

--- a/src/components/InputBase.vue
+++ b/src/components/InputBase.vue
@@ -11,7 +11,7 @@
     <!-- SLOT LABEL -->
     <!--- @since 4.0.1 If showlabel is defined by editor form structure by GlobalTabsNode.vue in getField method--> 
     <template v-if = "undefined === state.showlabel || state.showlabel">
-      <slot name="label">
+      <slot name = "label">
         <!-- @since 3.10.0 -->
         <label
           :for       = "state.name"
@@ -28,10 +28,10 @@
             style       = "margin-left: 3px; cursor: pointer"
             @click.stop = "showHideHelp">
           </i>
-          <slot name = "label-action"></slot>
         </label>
       </slot>
     </template>
+    <slot name = "label-action"></slot>
 
     <!-- @since 3.11.0 RELATION FIELD -->
     <div

--- a/src/components/InputSelect.vue
+++ b/src/components/InputSelect.vue
@@ -159,14 +159,27 @@
                   value:  values[this.state.input.options.key]
                 });
               }
+              //if autocpomplete is not set,just simple select check if value is not in current values
+              //Case Bonifica Renana https://github.com/orgs/g3w-suite/projects/12/views/1?pane=issue&itemId=123189761&issue=g3w-suite%7Cg3w-admin%7C1180
+              //use not strict equality to avoid issues with numbers and strings
+              if (!this.autocomplete && !this.state.input.options.values.find(v => v.value == value)) {
+                //set null value if no in values
+                value = null;
+              }
               //set new value to this.state.value
               await this.changeSelect(value);
               //trigger change value on select2
               this.select2.val(this.multiple ? this.getMultiValues() : value).trigger('change');
             }
-
             //show a success message
-            GUI.showUserMessage({ type: 'success', autoclose: true });
+            if (value) {
+              GUI.showUserMessage({ type: 'success', autoclose: true });
+            }
+
+            //In case of value is null, no value inside values, show warning message
+            if (null === value) {
+              GUI.showUserMessage({ type: 'warning', message: 'sdk.form.inputs.messages.warning.picklayer', autoclose: false });
+            }
 
             this.picked = false;
           }
@@ -291,6 +304,10 @@
     },
 
     async created() {
+
+      //@since 4.0.1 Force to set usecompleter false if filter_expression is set
+      //to avoid to handle filter_expression list results values with search text on autocomplete
+      //this.state.input.options.usecompleter = this.state.input.options.usecompleter && !this.state.input.options.filter_expression;
 
       //unwatch attributes
       this.unwatch;
@@ -517,7 +534,8 @@
               .getProjectLayer(dependencyLayerId)
               .getEditingLayer() || getCatalogLayerById(dependencyLayerId);
             // in case layer is on project, check if is non an alphanumeric layer
-            this.showPickLayer = dependencyLayer && Layer.LayerTypes.TABLE !== dependencyLayer.getType();
+            //@since 4.0.1 if not autocompleter with filter_expression
+            this.showPickLayer = dependencyLayer  && Layer.LayerTypes.TABLE !== dependencyLayer.getType() && !(this.autocomplete && this.state.input.options.filter_expression);
             if (this.showPickLayer) {
               const {
                 key,
@@ -555,7 +573,14 @@
           allowClear:         this.showNullOption,
           placeholder:        '', // need to set placeholder in case of allowClear, otherwise doesn't work
           language,
-          ajax: {
+          // @since 4.0.1 In case of autocomplete with filter_expression, need to tranform data from feilter espression values
+          data: this.state.input.options.filter_expression ? this.state.input.options.values.map(({key, value }) =>({
+            text:   key,
+            id:     value,
+            $value: value, 
+          })): null,
+          // @since 4.0.1 In case of autocomplete with filter_expression, get dat from already loaded filter expression without ajax request (data attribute above)
+          ajax: !this.state.input.options.filter_expression ? {
             delay: 250,
             transport: (params, success, failure) => {
               const search = params.data.term;
@@ -577,7 +602,7 @@
                   more: false
                 }
               }
-            }},
+            }}: null,
         });
         //check if input has a value
         if (this.state.value) {
@@ -587,7 +612,10 @@
             search: this.multiple ? this.getMultiValues(): this.state.value
           });
         }
-      } else {
+      } 
+      
+      //In case is not autocomplete (simple select)
+      if (!this.autocomplete){
         this.select2 = selectElement.select2({
           language,
           dropdownParent,
@@ -595,6 +623,7 @@
           minimumResultsForSearch: this.isMobile() ? - 1 : null
         });
       }
+
       this.setAndListenSelect2Change();
       //in the case of multiple selection, need to set array values as select2
       if (this.multiple && this.getMultiValues().length > 0) {

--- a/src/utils/getFilterExpression.js
+++ b/src/utils/getFilterExpression.js
@@ -67,7 +67,8 @@ export async function getFilterExpression({
         })
       }
       //Case Bonifica Renana https://github.com/orgs/g3w-suite/projects/12/views/1?pane=issue&itemId=123189761&issue=g3w-suite%7Cg3w-admin%7C1180
-      if (field.value && !values.find(({ value }) => value === field.value)) {
+      //use not strict equality to avoid issues with numbers and strings
+      if (field.value && !values.find(({ value }) => value == field.value)) {
         values.unshift({
           key:   `(${field.value})`,
           value: field.value,

--- a/src/utils/getFilterExpression.js
+++ b/src/utils/getFilterExpression.js
@@ -66,6 +66,13 @@ export async function getFilterExpression({
           value: features[i].properties[key]
         })
       }
+      //Case Bonifica Renana https://github.com/orgs/g3w-suite/projects/12/views/1?pane=issue&itemId=123189761&issue=g3w-suite%7Cg3w-admin%7C1180
+      if (field.value && !values.find(({ value }) => value === field.value)) {
+        values.unshift({
+          key:   `(${field.value})`,
+          value: field.value,
+        });
+      };
 
       field.input.options.values = values;
     }


### PR DESCRIPTION
## Motivation

In long-lived databases, it may happen that an expression associated with a field has been changed (over time).

In QGIS this is handled by showing the old values (still stored in DB) within parenthesis:

<img width="1260" height="326" alt="Screenshot_20250813_121742" src="https://github.com/user-attachments/assets/28077487-845d-4bb3-bda6-5de1ee5c3b63" />

## How to test

1. go to: https://v310.g3wsuite.it/it/map/g3w-suite-demo/qdjango/312/
2. edit a building address:

<img width="781" height="446" alt="image" src="https://github.com/user-attachments/assets/2c663ac7-de80-4bc2-813b-2d2ef965da67" />

3. the "c107" value is shown within parenthesis because it doesn't satisfies current expression field: 

<img width="781" height="446" alt="image" src="https://github.com/user-attachments/assets/b253ee63-bd95-46b8-967d-030ec783fb20" />

## Before:

The "old value" is not shown:

<img width="781" height="446" alt="Screenshot_20250813_122749" src="https://github.com/user-attachments/assets/84bedec8-403b-432c-87bf-6f8cd4664720" />



## After

The "old value" is shown within parenthesis:

<img width="781" height="446" alt="Screenshot_20250813_122854" src="https://github.com/user-attachments/assets/9cf91a39-47b4-45a5-bb18-f0a8b2e925af" />

