### PR TITLE
Select all button doesn't mantain its state across multiple queries

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -329,7 +329,7 @@ export default {
     async inverseSelection() {
       // get all features
       if (!this.getAll) {
-        await this.getFeatures()
+        await this.getFeatures({ formatter: 1 })
       }
       //invert select attribute from current loaded features
       this.state.features.forEach(f => f.selected = !f.selected);
@@ -352,7 +352,7 @@ export default {
 
       // get all features when any kind of filter is unset
       if (!filter && this.state.selectAll && !this.getAll) {
-        await this.getFeatures(); 
+        await this.getFeatures({ formatter: 1 }); 
       }
 
       // no filter

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -331,8 +331,11 @@ export default {
       if (!this.getAll) {
         await this.getFeatures()
       }
+      //invert select attribute from current loaded features
       this.state.features.forEach(f => f.selected = !f.selected);
+      //Invert selection
       this.layer.invertSelectionFids();
+      //set state of all features on table
       this.state.selectAll = this.layer.getSelectionFids().has(SELECTION.ALL) || this.state.features.every(f => f.selected);
     },
 

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -590,12 +590,12 @@ export default {
               this.layer.addOlSelectionFeature(_createFeatureForSelection(f));
               if (f.selected) { this.layer.includeSelectionFid(f.id) };
             }
-            
+
             return {
               id:         f.id,
               selected:   f.selected,
               attributes: f.attributes || f.properties,
-              geometry:   this.layer.isGeoLayer() && f.geometry || undefined
+              geometry:   has_geometry && f.geometry || undefined
             };
           })
         );

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -234,7 +234,7 @@ export default {
      * @since 4.0.0
      */
     show_on_active_filter() {
-      return !this.layer.state.filter.pagination && (this.layer.state.filter.active || !this.layer.state.selectionFids.has('__ALL__'));
+      return !(this.layer.state.filter.pagination && (this.layer.state.filter.active || !this.layer.state.selectionFids.has('__ALL__')));
     },
 
     current_layout() {
@@ -608,7 +608,7 @@ export default {
         );
 
         this.state.show_tools = this.layer.state.filter.active || this.layer.getSelectionFids().size > 0;
-        this.state.selectAll  = this.layer.state.filter.active || this.state.selectAll && this.state.features.every(f => f.selected);
+        this.state.selectAll  = this.layer.state.filter.active || this.layer.state.selectionFids.has('__ALL__') || (this.state.selectAll && this.state.features.every(f => f.selected));
 
         return {
           data:            this.state.features.map(f => [null].concat(this.state.headers.filter(h => h).map(h => { h.value = (f.attributes || f.properties)[h.name]; return h.value; }))),

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -369,9 +369,8 @@ export default {
         await this.$nextTick();                                                                  // wait for DOM changes
         (await this.getFeatures({ field: this.search.field, formatter: 1 }) || [])
           .forEach(f => {
-            const geometry = (this.layer.isGeoLayer() && f.geometry) || undefined;
             f.selected = this.state.selectAll;
-            if (geometry) {
+            if (f.geometry) {
               this.layer.addOlSelectionFeature(_createFeatureForSelection(f));
             }
             this.layer.includeSelectionFid(f.id);
@@ -379,7 +378,7 @@ export default {
               id:         f.id,
               selected:   f.selected,                                                            // whether filter token comes from a pagination
               attributes: f.attributes || f.properties,
-              geometry
+              geometry  : f.geometry
           });
         })
       }

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -367,7 +367,7 @@ export default {
         this.state.selectAll = true;                                                             // force selectAll
         this.state.features.splice(0);                                                           // reset features
         await this.$nextTick();                                                                  // wait for DOM changes
-        (await this.getFeatures({ field: this.search.field }) || [])
+        (await this.getFeatures({ field: this.search.field, formatter: 1 }) || [])
           .forEach(f => {
             const geometry = (this.layer.isGeoLayer() && f.geometry) || undefined;
             f.selected = this.state.selectAll;

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -70,7 +70,7 @@
         </tr>
         <tr>
           <th v-disabled = "disableSelectAll">
-            <label @click = "selectAllRows">
+            <label @click.stop = "selectAllRows">
               <input type = "checkbox" :checked = "state.selectAll && state.features.length > 0" />
             </label>
           </th>
@@ -104,8 +104,8 @@
           <td>
             <div style = "display: flex">
               <label
-                v-if   = "show_on_active_filter"
-                @click = "select(feature)"
+                v-if        = "show_on_active_filter"
+                @click.stop = "select(feature)"
               >
                 <input type = "checkbox" :checked = "feature.selected" />
               </label>

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -70,7 +70,7 @@
         </tr>
         <tr>
           <th v-disabled = "disableSelectAll">
-            <label @click.stop = "selectAllRows">
+            <label @click = "selectAllRows">
               <input type = "checkbox" :checked = "state.selectAll && state.features.length > 0" />
             </label>
           </th>
@@ -104,8 +104,8 @@
           <td>
             <div style = "display: flex">
               <label
-                v-if        = "show_on_active_filter"
-                @click.stop = "select(feature)"
+                v-if   = "show_on_active_filter"
+                @click = "select(feature)"
               >
                 <input type = "checkbox" :checked = "feature.selected" />
               </label>

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -474,8 +474,8 @@ export default {
      */
     select(feature) {
       feature.selected      = !feature.selected;                                                // inverse selected feature
-      this.state.selectAll  = this.state.features.every(f => f.selected);                       // check if all rows are selected
-      this.layer[feature.selected ? 'includeSelectionFid' : 'excludeSelectionFid'](feature.id);
+      this.state.selectAll  = this.state.features.every(f => f.selected); 
+      this.layer[feature.selected ? 'includeSelectionFid' : 'excludeSelectionFid'](`${feature.id}`); //string
       this.state.show_tools = this.layer.getSelectionFids().size > 0;                           // show tools based on selected state
     },
 

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -584,23 +584,16 @@ export default {
         // add features
         this.state.features.push(
           ...(data.features || []).map(f => {
+            f.selected = this.state.selectAll || this.layer.state.filter.active || this.layer.hasSelectionFid(f.id)
             const has_geometry = this.layer.isGeoLayer() && f.geometry;
-            
             if (has_geometry && !this.layer.getOlSelectionFeature(f.id)) {
-              f.selected = this.state.selectAll;
               this.layer.addOlSelectionFeature(_createFeatureForSelection(f));
-              if (f.selected) {
-                this.layer.includeSelectionFid(f.id)
-              };
+              if (f.selected) { this.layer.includeSelectionFid(f.id) };
             }
-
-            if (has_geometry && this.layer.getOlSelectionFeature(f.id)) {
-              f.selected = true;
-            }
-
+            
             return {
               id:         f.id,
-              selected:   this.layer.getFilterToken() || this.layer.hasSelectionFid(f.id),
+              selected:   f.selected,
               attributes: f.attributes || f.properties,
               geometry:   this.layer.isGeoLayer() && f.geometry || undefined
             };

--- a/src/map/layers/layer.js
+++ b/src/map/layers/layer.js
@@ -2734,8 +2734,7 @@ class Layer extends G3WObject {
     const feature = new ol.Feature(feat.geometry);
     //@since 4.0.2 In case of no G3W_FID attribute, need to add it to selection features to sync with content result
     if (undefined === feat.attributes[G3W_FID]) {
-      feat.attributes[G3W_FID] = id; //add as string
-    }
+      feat.attributes[G3W_FID] = id; //add id as G3W_FID attribute
     feature.setId(`${this.getId()}_${id}`); // see: #777, prevent ID collision when selecting features from multiple layers
     Object.entries(feat.attributes).forEach(([a, v]) => feature.set(a, v));
     this.state.ol_selection[id] = this.state.ol_selection[id] || {

--- a/src/map/layers/layer.js
+++ b/src/map/layers/layer.js
@@ -2732,6 +2732,10 @@ class Layer extends G3WObject {
   addOlSelectionFeature({ id, feature: feat } = {}) {
     //create a new ol feature
     const feature = new ol.Feature(feat.geometry);
+    //@since 4.0.2 In case of no G3W_FID attribute, need to add it to selection features to sync with content result
+    if (undefined === feature.get(G3W_FID)) {
+      feature.set(G3W_FID, id);
+    }
     feature.setId(`${this.getId()}_${id}`); // see: #777, prevent ID collision when selecting features from multiple layers
     Object.entries(feat.attributes).forEach(([a, v]) => feature.set(a, v));
     this.state.ol_selection[id] = this.state.ol_selection[id] || {

--- a/src/map/layers/layer.js
+++ b/src/map/layers/layer.js
@@ -2733,8 +2733,8 @@ class Layer extends G3WObject {
     //create a new ol feature
     const feature = new ol.Feature(feat.geometry);
     //@since 4.0.2 In case of no G3W_FID attribute, need to add it to selection features to sync with content result
-    if (undefined === feature.get(G3W_FID)) {
-      feature.set(G3W_FID, `${id}`); //set as string
+    if (undefined === feat.attributes[G3W_FID]) {
+      feat.attributes[G3W_FID] = id; //add as string
     }
     feature.setId(`${this.getId()}_${id}`); // see: #777, prevent ID collision when selecting features from multiple layers
     Object.entries(feat.attributes).forEach(([a, v]) => feature.set(a, v));

--- a/src/map/layers/layer.js
+++ b/src/map/layers/layer.js
@@ -1496,11 +1496,12 @@ class Layer extends G3WObject {
   invertSelectionFids() {
     const selection = this.state.selectionFids;
 
-    /** @TODO add description */
+    /** In case selection set has EXCLUDE string, just remove it and ids are already selection */
     if (selection.has(SELECTION.EXCLUDE))  { selection.delete(SELECTION.EXCLUDE); }
+    // In case of all features selected, need to remove ALL, and size of selection is 0 (no selection features)
     else if (selection.has(SELECTION.ALL)) { selection.delete(SELECTION.ALL); }
+    //In case there are some feature id selected, just add EXCLUDE to exclude current selection fids
     else if (selection.size > 0)           { selection.add(SELECTION.EXCLUDE); }
-
     // invert selection (state)
     if (this.isGeoLayer()) {
       const map = GUI.getService('map');

--- a/src/map/layers/layer.js
+++ b/src/map/layers/layer.js
@@ -2735,6 +2735,7 @@ class Layer extends G3WObject {
     //@since 4.0.2 In case of no G3W_FID attribute, need to add it to selection features to sync with content result
     if (undefined === feat.attributes[G3W_FID]) {
       feat.attributes[G3W_FID] = id; //add id as G3W_FID attribute
+    }
     feature.setId(`${this.getId()}_${id}`); // see: #777, prevent ID collision when selecting features from multiple layers
     Object.entries(feat.attributes).forEach(([a, v]) => feature.set(a, v));
     this.state.ol_selection[id] = this.state.ol_selection[id] || {

--- a/src/map/layers/layer.js
+++ b/src/map/layers/layer.js
@@ -2734,7 +2734,7 @@ class Layer extends G3WObject {
     const feature = new ol.Feature(feat.geometry);
     //@since 4.0.2 In case of no G3W_FID attribute, need to add it to selection features to sync with content result
     if (undefined === feature.get(G3W_FID)) {
-      feature.set(G3W_FID, id);
+      feature.set(G3W_FID, `${id}`); //set as string
     }
     feature.setId(`${this.getId()}_${id}`); // see: #777, prevent ID collision when selecting features from multiple layers
     Object.entries(feat.attributes).forEach(([a, v]) => feature.set(a, v));

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -456,7 +456,7 @@ export default new (class QueryResultsService extends G3WObject {
             id:         external ? f.getId() : (f instanceof ol.Feature ? f.getId() : f.id),
             attributes: f instanceof ol.Feature ? f.getProperties() : f.properties,
             geometry:   f instanceof ol.Feature ? f.getGeometry()   : f.geometry,
-            selection:  { selected: !external && (!!queryResponse.query.autofilter || layer.state.selection.active)}, //@since 3.11.8 check if autofilter is set
+            selection:  { selected: !external && (!!queryResponse.query.autofilter || layer.hasSelectionFid((f instanceof ol.Feature ? f.getId() : f.id)))}, //@since 3.11.8 check if autofilter is set
             show:       true,
           })),
           hasgeometry:            Array.isArray(features) && !rawdata && features.some(f => f instanceof ol.Feature ? f.getGeometry() : f.geometry),
@@ -845,10 +845,8 @@ export default new (class QueryResultsService extends G3WObject {
             }
             const _layer                = getCatalogLayerById(layer.id);
             const fid                   = feature.attributes[G3W_FID] || feature.id;
-            const selected              = layer.external ? feature.selection.selected : (_layer.state.filter.active || _layer.hasSelectionFid(fid));
-            action.state.toggled[index] = selected;
-            layer.selection.active      = (0 === index || layer.selection.active) && selected;
-            if (_layer && selected && !_layer.hasSelectionFid(fid)) {
+            action.state.toggled[index] = feature.selection.selected;
+            if (_layer && feature.selection.selected && !_layer.hasSelectionFid(fid)) {
               _layer.addOlSelectionFeature({ id: fid, feature }).selected = true;
               _layer.includeSelectionFid(fid, false);
             }


### PR DESCRIPTION
## How to reproduce

https://github.com/user-attachments/assets/6b9b98c0-c610-4255-abb1-bb450bae56f4

## Before

After querying again that features, select all button is un-toggled but all features are selected.

<img width="1565" height="704" alt="Screenshot_20250916_161657" src="https://github.com/user-attachments/assets/ec49f715-c06d-4f26-aa8c-7abd521f8bc3" />

## After

After querying again that features, select all button is toggled and all features are selected.

<img width="1565" height="704" alt="Screenshot_20250916_161822" src="https://github.com/user-attachments/assets/214b04e8-8ecc-4acd-84f5-6c61989b68bc" />

