### PR TITLE
Empty result when querying a layer having a projection different from map (ref: `query:bbox`, `query:polygon`)

### DIFF
--- a/src/map/controls/queryby.js
+++ b/src/map/controls/queryby.js
@@ -308,6 +308,11 @@ export class QueryBy extends InteractionControl {
             },
             beforeDestroy: () => {
               GUI.toggleUserMessage(true);
+              //@since 4.0.3 take in account error/warning user message arise
+              //during runSpatialQuery
+              if (this.isToggled()) {
+                this.toggle();
+              }
               this.types.forEach(t => {
                 CONTROLS[t].toggle(false);
                 CONTROLS[t].autorun = false;

--- a/src/map/controls/queryby.js
+++ b/src/map/controls/queryby.js
@@ -310,9 +310,7 @@ export class QueryBy extends InteractionControl {
               GUI.toggleUserMessage(true);
               //@since 4.0.3 take in account error/warning user message arise
               //during runSpatialQuery
-              if (this.isToggled()) {
-                this.toggle();
-              }
+              this.toggle(false);
               this.types.forEach(t => {
                 CONTROLS[t].toggle(false);
                 CONTROLS[t].autorun = false;

--- a/src/services/data.js
+++ b/src/services/data.js
@@ -525,7 +525,6 @@ export default {
   async getQueryLayersPromisesByGeometry(layers,
     {
       geometry,
-      projection,
       filterConfig  = {},
       multilayers   = false,
       feature_count = 10
@@ -536,20 +535,16 @@ export default {
       return [];
     }
 
-    const mapCrs = projection.getCode();
-
     return await handleQueryPromises(Object.values(
       multilayers
         ? groupBy(layers, l => `${l.getMultiLayerId()}_${l.getProjection().getCode()}`)
         : layers
     ).map(layers => {
       const layer = [].concat(layers)[0];
-      const crs   = layer.getProjection().getCode();
       const filter = {
         config: filterConfig,
         type:   'geometry',
-        // Convert filter geometry from map to layer CRS
-        value:  mapCrs === crs ? geometry : geometry.clone().transform(mapCrs, crs),
+        value:  geometry,
       };
       return promisify(layer.query(
         multilayers

--- a/src/services/data.js
+++ b/src/services/data.js
@@ -191,7 +191,7 @@ export default {
           messagetext: true,
           autoclose:   false
         },
-        data: (await this.getQueryLayersPromisesByGeometry(
+        data: geometry ? (await this.getQueryLayersPromisesByGeometry(
           // layers
           getMapLayersByFilter({
             ...(
@@ -210,11 +210,11 @@ export default {
             filterConfig,
             projection: ApplicationState.project.getProjection()
           }
-        ) || []).flatMap(({ data = [] }) => data),
+        ) || []).flatMap(({ data = [] }) => data) : [],
       };
-    } catch (error) {
-      console.warn(error);
-      throw error;
+    } catch (err) {
+      console.warn(err);
+      throw err;
     }
   },
 
@@ -530,8 +530,8 @@ export default {
       feature_count = 10
     } = {}
   ) {
-    // skip when no features
-    if (0 === layers.length) {
+    // skip when no features or no geometry
+    if (0 === layers.length || !geometry) {
       return [];
     }
 

--- a/src/services/gui.js
+++ b/src/services/gui.js
@@ -342,7 +342,7 @@ export default new (class GUI extends G3WObject {
 
       //Check id we can show data
       const show = 'function' === typeof output.condition ? await output.condition(data) : false !== output.condition;
-      const last = show && rid === this.outputDataPlace.reqs.at(-1);
+      const last = rid === this.outputDataPlace.reqs.at(-1);
 
       // set request output ids empty
       if (last) {
@@ -364,8 +364,12 @@ export default new (class GUI extends G3WObject {
       }
 
       // check if data can be shown on query result content
-      if (last) {
+      if (last && show) {
         (this.getService('queryresults') || this.showQueryResults(output.title || '')).setQueryResponse(data, { add: !!output.add });
+      }
+      //@since 4.0.3 in case of show false, need to close content
+      if (last && !show) {
+        await this.closeContent();
       }
 
       // call after is set with data

--- a/src/services/gui.js
+++ b/src/services/gui.js
@@ -351,16 +351,16 @@ export default new (class GUI extends G3WObject {
 
       //if set before call method and wait
       if (last && output.before) {
-        await output.before(data)
+        await output.before(data);
       }
 
       // in case of usermessage show user message
       if (last && data.usermessage) {
-        this.showUserMessage({
+        await this.showUserMessage({
           type:      data.usermessage.type,
           message:   data.usermessage.message,
           autoclose: data.usermessage.autoclose
-        });
+        });  
       }
 
       // check if data can be shown on query result content
@@ -374,7 +374,7 @@ export default new (class GUI extends G3WObject {
 
       // call after is set with data
       if (last && output.after) {
-        output.after(data)
+        output.after(data);
       }
     } catch(e) {
       console.warn(e);
@@ -546,7 +546,7 @@ export default new (class GUI extends G3WObject {
   }
 
   //showusermessage
-  showUserMessage({
+  async showUserMessage({
     title,
     subtitle,
     message,
@@ -563,8 +563,8 @@ export default new (class GUI extends G3WObject {
   } = {}) {
 
     this.closeUserMessage();
-
-    setTimeout(() => {
+    //@since 4.0.3
+    await new Promise((res) => setTimeout(() => {
       Object.assign(ApplicationState.viewport.usermessage, {
         id: getUniqueDomId(),
         show: true,
@@ -582,7 +582,8 @@ export default new (class GUI extends G3WObject {
         hooks,
         iconClass,
       });
-    });
+      res();
+    }));
 
     return ApplicationState.viewport.usermessage;
   }

--- a/src/services/map.js
+++ b/src/services/map.js
@@ -514,7 +514,8 @@ class MapService extends G3WObject {
     const { data = [] } = await DataRouterService.getData('search:fids', {
       inputs: {
         layer,
-        fids:  [fid]
+        fids:      [fid],
+        formatter: 1, //@since 4.0.3 need to set formatter 1 to show formatted data
       },
       outputs: {
         show: {


### PR DESCRIPTION
## How to test

[project.zip](https://github.com/user-attachments/files/22736392/project.zip)

If we query a layer having a different projection from map using query area control 

Map **[EPSG:3857]** - Layer _testdate_ **[EPSG:4326]**

<img width="834" height="696" alt="Screenshot_20251007_084627" src="https://github.com/user-attachments/assets/235be5d7-8634-4998-a848-ce1d913ccdc8" />

## Before

No results

<img width="1085" height="1018" alt="Screenshot_20251007_085329" src="https://github.com/user-attachments/assets/a828b0b7-6d8a-45a0-9c5f-4e443ae4ea63" />

Coordinates are in EPSG: 4326 (layer projection)

<img width="788" height="156" alt="Screenshot_20251007_085417" src="https://github.com/user-attachments/assets/14e718df-5a87-4a83-b7b6-1528dec86ad7" />

## After

<img width="1034" height="1020" alt="Screenshot_20251007_085553" src="https://github.com/user-attachments/assets/7b45dfb5-da4f-4786-99bb-ff2012293061" />

Coordinates are in EPSG: 3857 (map projection)

<img width="793" height="164" alt="Screenshot_20251007_085636" src="https://github.com/user-attachments/assets/18f57a1d-6677-4196-99b9-90d9b019d627" />
