### PR TITLE
🐛 Missing G3W_FID

### DIFF
--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -567,6 +567,7 @@
 </template>
 
 <script>
+  import { G3W_FID }                 from 'g3w-constants';
   import ApplicationState            from 'store/application';
   import { fieldsMixin }             from 'mixins';
   import TableAttributeFieldValue    from 'components/QueryResultsTableAttributeFieldValue.vue';


### PR DESCRIPTION
When we run a search with pagination, after setting filter results, if we change page we receive a javascript warning message and no features are who on content

**Before** 

<img width="1920" height="752" alt="Screenshot_20251014_171058" src="https://github.com/user-attachments/assets/90ace47a-d6d8-4b7d-8421-5a139b9e9cd0" />


**After**

<img width="1919" height="876" alt="Screenshot_20251014_171240" src="https://github.com/user-attachments/assets/5def732b-2ec3-4f6f-92be-bd3a57cf84e5" />
