### PR TITLE
Add a style parameter to commit url api [EDITING]

### DIFF
--- a/src/app/gui/inputs/picklayer/service.js
+++ b/src/app/gui/inputs/picklayer/service.js
@@ -13,6 +13,8 @@ module.exports = class PickLayerService {
     this.interaction = 'map' === this.pick_type  ? new PickFeatureInteraction({
       layers: [this.mapService.getLayerById(this.layerId)]
     }) : new PickCoordinatesInteraction();
+    //@since 4.0.1 set id. It used on editing plugin
+    this.interaction.set('id', 'picklayer');
   }
 
   /**

--- a/src/components/InputSelect.vue
+++ b/src/components/InputSelect.vue
@@ -58,11 +58,8 @@
           :value = "select2NullValue">
         </option>
 
-        <option
-          v-for  = "({ key, value }) in state.input.options.values"
-          :key   = "getValue(value)"
-          :value = "getValue(value)">
-            {{ key }}
+        <option v-for  = "({ key, value }) in state.input.options.values"
+          :value = "getValue(value)">{{ key }}
         </option>
       </select>
     </div>

--- a/src/map/layers/featuresstore.js
+++ b/src/map/layers/featuresstore.js
@@ -121,12 +121,12 @@ export class FeaturesStore extends G3WObject {
     return $promisify(async () => {
       if (commitItems && this._provider) {
         commitItems.lockids = this._lockIds;
-        //get editing config style related to layer
-        const style = this._provider._layer.config?.editing?.layer_style;
         return await XHR.post({
           //@since 4.0.1 need to add style parameter to commit url in case of layer has a specific editing style
-          url:         `${this._provider._layer.getUrl('commit')}${ style ? `?style=${style}` : ''}`,
-          data:        JSON.stringify(commitItems),
+          url:         this._provider._layer.getUrl('commit'),
+          //layer_style, if not set on admin, it set as empty string as default. So in this case need to se undefine to avoid to set style parameter
+          //on POST body
+          data:        JSON.stringify(Object.assign(commitItems, { style: this._provider._layer.config?.editing?.layer_style || undefined })),
           contentType: 'application/json',
         });
       }

--- a/src/map/layers/featuresstore.js
+++ b/src/map/layers/featuresstore.js
@@ -121,9 +121,11 @@ export class FeaturesStore extends G3WObject {
     return $promisify(async () => {
       if (commitItems && this._provider) {
         commitItems.lockids = this._lockIds;
+        //get editing config style related to layer
+        const style = this._provider._layer.config?.editing?.layer_style;
         return await XHR.post({
           //@since 4.0.1 need to add style parameter to commit url in case of layer has a specific editing style
-          url:         `${this._provider._layer.getUrl('commit')}${this._provider._layer.config?.editing?.layer_style ? `?style=${this._provider._layer.config.editing.layer_style}` : ''}`,
+          url:         `${this._provider._layer.getUrl('commit')}${ style ? `?style=${style}` : ''}`,
           data:        JSON.stringify(commitItems),
           contentType: 'application/json',
         });

--- a/src/map/layers/featuresstore.js
+++ b/src/map/layers/featuresstore.js
@@ -180,15 +180,12 @@ export class FeaturesStore extends G3WObject {
      *
      * @type {*[]}
      */
-    const { features = [], featurelocks = [] } = options;
+    const { count, features = [], featurelocks = [] } = options;
 
-    //if no features locks mean another user locks all feature requests
-    if (0 === featurelocks.length) {
-      //if there are features on response
-      if (features.length > 0) {
-        //It means that another user locks these features
-        this.featuresLockedByOtherUser(features);
-      }
+    //@since 4.0.1 if no features are locked, but features returned by server (count) is more than 0
+    if (count > 0 && 0 === features.length) { 
+      //It means that another user locks these features
+      this.featuresLockedByOtherUser(features);
       return [];
     }
 
@@ -221,9 +218,8 @@ export class FeaturesStore extends G3WObject {
       }
     });
 
-    //if features locks are less than features get from server,
-    // it means that another user locks some features
-    if (featurelocks.length < features.length) {
+    //@since 4.0.1 if count (number of feature get from server) is more than features (features not locked)
+    if (count > features.length) {
       this.featuresLockedByOtherUser(lockFeatures);
     }
 

--- a/src/map/layers/featuresstore.js
+++ b/src/map/layers/featuresstore.js
@@ -122,7 +122,7 @@ export class FeaturesStore extends G3WObject {
       if (commitItems && this._provider) {
         commitItems.lockids = this._lockIds;
         return await XHR.post({
-          url:         this._provider._layer.getUrl('commit'),
+          url:         `${this._provider._layer.getUrl('commit')}${this._provider._layer.config?.editing?.layer_style ? `?style=${this._provider._layer.config.editing.layer_style}` : ''}`,
           data:        JSON.stringify(commitItems),
           contentType: 'application/json',
         });

--- a/src/map/layers/featuresstore.js
+++ b/src/map/layers/featuresstore.js
@@ -122,6 +122,7 @@ export class FeaturesStore extends G3WObject {
       if (commitItems && this._provider) {
         commitItems.lockids = this._lockIds;
         return await XHR.post({
+          //@since 4.0.1 need to add style parameter to commit url in case of layer has a specific editing style
           url:         `${this._provider._layer.getUrl('commit')}${this._provider._layer.config?.editing?.layer_style ? `?style=${this._provider._layer.config.editing.layer_style}` : ''}`,
           data:        JSON.stringify(commitItems),
           contentType: 'application/json',

--- a/src/map/layers/layer.js
+++ b/src/map/layers/layer.js
@@ -1507,7 +1507,8 @@ class Layer extends G3WObject {
       Object
         .values(this.state.ol_selection)
         .forEach(f => {
-          f.selected = !f.selected;
+          f.selected          = !f.selected;
+          f.feature.__layerId = this.getId(); //need to add __layerId
           if (f.selected !== f.added) {
             map.setSelectionFeatures(f.selected ? 'add' : 'remove', { feature: f.feature });
             f.added = f.selected;
@@ -2754,6 +2755,7 @@ class Layer extends G3WObject {
       .values(this.state.ol_selection)
       .forEach(f => {
         if (f.selected !== f.added) {
+          f.feature.__layerId = this.getId(); //@since 4.0.1 need to add layerId. It used to reconize feature selected by layer id
           map.setSelectionFeatures(f.selected ? 'add' : 'remove', { feature: f.feature });
           f.added = f.selected;
         }


### PR DESCRIPTION
In case a layer has a specific style for editing


<img width="885" height="443" alt="Screenshot_20250905_093426" src="https://github.com/user-attachments/assets/bf0a0f36-1032-412c-8a50-25607d62d1b0" />


need to add this parameter to commit api call

**Before**

http://localhost:8000/vector/api/commit/qdjango/180/buildings_2f43dc1d_6725_42d2_a09b_dd446220104a/


**After**

http://localhost:8000/vector/api/commit/qdjango/180/buildings_2f43dc1d_6725_42d2_a09b_dd446220104a/?style=Categorized