### PR TITLE
🐛 Spinner on map not hide when a map proxy layer get tileloaderror event

### DIFF
--- a/src/map/layers/imagelayer.js
+++ b/src/map/layers/imagelayer.js
@@ -220,10 +220,17 @@ class RasterLayer extends G3WObject {
         extraParams: this.extraParams,
       }, this._method);
     }
-
-    olLayer.getSource().on(`${image}loadstart`, () => this.emit('loadstart'));
-    olLayer.getSource().on(`${image}loadend`,   () => this.emit('loadend'));
-    olLayer.getSource().on(`${image}loaderror`, () => this.emit('loaderror'));
+    
+    //@since 4.0.2 in case of 'mapproxy' there are load start events tiles different in number from loadend or loaderror
+    //FIX asking to server ancd check only unique url tiles 
+    if ('mapproxy' === this.config.cache_provider) {
+      //Use a set to store unique url tiles loading
+      const loadTile = new Set();
+      olLayer.getSource().on(`${image}loadstart`, e => { if (!loadTile.has(e.tile.src_)) { loadTile.add(e.tile.src_);    this.emit('loadstart') }});
+      olLayer.getSource().on([`${image}loadend`, `${image}loaderror`], e => { if (loadTile.has(e.tile.src_) ) { loadTile.delete(e.tile.src_); this.emit(e.type.split(image)[1]) }} );
+    } else {
+      olLayer.getSource().on([`${image}loadstart`, `${image}loadend`, `${image}loaderror`] , e => this.emit(e.type.split(image)[1]) );
+    }
 
     return olLayer
   }

--- a/src/map/layers/imagelayer.js
+++ b/src/map/layers/imagelayer.js
@@ -226,7 +226,7 @@ class RasterLayer extends G3WObject {
     if ('mapproxy' === this.config.cache_provider) {
       //Use a set to store unique url tiles loading
       const loadTile = new Set();
-      olLayer.getSource().on(`${image}loadstart`, e => { if (!loadTile.has(e.tile.src_)) { loadTile.add(e.tile.src_);    this.emit('loadstart') }});
+      olLayer.getSource().on(`${image}loadstart`, e => { if (!loadTile.has(e.tile.src_)) { loadTile.add(e.tile.src_); this.emit('loadstart') }});
       olLayer.getSource().on([`${image}loadend`, `${image}loaderror`], e => { if (loadTile.has(e.tile.src_) ) { loadTile.delete(e.tile.src_); this.emit(e.type.split(image)[1]) }} );
     } else {
       olLayer.getSource().on([`${image}loadstart`, `${image}loadend`, `${image}loaderror`] , e => this.emit(e.type.split(image)[1]) );

--- a/src/services/map.js
+++ b/src/services/map.js
@@ -229,6 +229,8 @@ class MapService extends G3WObject {
    * @since 3.11.0
    */
   onLayerLoadError() {
+    //need to reduce layer loading counter
+    this.onLayerLoadEnd();
     /** @since 3.10.0 - fails silently */
     if (!this.project.state.show_load_layer_error) {
       return;
@@ -237,8 +239,7 @@ class MapService extends G3WObject {
       GUI.notify.warning('Some layers are not available');
       this.onLayerLoadError.shown = true;
     }
-    this.onLayerLoadEnd();
-  }
+    }
 
   /**
    * @returns promise ready


### PR DESCRIPTION
Steps:

1. Set a layer with mapproxy cache

<img width="1204" height="305" alt="Screenshot_20250912_141528" src="https://github.com/user-attachments/assets/09d4e181-b285-49bc-b1e4-370736c7f258" />

<img width="605" height="305" alt="Screenshot_20250912_141502" src="https://github.com/user-attachments/assets/8440e932-1fd8-4991-9cda-5e0d2d145e8d" />

**Before** 
Spinner stay on map in case of some tile fail to load

<img width="616" height="305" alt="Screenshot_20250912_142957" src="https://github.com/user-attachments/assets/1e825ec2-02a4-4606-b47d-a4eb6a8a4b0d" />

**After**

Spinner is hide
<img width="605" height="406" alt="Screenshot_20250912_143102" src="https://github.com/user-attachments/assets/10a78b3c-a602-469c-917c-2872c28fb14c" />

