### PR TITLE
✨ Send OPACITIES param to getPrint service api

### DIFF
--- a/src/components/Print.vue
+++ b/src/components/Print.vue
@@ -506,6 +506,7 @@ export default {
             TEMPLATE:       this.state.template,
             DPI:            this.state.dpi,
             STYLES:         layers.map(l => l.getStyle()).join(','),
+            OPACITIES:      layers.map(l => parseInt((l.getOpacity() / 100) * 255)).join(','), //@since 4.0.1 send OPACITIES parameter
             ...(has_theme ? {} : { LAYERS }), // in the case of a map that has preset_theme, no LAYERS need tyo pass as parameter.
             FORMAT:         ({ png: 'png', pdf: 'application/pdf', geopdf: 'application/pdf' })[this.state.format] || this.state.format,
             ...('geopdf' === this.state.format ? { FORMAT_OPTIONS: 'WRITE_GEO_PDF:TRUE'} : {}), //@since 3.10.0


### PR DESCRIPTION
Add **OPACITIES** param to getPrint service to show on print result the opacity set on each layers