### PR TITLE
🐛 Compare relation feature filter expression value with key to select option  [editing]

### DIFF
--- a/src/map/layers/layer.js
+++ b/src/map/layers/layer.js
@@ -206,7 +206,7 @@ const Providers = {
             response = await XHR.post({
               url:         createRelationsUrl(options.filter.fid),
               contentType: 'application/json',
-              data:        JSON.stringify({ formatter: 0 }), //@since 4.0.3 set formatter 0 becouse need pure (raw) dara
+              data:        JSON.stringify({ formatter: 1 }),
             });
           } else if (options.filter.field) {
             response = await XHR.post({

--- a/src/map/layers/layer.js
+++ b/src/map/layers/layer.js
@@ -206,7 +206,7 @@ const Providers = {
             response = await XHR.post({
               url:         createRelationsUrl(options.filter.fid),
               contentType: 'application/json',
-              data:        JSON.stringify({ formatter: 1 }),
+              data:        JSON.stringify({ formatter: 0 }), //@since 4.0.3 set formatter 0 becouse need pure (raw) dara
             });
           } else if (options.filter.field) {
             response = await XHR.post({

--- a/src/utils/getFilterExpression.js
+++ b/src/utils/getFilterExpression.js
@@ -1,4 +1,5 @@
 import DataRouterService from 'services/data';
+import ApplicationState  from 'store/application';
 
 /**
  * ORIGINAL SOURCE: src/app/core/expression/inputservice.js@3.8.6
@@ -66,18 +67,23 @@ export async function getFilterExpression({
           value: features[i].properties[key]
         })
       }
+      //@since 4.0.3 change value of relation field because relation firld value is get with formatter 1
+      if (parentData && null !== field.value) {
+        field.value = values.find(({ key }) => key == field.value)?.value ?? field.value;
+      }
       //Case Bonifica Renana https://github.com/orgs/g3w-suite/projects/12/views/1?pane=issue&itemId=123189761&issue=g3w-suite%7Cg3w-admin%7C1180
       //use not strict equality to avoid issues with numbers and strings
-      //@since 4.0.3 In case of parentDat, case relation, need to compare with key and not value
-      //because relations features are get with formatter: 1
-      if (field.value && !values.find(({ value, key }) => parentData ? key : value == field.value)) {
+      if (field.value && !values.find(({ value }) => value == field.value)) {
         values.unshift({
           key:   `(${field.value})`,
           value: field.value,
         });
       };
-
       field.input.options.values = values;
+      //@since 4.0.3 need to set values from input.option.values of config editing field to show key (formatter 1) value on relation table features
+      if (parentData) {
+        ApplicationState.project.getLayerById(qgs_layer_id).config.editing.fields.find(f => f.name === field.name ).input.options.values = values;
+      }
     }
 
     return features;

--- a/src/utils/getFilterExpression.js
+++ b/src/utils/getFilterExpression.js
@@ -68,7 +68,9 @@ export async function getFilterExpression({
       }
       //Case Bonifica Renana https://github.com/orgs/g3w-suite/projects/12/views/1?pane=issue&itemId=123189761&issue=g3w-suite%7Cg3w-admin%7C1180
       //use not strict equality to avoid issues with numbers and strings
-      if (field.value && !values.find(({ value }) => value == field.value)) {
+      //@since 4.0.3 In case of parentDat, case relation, need to compare with key and not value
+      //because relations features are get with formatter: 1
+      if (field.value && !values.find(({ value, key }) => parentData ? key : value == field.value)) {
         values.unshift({
           key:   `(${field.value})`,
           value: field.value,


### PR DESCRIPTION
## Test page

https://v310.g3wsuite.it/it/map/epsg-25833/qdjango/323/

## Before

Try to edit a relation _elementi_caratterizzanti_ from _piani_

<img width="773" height="653" alt="Screenshot_20250930_103257" src="https://github.com/user-attachments/assets/6f9a0a69-9b6a-4c56-b96d-2843e5b25a95" />

**lin_inq_tsubinq_id** contain a value with parenthesis, mean no value on select values is found.
This because relations  _elementi_caratterizzanti feature from piani (parent layer) feature are get using formatter 1 parameter:

<img width="773" height="292" alt="Screenshot_20250930_103611" src="https://github.com/user-attachments/assets/9e5057f0-bc05-4159-a218-1d777feae120" />

so we need to compate this value with keys and not value of select options


<img width="773" height="648" alt="Screenshot_20250930_103652" src="https://github.com/user-attachments/assets/4d3dcfb4-ec8e-4004-a40a-00967ce8e641" />

## After

<img width="410" height="395" alt="Screenshot_20250930_104755" src="https://github.com/user-attachments/assets/5a7638da-2fcb-4c43-82e5-beb09fe2207a" />

