### PR TITLE
Show clear selection, toggle filter on TOC, when results features of layer are more than one

### DIFF
--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -125,7 +125,7 @@
                     @click.stop      = "toggleSelection(layer)"
                     class            = "action-button"
                     v-t-tooltip:left = "'Add/Remove Selection'"
-                    :class           = "{'toggled': layer.selection.active}"
+                    :class           = "{'toggled': layer.selection.active && layer.features.every(f => f.selection.selected)}"
                   >
                     <span
                       class  = "action-button-icon"

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -1620,7 +1620,7 @@ export default new (class QueryResultsService extends G3WObject {
       );
 
       // set selection property (external layer)
-      catalog_layer.selection.active = Object.values(action.state.toggled).every(t => t);;
+      catalog_layer.selection.active = Object.values(action.state.toggled).some(t => t);;
       
       return;
     }
@@ -1673,7 +1673,7 @@ export default new (class QueryResultsService extends G3WObject {
       });
     }
 
-    catalog_layer.state.selection.active = Object.values(action.state.toggled).every(t => t);
+    catalog_layer.state.selection.active = Object.values(action.state.toggled).some(t => t);
 
     //remove Highlight geometry layer fetures
     GUI.getService('map').clearHighlightGeometry();


### PR DESCRIPTION
In case of more than one features result

## Before

After set a feature selected, on TOC is not show clear selection, toggle filet tools

<img width="1472" height="588" alt="Screenshot_20250911_135440" src="https://github.com/user-attachments/assets/1905f327-c0c5-4199-8fd5-687a47541f25" />


## After

<img width="1472" height="588" alt="Screenshot_20250911_135618" src="https://github.com/user-attachments/assets/c685a514-924e-47f1-9b6c-9c6282a3b724" />

