### PR TITLE
Pagination controls on multi layers search is shown on wrong layers when any of them got no response

### DIFF
--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -25,8 +25,7 @@
           style = "position: relative"
         >
           <li
-            v-show = "showLayer(layer)"
-            v-for = "(layer, index) in state.layers"
+            v-for = "(layer, index) in state.layers.filter(l => showLayer(l))"
           >
             <bar-loader :loading = "layer.loading"/>
             <div class = "box box-primary">
@@ -986,7 +985,9 @@
 
           // get config from getData object
           const { method, params } = query.pagination.getData;
-          const layer              = (query.pagination.getData.layers || [])[index];
+          //@since 4.0.1 need to checck layer id of layer beacause can happend,
+          // that order of this.state.layers is not equal to 
+          const layer              = (query.pagination.getData.layers || []).find(l => layers[index].id === l.getId());
 
           // whehter layer has filter
           const has_filtertoken = !!layer.getFilterToken();

--- a/src/services/data.js
+++ b/src/services/data.js
@@ -252,11 +252,12 @@ export default {
     const counts     = [];
     const page_sizes = []; //set pages based on count feature returned by server
     const paginate   = []; //@since v4.0.0 set if is paginate, mean ctat data i more tna count
+    const layers     = []; //@since 4.0.1 need to add layers that has at least one feature to show on query result
     return {
       data: (await Promise.allSettled(
         [].concat(layer).map((l, i) => l.searchFeatures({ ...params, filter: params.filter[i] }))
       ))
-        .filter(d => 'fulfilled' === d.status)
+        .filter(d => 'fulfilled' === d.status && (d.value?.data || [])[0].features?.length > 0) //@since 4.0.1 check length features
         .map(({ value } = {}) => {
           //@since 3.11.0 In case autofilter set
           if (1 === params.autofilter) {
@@ -271,13 +272,16 @@ export default {
 
           if (params.page_sizes)  {
             const features = (value.data || [])[0].features;
+            //@since 4.0.1 get project layer
+            const layer    = (value.data || [])[0].layer;
             //get max number of elements per page
-            const max = Math.max(...(Array.isArray(params.page_sizes)? params.page_sizes : [params.page_sizes]));
+            const max      = Math.max(...(Array.isArray(params.page_sizes)? params.page_sizes : [params.page_sizes]));
             //Check if count (total number of elements of search is more o less than max)
             page_sizes.push(max <= value.count ? params.page_sizes : [...params.page_sizes.filter(p => p < value.count), value.count]);
             //add a count element on counts array
             counts.push(value.count);
             paginate.push(features && value.count > features.length);
+            layers.push(layer);
           }
           if (params.raw)                                         { return { data: value }; }
           if (Array.isArray(value.data) && value.data.length > 0) { return value.data[0]; }
@@ -296,9 +300,10 @@ export default {
           paginate,
           //Object contains info for do another request by another part of code
           getData: {
-            params: params.filter.map(filter => ({ ...params, filter })),
+            //@since 4.0.1 need
+            params: params.filter.slice(0, layers.length).map(filter => ({ ...params, filter })),
             method: 'searchFeatures',
-            layers: [].concat(layer)
+            layers: [].concat(layers)
           }
         },
       },

--- a/src/services/data.js
+++ b/src/services/data.js
@@ -259,7 +259,7 @@ export default {
     ApplicationState.project.state.layerstree.forEach(traverse);
     return {
       data: (await Promise.allSettled(
-        [].concat(layer).sort((a,b) => (layersId.indexOf(a.id) > layersId.indexOf(b.id) ? 1 : -1)).map((l, i) => l.searchFeatures({ ...params, filter: params.filter[i] }))
+        ([].concat(layer).sort((a, b) => (layersId.indexOf(a.state.id) > layersId.indexOf(b.state.id) ? 1 : -1))).map((l, i) => l.searchFeatures({ ...params, filter: params.filter[i] }))
       ))
         .filter(d => 'fulfilled' === d.status && (d.value?.data || [])[0].features?.length > 0) //@since 4.0.1 check length features
         .map(({ value } = {}) => {

--- a/src/services/data.js
+++ b/src/services/data.js
@@ -251,7 +251,7 @@ export default {
     //@since 3.11.0 count features returned by
     const counts     = [];
     const page_sizes = []; //set pages based on count feature returned by server
-    const paginate   = []; //@since v4.0.0 set if is paginate, mean ctat data i more tna count
+    const paginate   = []; //@since v4.0.0 Boolean Array. Store if layer has pagination, mean response count is more that features length returned by server request
     const layers     = []; //@since 4.0.1 need to add layers that has at least one feature to show on query result
     //@since 4.0.1 need to get project layers id order as on TOC. results thake in aoccount this order
     const layersId   = [];

--- a/src/services/data.js
+++ b/src/services/data.js
@@ -253,9 +253,13 @@ export default {
     const page_sizes = []; //set pages based on count feature returned by server
     const paginate   = []; //@since v4.0.0 set if is paginate, mean ctat data i more tna count
     const layers     = []; //@since 4.0.1 need to add layers that has at least one feature to show on query result
+    //@since 4.0.1 need to get project layers id order as on TOC. results thake in aoccount this order
+    const layersId   = [];
+    const traverse = tree => (tree.nodes || [tree]).forEach(n => { if (n.id) { layersId.push(n.id) } else { traverse(n) } });
+    ApplicationState.project.state.layerstree.forEach(traverse);
     return {
       data: (await Promise.allSettled(
-        [].concat(layer).map((l, i) => l.searchFeatures({ ...params, filter: params.filter[i] }))
+        [].concat(layer).sort((a,b) => (layersId.indexOf(a.id) > layersId.indexOf(b.id) ? 1 : -1)).map((l, i) => l.searchFeatures({ ...params, filter: params.filter[i] }))
       ))
         .filter(d => 'fulfilled' === d.status && (d.value?.data || [])[0].features?.length > 0) //@since 4.0.1 check length features
         .map(({ value } = {}) => {


### PR DESCRIPTION
## How to test

Go to: https://v310.g3wsuite.it/en/map/osm-lac/qdjango/299/

1. A layer has no features on results
2. The order of search layers not follow TOC layer order, which is based  state.layers of queryresults

Both of these case show pagination a a wrong layer, due of order of layers presentation on query result content

## Before

Make a search with 3 layers (Generators, Stations and Connectors)

- **Generators** response 0 features and are not show on result content.
- **Stations** return 12 features (pagination) but not show on result 

  <img width="1869" height="874" alt="Screenshot_20250821_142919" src="https://github.com/user-attachments/assets/9d02d122-a2c1-4345-a886-7cc2f2006ccf" />

- **Connectors** return 6 results but **Stations** layer pagination is created in a wrong layer

<img width="469" height="874" alt="Screenshot_20250821_143240" src="https://github.com/user-attachments/assets/79c080b0-8f1c-4f9a-b264-4be2393df51c" />


## After

**Stations** layer is paginated

<img width="469" height="222" alt="Screenshot_20250821_143422" src="https://github.com/user-attachments/assets/0753c4cc-2fb5-45aa-b9c1-9983077de3f2" />

**Connectors** - No pagination

<img width="469" height="222" alt="Screenshot_20250821_143515" src="https://github.com/user-attachments/assets/bb7f979b-3024-41da-a8b2-8f2b0b3ed444" />
