### PR TITLE
🐛Filter pagination issue after a paginate search with autofilter

### DIFF
--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -717,6 +717,11 @@ export default {
           GUI.getService('map').setSelectionFeatures('remove', { feature });
         });
       }
+
+      //@since 4.0.4 Need to sett to false eventually features of layer in queryresults service
+      if (!layer.external) {
+        (service.state.layers.find(l => layer.id === l.id)?.features || []).forEach(f => f.selection.selected = false);
+      }
     },
 
     /**

--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -689,7 +689,7 @@ export default {
      *
      * @since 3.10.0
      */
-    onUnSelectionLayer(storeid, layer) {
+    async onUnSelectionLayer(storeid, layer) {
       if (!layer) {
         return console.warn('undefined layer');;
       }
@@ -699,7 +699,7 @@ export default {
 
       // PROJECT LAYER
       if (!layer.external && storeid) {
-        ApplicationState.catalog[storeid].getLayerById(layer.id).clearSelectionFids();
+        await ApplicationState.catalog[storeid].getLayerById(layer.id).clearSelectionFids();
       }
 
       // EXTERNAL LAYER
@@ -718,7 +718,7 @@ export default {
         });
       }
 
-      //@since 4.0.4 Need to sett to false eventually features of layer in queryresults service
+      //@since 4.0.4 Need to set to false eventually features of layer in queryresults service
       if (!layer.external) {
         (service.state.layers.find(l => layer.id === l.id)?.features || []).forEach(f => f.selection.selected = false);
       }

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -811,14 +811,7 @@
         return Array.isArray(layer.features) && layer.features.length > 0;
       },
       async toggleSelection(layer) {
-        //check if a filter pagination is set
-        const pagination = layer.filter.pagination;
         await this.$options.service.toggleSelection(layer);
-        //@since 4.0.4
-        //In case of pafination, need to show single select tool of each feature
-        if (pagination) {
-          this.$options.service.changeLayerResult(layer);
-        }
       },
       extractAttributesFromFirstTabOfFormStructureLayers(layer) {
         const attributes = new Set();

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -810,8 +810,15 @@
       layerHasFeatures(layer) {
         return Array.isArray(layer.features) && layer.features.length > 0;
       },
-      toggleSelection(layer) {
-        this.$options.service.toggleSelection(layer);
+      async toggleSelection(layer) {
+        //check if a filter pagination is set
+        const pagination = layer.filter.pagination;
+        await this.$options.service.toggleSelection(layer);
+        //@since 4.0.4
+        //In case of pafination, need to show single select tool of each feature
+        if (pagination) {
+          this.$options.service.changeLayerResult(layer);
+        }
       },
       extractAttributesFromFirstTabOfFormStructureLayers(layer) {
         const attributes = new Set();

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -136,7 +136,7 @@
                   <!-- Filter template tools -->
                   <template v-if = "!layer.external && layer.selection.active">
                     <span
-                      v-if             = !layer.filter.pagination
+                      v-if             = "!layer.filter.pagination && layer.features.some(f => f.selection.selected)"
                       @click.stop      = "addRemoveFilter(layer)"
                       class            = "action-button"
                       :class           = "{'toggled': layer.filter.active}"

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -699,7 +699,8 @@
        */
       canSelect(layer) {
         return (
-          GUI.getService('queryresults').getActionLayerById({ layer, id: 'selection' })
+          !layer.filter.active //@since 4.0.4 In case of filter active, doen't show select action
+          && GUI.getService('queryresults').getActionLayerById({ layer, id: 'selection' })
           && (!this.canPaginate(layer) || (layer.selection.active && layer.filter.active))
           && layer.features.length > 1
         );

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -107,7 +107,7 @@
                     <!--        END DOWNLOAD        -->
                   </template>
                   <span
-                    v-if             = "layer.external || (layer.source && 'wms' !== layer.source.type && !(state.query && state.query.pagination))"
+                    v-if             = "layer.external || (!layer.filter.active && layer.source && 'wms' !== layer.source.type && !(state.query && state.query.pagination))"
                     @click.stop      = "addLayerFeaturesToResults(layer)"
                     class            = "action-button"
                     :class           = "{'toggled': layer.addfeaturesresults.active}"

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -301,11 +301,7 @@
                 <!-- CASE FORM STRUCTURE LAYER-->
                 <template v-else-if = "hasFormStructure(layer)">
                   <table class = "table" :class = "{'mobile': isMobile()}">
-                    <tbody 
-                      v-for = "(feature, index) in layer.features"
-                      v-if  = "showFeature(layer, feature)"
-                      :key  = "feature.id"
-                      > 
+                    <tbody v-for = "(feature, index) in layer.features.filter(f => showFeature(layer, f))" :key  = "feature.id"> 
                         <header-feature-actions-body
                           :colspan                 = "getColSpan(layer)"
                           :actions                 = "state.layersactions[layer.id]"
@@ -406,11 +402,7 @@
                 <template v-else>
                   <!-- CASE SIMPLE LAYER WITH NO STRUCTURE -->
                   <table class = "table" :class = "{'mobile': isMobile()}">
-                    <tbody
-                      v-for = "(feature, index) in layer.features"
-                      v-if  = "showFeature(layer, feature)"
-                      :key  = "feature.id"
-                    >
+                    <tbody v-for = "(feature, index) in layer.features.filter(f => showFeature(layer, f))" :key  = "feature.id">
                       <header-feature-actions-body
                         :colspan                 = "getColSpan(layer)"
                         :actions                 = "state.layersactions[layer.id]"

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -65,7 +65,7 @@
                 >
                   <!-- info format layer component -->
                   <infoformats :layer = "layer"/>
-                  <template v-if = "layer.features.length > 1">
+                  <template v-if = "layer.features.length > 0">
                     <span
                       v-if             = "layer.hasgeometry"
                       @click.stop      = "zoomToLayerFeaturesExtent(layer)"

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -302,100 +302,98 @@
                 <template v-else-if = "hasFormStructure(layer)">
                   <table class = "table" :class = "{'mobile': isMobile()}">
                     <tbody v-for = "(feature, index) in layer.features.filter(f => showFeature(layer, f))" :key  = "feature.id"> 
-                        <header-feature-actions-body
-                          :colspan                 = "getColSpan(layer)"
-                          :actions                 = "state.layersactions[layer.id]"
-                          :layer                   = "layer"
-                          :feature                 = "feature"
-                          :index                   = "index"
-                          :onelayerresult          = "onelayerresult"
-                          :trigger                 = "trigger"
-                          :toggleFeatureBoxAndZoom = "toggleFeatureBoxAndZoom"
-                          :hasLayerOneFeature      = "hasLayerOneFeature"
-                          :boxLayerFeature         = "getLayerFeatureBox(layer, feature)"
-                          :attributesSubset        = "attributesSubset"
-                          :getLayerField           = "getLayerField"/>
-                          <tr class = "g3w-feature-result-action-tools">
-                            <template v-if = "state.currentactiontools[layer.id][index]">
-                              <td :colspan = "getColSpan(layer)">
-                                <component
-                                  :is           = "state.currentactiontools[layer.id][index]"
-                                  :colspan      = "getColSpan(layer)"
-                                  :layer        = "layer"
-                                  :feature      = "feature"
-                                  :featureIndex = "index"
-                                  :config       = "state.actiontools[state.currentactiontools[layer.id][index].name][layer.id]"
-                                />
-                              </td>
-                            </template>
-                          </tr>
-                          <tr
-                            v-if  = "!hasLayerOneFeature(layer)"
-                            style = "font-weight: bold; text-align: center" >
-                            <td
-                              v-for = "(attribute, index) in attributesSubset(layer)"
-                              class = "centered"
-                            >
-                              {{getLayerFeatureBox(layer, feature).collapsed ? attribute.label : ''}}
+                      <header-feature-actions-body
+                        :colspan                 = "getColSpan(layer)"
+                        :actions                 = "state.layersactions[layer.id]"
+                        :layer                   = "layer"
+                        :feature                 = "feature"
+                        :index                   = "index"
+                        :onelayerresult          = "onelayerresult"
+                        :trigger                 = "trigger"
+                        :toggleFeatureBoxAndZoom = "toggleFeatureBoxAndZoom"
+                        :hasLayerOneFeature      = "hasLayerOneFeature"
+                        :boxLayerFeature         = "getLayerFeatureBox(layer, feature)"
+                        :attributesSubset        = "attributesSubset"
+                        :getLayerField           = "getLayerField"/>
+                        <tr class = "g3w-feature-result-action-tools">
+                          <template v-if = "state.currentactiontools[layer.id][index]">
+                            <td :colspan = "getColSpan(layer)">
+                              <component
+                                :is           = "state.currentactiontools[layer.id][index]"
+                                :colspan      = "getColSpan(layer)"
+                                :layer        = "layer"
+                                :feature      = "feature"
+                                :featureIndex = "index"
+                                :config       = "state.actiontools[state.currentactiontools[layer.id][index].name][layer.id]"
+                              />
                             </td>
-                            <td
-                              @click.stop = "toggleFeatureBoxAndZoom(layer,feature)"
-                              class       = "collapsed"
-                              style       = "text-align: end"
-                              :class      = "{noAttributes: attributesSubset(layer).length === 0}">
-                              <span
-                                class  = "fa link morelink skin-color"
-                                :class = "g3wtemplate.font[getLayerFeatureBox(layer, feature).collapsed  ? 'plus': 'minus']">
-                              </span>
-                            </td>
-                          </tr>
-                        <header-feature-body
-                          v-if = "!hasLayerOneFeature(layer) && getLayerFeatureBox(layer, feature).collapsed"
-                          :actions                 = "state.layersactions[layer.id]"
-                          :layer                   = "layer"
-                          :feature                 = "feature"
-                          :index                   = "index"
-                          :onelayerresult          = "onelayerresult"
-                          :trigger                 = "trigger"
-                          :toggleFeatureBoxAndZoom = "toggleFeatureBoxAndZoom"
-                          :hasLayerOneFeature      = "hasLayerOneFeature"
-                          :boxLayerFeature         = "getLayerFeatureBox(layer, feature)"
-                          :attributesSubset        = "attributesSubset"
-                          :getLayerField           = "getLayerField"/>
-                        <tr v-for = "({component}) in getLayerCustomComponents(layer.id, 'feature', 'before')">
-                          <td :colspan = "getColSpan(layer)">
-                            <component
-                             :is      = "component"
-                             :layer   = "layer"
-                             :feature = "feature"/>
-                          </td>
+                          </template>
                         </tr>
                         <tr
-                          v-show = "!collapsedFeatureBox(layer,feature) || hasOneLayerAndOneFeature(layer)"
-                          :id    = "`${layer.id}_${index}`"
-                          class  = "featurebox-body"
-                        >
+                          v-if  = "!hasLayerOneFeature(layer)"
+                          style = "font-weight: bold; text-align: center" >
                           <td
-                            :colspan              = "getColSpan(layer)"
-                            :feature-html-content = "`${layer.id}_${index}`"
-                          > <!-- @since v3.10.0  Reference to content of feature html response -->
-                            <tabs
-                              :fields  = "getQueryFields(layer, feature)"
-                              :layerid = "layer.id"
-                              :feature = "feature"
-                              :tabs    = "getLayerFormStructure(layer)"/>
+                            v-for = "(attribute, index) in attributesSubset(layer)"
+                            class = "centered"
+                          >
+                            {{getLayerFeatureBox(layer, feature).collapsed ? attribute.label : ''}}
+                          </td>
+                          <td
+                            @click.stop = "toggleFeatureBoxAndZoom(layer,feature)"
+                            class       = "collapsed"
+                            style       = "text-align: end"
+                            :class      = "{noAttributes: attributesSubset(layer).length === 0}">
+                            <span
+                              class  = "fa link morelink skin-color"
+                              :class = "g3wtemplate.font[getLayerFeatureBox(layer, feature).collapsed  ? 'plus': 'minus']">
+                            </span>
                           </td>
                         </tr>
-                        <tr
-                          v-for = "({component}) in getLayerCustomComponents(layer.id, 'feature', 'after')"
-                        >
-                          <td :colspan = "getColSpan(layer)">
-                            <component
-                              :is      = "component"
-                              :layer   = "layer"
-                              :feature = "feature"/>
-                          </td>
-                        </tr>
+                      <header-feature-body
+                        v-if = "!hasLayerOneFeature(layer) && getLayerFeatureBox(layer, feature).collapsed"
+                        :actions                 = "state.layersactions[layer.id]"
+                        :layer                   = "layer"
+                        :feature                 = "feature"
+                        :index                   = "index"
+                        :onelayerresult          = "onelayerresult"
+                        :trigger                 = "trigger"
+                        :toggleFeatureBoxAndZoom = "toggleFeatureBoxAndZoom"
+                        :hasLayerOneFeature      = "hasLayerOneFeature"
+                        :boxLayerFeature         = "getLayerFeatureBox(layer, feature)"
+                        :attributesSubset        = "attributesSubset"
+                        :getLayerField           = "getLayerField"/>
+                      <tr v-for = "({component}) in getLayerCustomComponents(layer.id, 'feature', 'before')">
+                        <td :colspan = "getColSpan(layer)">
+                          <component
+                            :is      = "component"
+                            :layer   = "layer"
+                            :feature = "feature"/>
+                        </td>
+                      </tr>
+                      <tr
+                        v-show = "!collapsedFeatureBox(layer,feature) || hasOneLayerAndOneFeature(layer)"
+                        :id    = "`${layer.id}_${index}`"
+                        class  = "featurebox-body"
+                      >
+                        <td
+                          :colspan              = "getColSpan(layer)"
+                          :feature-html-content = "`${layer.id}_${index}`"
+                        > <!-- @since v3.10.0  Reference to content of feature html response -->
+                          <tabs
+                            :fields  = "getQueryFields(layer, feature)"
+                            :layerid = "layer.id"
+                            :feature = "feature"
+                            :tabs    = "getLayerFormStructure(layer)"/>
+                        </td>
+                      </tr>
+                      <tr v-for = "({component}) in getLayerCustomComponents(layer.id, 'feature', 'after')">
+                        <td :colspan = "getColSpan(layer)">
+                          <component
+                            :is      = "component"
+                            :layer   = "layer"
+                            :feature = "feature"/>
+                        </td>
+                      </tr>
                     </tbody>
                   </table>
                 </template>

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -241,10 +241,6 @@ export default {
      * @since 3.11.0
      */
     toggleFilterToken(layer) {
-      // get selection features in case of autofilter + pagination
-      if (layer.state.filter.active && !layer.state.selectionFids.has('__ALL__')) {
-        this.state.selectAll = false;
-      }
       layer.toggleFilterToken();
     },
 

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -462,6 +462,7 @@ export default {
     select(feature) {
       feature.selected      = !feature.selected;                                                // inverse selected feature
       this.state.selectAll  = this.state.features.every(f => f.selected); 
+      if (feature.selected && feature.geometry) { this.layer.addOlSelectionFeature(_createFeatureForSelection(feature)); };
       this.layer[feature.selected ? 'includeSelectionFid' : 'excludeSelectionFid'](`${feature.id}`); //string
     },
 

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -26,7 +26,7 @@
 
       <!-- CLEAR SELECTION -->
       <div
-        v-show         = "state.show_tools"
+        v-show         = "layer.state.selection.active"
         class          = "skin-color action-button"
         :class         = "$fa('clear')"
         v-t-tooltip    = "'Clear Selection'"
@@ -36,7 +36,7 @@
 
       <!-- INVERSE SELECTION -->
       <div
-        v-show         = "state.show_tools"
+        v-show         = "!layer.state.filter.active && layer.state.selection.active"
         class          = "skin-color action-button"
         :class         = "[ $fa('invert'), layer.state.filter.active ? 'g3w-disabled': '' ]"
         v-t-tooltip    = "'Invert Selection'"
@@ -46,7 +46,7 @@
 
       <!-- TOGGLE FILTER -->
       <div
-        v-show         = "state.show_tools && show_on_active_filter"
+        v-show         = "layer.state.selection.active && !layer.state.filter.pagination"
         class          = "skin-color action-button"
         :class         = "[ $fa('filter'), layer.state.filter.active ? 'toggled' : '' ]"
         v-t-tooltip    = "'Enable/Disable filter'"
@@ -104,7 +104,7 @@
           <td>
             <div style = "display: flex">
               <label
-                v-if   = "show_on_active_filter"
+                v-if   = "!layer.state.filter.active"
                 @click = "select(feature)"
               >
                 <input type = "checkbox" :checked = "feature.selected" />
@@ -199,7 +199,6 @@ export default {
         allfeatures:   0,
         selectAll:     false,
         nofilteredrow: false,
-        show_tools:    false,
         geolayer: {
           active:    false,
           in_bbox:   undefined,
@@ -227,15 +226,6 @@ export default {
   },
   
   computed: {
-
-    /**
-     * @returns { Boolean } In case of filter without pagination active
-     * 
-     * @since 4.0.0
-     */
-    show_on_active_filter() {
-      return !(this.layer.state.filter.pagination && (this.layer.state.filter.active || !this.layer.state.selectionFids.has('__ALL__')));
-    },
 
     current_layout() {
       return ApplicationState.gui.layout[ApplicationState.gui.layout.__current];
@@ -399,8 +389,6 @@ export default {
         this.state.features.forEach(f => f.selected = false);
         await this.layer.clearSelectionFids();
       }
-
-      this.state.show_tools = this.state.features.some(f => f.selected);
     },
 
     /**
@@ -475,7 +463,6 @@ export default {
       feature.selected      = !feature.selected;                                                // inverse selected feature
       this.state.selectAll  = this.state.features.every(f => f.selected); 
       this.layer[feature.selected ? 'includeSelectionFid' : 'excludeSelectionFid'](`${feature.id}`); //string
-      this.state.show_tools = this.layer.getSelectionFids().size > 0;                           // show tools based on selected state
     },
 
     async resize() {
@@ -600,7 +587,6 @@ export default {
           })
         );
 
-        this.state.show_tools = this.layer.state.filter.active || this.layer.getSelectionFids().size > 0;
         this.state.selectAll  = this.layer.state.filter.active || this.layer.state.selectionFids.has('__ALL__') || (this.state.selectAll && this.state.features.every(f => f.selected));
 
         return {
@@ -621,7 +607,6 @@ export default {
 
     unSelectAll() {
       this.state.features.forEach(f => f.selected = false);
-      this.state.show_tools = false;
       this.state.selectAll  = false;
     },
 

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -586,7 +586,7 @@ export default {
             f.selected = this.state.selectAll || this.layer.state.filter.active || this.layer.hasSelectionFid(f.id);
             const has_geometry = this.layer.isGeoLayer() && f.geometry;
             //@since 4.0.4 Need to take in account filter pagination active from selection
-            if (this.show_on_active_filter && has_geometry && !this.layer.getOlSelectionFeature(f.id)) {
+            if (!this.layer.state.filter.active && has_geometry && !this.layer.getOlSelectionFeature(f.id)) {
               this.layer.addOlSelectionFeature(_createFeatureForSelection(f));
               if (f.selected) { this.layer.includeSelectionFid(f.id) };
             }

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -571,18 +571,11 @@ export default {
         this.state.features.push(
           ...(data.features || []).map(f => {
             f.selected = this.state.selectAll || this.layer.state.filter.active || this.layer.hasSelectionFid(f.id);
-            const has_geometry = this.layer.isGeoLayer() && f.geometry;
-            //@since 4.0.4 Need to take in account filter active from selection
-            if (!this.layer.state.filter.active && has_geometry && !this.layer.getOlSelectionFeature(f.id)) {
-              this.layer.addOlSelectionFeature(_createFeatureForSelection(f));
-              if (f.selected) { this.layer.includeSelectionFid(f.id) };
-            }
-
             return {
               id:         f.id,
               selected:   f.selected,
               attributes: f.attributes || f.properties,
-              geometry:   has_geometry && f.geometry || undefined
+              geometry:   f.geometry || undefined
             };
           })
         );

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -564,7 +564,7 @@ export default {
 
       this.search = {
         field:     columns.filter(c => c.search && c.search.value).map((c, i, arr) => `${c.name}|ilike|${c.search.value}${i < arr.length - 1 ? '|AND' : ''}`).join(',') || undefined,
-        page:      (start === 0 || this.layer.state.filter.active) ? 1 : (start/length) + 1, // get current page
+        page:      start === 0 ? 1 : (start/length) + 1, // get current page
         page_size: length,
         search:    search.value && search.value.length > 0 ? search.value : null,
         in_bbox:   this.state.geolayer.in_bbox,

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -571,7 +571,7 @@ export default {
         // add features
         this.state.features.push(
           ...(data.features || []).map(f => {
-            f.selected = this.state.selectAll || this.layer.state.filter.active || this.layer.hasSelectionFid(f.id);
+            f.selected = this.layer.state.filter.active || this.layer.hasSelectionFid(f.id);
             return {
               id:         f.id,
               selected:   f.selected,

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -583,9 +583,10 @@ export default {
         // add features
         this.state.features.push(
           ...(data.features || []).map(f => {
-            f.selected = this.state.selectAll || this.layer.state.filter.active || this.layer.hasSelectionFid(f.id)
+            f.selected = this.state.selectAll || this.layer.state.filter.active || this.layer.hasSelectionFid(f.id);
             const has_geometry = this.layer.isGeoLayer() && f.geometry;
-            if (has_geometry && !this.layer.getOlSelectionFeature(f.id)) {
+            //@since 4.0.4 Need to take in account filter pagination active from selection
+            if (this.show_on_active_filter && has_geometry && !this.layer.getOlSelectionFeature(f.id)) {
               this.layer.addOlSelectionFeature(_createFeatureForSelection(f));
               if (f.selected) { this.layer.includeSelectionFid(f.id) };
             }

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -585,7 +585,7 @@ export default {
           ...(data.features || []).map(f => {
             f.selected = this.state.selectAll || this.layer.state.filter.active || this.layer.hasSelectionFid(f.id);
             const has_geometry = this.layer.isGeoLayer() && f.geometry;
-            //@since 4.0.4 Need to take in account filter pagination active from selection
+            //@since 4.0.4 Need to take in account filter active from selection
             if (!this.layer.state.filter.active && has_geometry && !this.layer.getOlSelectionFeature(f.id)) {
               this.layer.addOlSelectionFeature(_createFeatureForSelection(f));
               if (f.selected) { this.layer.includeSelectionFid(f.id) };

--- a/src/map/controls/geocoding.js
+++ b/src/map/controls/geocoding.js
@@ -449,8 +449,9 @@ class GeocodingControl extends ol.control.Control {
       GUI.getComponent('search').actions.findLast((action) => {
         const tmp = document.createElement('li');
         tmp.style.cursor = 'pointer';
-        tmp.className= 'action-tool';
-        tmp.innerHTML = /* html */`<i class="${action.class.replace('sidebar-button', '').replace('sidebar-button-icon', '')}"></i> ${action.tooltip}`;
+        tmp.id           = 'geocoding-advanced-search';
+        tmp.className    = 'action-tool';
+        tmp.innerHTML    = /* html */`<i class="${action.class.replace('sidebar-button', '').replace('sidebar-button-icon', '')}"></i> ${action.tooltip}`;
         tmp.addEventListener('click', e => {
           e.preventDefault();
           GUI.showSidebar();

--- a/src/map/layers/layer.js
+++ b/src/map/layers/layer.js
@@ -1262,7 +1262,7 @@ class Layer extends G3WObject {
   saveFilter() {
 
     // skip when ..
-    if (!this.providers['filtertoken'] || !this.state.selectionFids.size > 0) {
+    if (!this.providers['filtertoken'] || !this.state.filter.active) {
       return;
     }
 

--- a/src/map/layers/layer.js
+++ b/src/map/layers/layer.js
@@ -1205,7 +1205,7 @@ class Layer extends G3WObject {
    * @param {boolean} bool
    */
   setFilter(bool = false) {
-    this.state.filter.active     = bool;
+    this.state.filter.active = bool;
     if (this.isGeoLayer() && this.state.filter.active) {
       GUI.getService('map').toggleSelection(false, this.state.id); // hide selection features (open layers)
     }

--- a/src/map/layers/tablelayer.js
+++ b/src/map/layers/tablelayer.js
@@ -36,6 +36,7 @@ export class TableLayer extends Layer {
       'setColor',
       'getFeatures',
       'commit',
+      'change',
     ];
 
     /**
@@ -112,6 +113,9 @@ export class TableLayer extends Layer {
     this._featuresstore = new FeaturesStore({ provider: this.providers.data });
 
   }
+
+  /**@since 4.0.4 aligned with image layer */
+  change() {}
 
   /**
    * Clear all features of the layer

--- a/src/services/data.js
+++ b/src/services/data.js
@@ -261,7 +261,7 @@ export default {
       data: (await Promise.allSettled(
         ([].concat(layer).sort((a, b) => (layersId.indexOf(a.state.id) > layersId.indexOf(b.state.id) ? 1 : -1))).map((l, i) => l.searchFeatures({ ...params, filter: params.filter[i] }))
       ))
-        .filter(d => 'fulfilled' === d.status && (d.value?.data || [])[0].features?.length > 0) //@since 4.0.1 check length features
+        .filter(d => 'fulfilled' === d.status && (d.value?.data || [])[0].features) //@since 4.0.4 remove check lenght
         .map(({ value } = {}) => {
           //@since 3.11.0 In case autofilter set
           if (1 === params.autofilter) {

--- a/src/services/data.js
+++ b/src/services/data.js
@@ -275,7 +275,6 @@ export default {
           }
 
           if (params.page_sizes)  {
-            const features = (value.data || [])[0].features;
             //@since 4.0.1 get project layer
             const layer    = (value.data || [])[0].layer;
             //get max number of elements per page
@@ -284,7 +283,7 @@ export default {
             page_sizes.push(max <= value.count ? params.page_sizes : [...params.page_sizes.filter(p => p < value.count), value.count]);
             //add a count element on counts array
             counts.push(value.count);
-            paginate.push(features && value.count > features.length);
+            paginate.push(true); //@since 4.0.4 set always true to has results uniform layer tools (selection, filter, save filter)
             layers.push(layer);
           }
           if (params.raw)                                         { return { data: value }; }

--- a/src/services/map.js
+++ b/src/services/map.js
@@ -1022,8 +1022,9 @@ class MapService extends G3WObject {
       });
       //In case of add wms on bottom position, check current zindex of default layers that need to set on top of map layers
       if (this.defaultsLayers.mapcenter)      { this.defaultsLayers.mapcenter.getZIndex()      < zindex && this.defaultsLayers.mapcenter.setZIndex(zindex + 1); }
-      if (this.defaultsLayers.highlightLayer) { this.defaultsLayers.highlightLayer.getZIndex() < zindex && this.defaultsLayers.highlightLayer.setZIndex(zindex + 1); }
-      if (this.defaultsLayers.selectionLayer) { this.defaultsLayers.selectionLayer.getZIndex() < zindex && this.defaultsLayers.selectionLayer.setZIndex(zindex + 2); }
+      if (this.defaultsLayers.selectionLayer) { this.defaultsLayers.selectionLayer.getZIndex() < zindex && this.defaultsLayers.selectionLayer.setZIndex(zindex + 1); }
+      if (this.defaultsLayers.highlightLayer) { this.defaultsLayers.highlightLayer.getZIndex() < zindex && this.defaultsLayers.highlightLayer.setZIndex(zindex + 2); }
+
     });
 
     this.viewer.map.getLayers().on('remove', e => {

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -837,7 +837,7 @@ export default new (class QueryResultsService extends G3WObject {
           hint:     'Add/Remove Selection',
           state:    Vue.observable({
             toggled: layer.features.reduce((a, _ , i ) => { a[i] = false; return a; }, {}),
-            show:    !layer.filter.pagination // show action when filter with pagination is not set
+            show:    !layer.filter.active // show action when filter with pagination is not set
           }),
           init({ layer, feature, index, action } = {}) {
             this.unwatch = VM.$watch(() => layer.filter.active, bool => this.state.show = !bool ); // listen filter layer pagination change

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -837,7 +837,7 @@ export default new (class QueryResultsService extends G3WObject {
           hint:     'Add/Remove Selection',
           state:    Vue.observable({
             toggled: layer.features.reduce((a, _ , i ) => { a[i] = false; return a; }, {}),
-            show:    !layer.filter.active // show action when filter with pagination is not set
+            show:    !layer.filter.active // show action when filter is not set
           }),
           init({ layer, feature, index, action } = {}) {
             this.unwatch = VM.$watch(() => layer.filter.active, bool => this.state.show = !bool ); // listen filter layer pagination change

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -456,7 +456,7 @@ export default new (class QueryResultsService extends G3WObject {
             id:         external ? f.getId() : (f instanceof ol.Feature ? f.getId() : f.id),
             attributes: f instanceof ol.Feature ? f.getProperties() : f.properties,
             geometry:   f instanceof ol.Feature ? f.getGeometry()   : f.geometry,
-            selection:  { selected: !external && (!!queryResponse.query.autofilter || layer.hasSelectionFid((f instanceof ol.Feature ? f.getId() : f.id)))}, //@since 3.11.8 check if autofilter is set
+            selection:  { selected: !external && (!!queryResponse.query.autofilter || layer.state.filter.active || layer.hasSelectionFid((f instanceof ol.Feature ? f.getId() : f.id)))}, //@since 3.11.8 check if autofilter is set
             show:       true,
           })),
           hasgeometry:            Array.isArray(features) && !rawdata && features.some(f => f instanceof ol.Feature ? f.getGeometry() : f.geometry),

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -482,7 +482,7 @@ export default new (class QueryResultsService extends G3WObject {
           relationsattributes:       (is_layer || is_vector || is_string)                       ? []                     : undefined,
           hasdownloadablerelations:  !external && layer.hasDowloadableRelations(), //@since 3.11.7
           filter:                    (is_layer && !['wms', 'wcs', 'wmst'].includes(sourceType)) ? layer.state.filter     : {},
-          selection:                 (is_layer && !['wms', 'wcs', 'wmst'].includes(sourceType) && layer.state.selection) || (is_vector && layer.selection) || { active: false },
+          selection:                 (is_vector && layer.selection) || { active: false }, //@since 4.0.4 init false if not extrnal
           title:                     (is_layer && layer.getTitle()) || (is_vector && layer.get('name')) || (is_string && name && (name.length > 4 ? name.slice(0, name.length - 4).join(' ') : layer)) || undefined,
           atlas:                     this._atlas.filter(a => a.atlas.qgs_layer_id === id),
           rawdata:                   rawdata  || null,
@@ -844,6 +844,7 @@ export default new (class QueryResultsService extends G3WObject {
             if (!feature) {
               return console.trace('Invalid feature');
             }
+            layer.selection.active      = layer.features.every(f => f.selection.selected); //@since 4.0.4 set active base on features
             const _layer                = getCatalogLayerById(layer.id);
             const fid                   = feature.attributes[G3W_FID] || feature.id;
             action.state.toggled[index] = feature.selection.selected;

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -507,8 +507,8 @@ export default new (class QueryResultsService extends G3WObject {
     }
     // get features from added pick layer in case of a new request query
     layers.forEach((l, index) => {
-      // whether result comes from pagination
-      l.filter.pagination = l.filter.active && this.state.query?.pagination?.paginate?.at(index);
+      // whether result comes from pagination or previous requestis a filter pagination (case search with autofilter)
+      l.filter.pagination = l.filter.active && (l.filter.pagination || !!(this.state.query?.pagination?.paginate?.at(index)));
       if (options.add || options.update) {
         this.updateLayerResultFeatures(l, options.update);
       } else {
@@ -854,7 +854,7 @@ export default new (class QueryResultsService extends G3WObject {
           change({ features }) {
             // wait for pagination change request
             setTimeout(() => {
-              this.state.show = !layer.filter.pagination; 
+              this.state.show = !layer.filter.pagination; // show action when filter with pagination is not set or is set and current index is paginated
               features.forEach((_, index) => undefined === this.state.toggled[index] && VM.$set(this.state.toggled, index, false))
             })
           },
@@ -1559,7 +1559,7 @@ export default new (class QueryResultsService extends G3WObject {
 
     // handle pagination
     if (!layer.external && !feature && toggled) {
-      catalog_layer.clearSelectionFids();
+      await catalog_layer.clearSelectionFids();
       return;
     }
 

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -840,21 +840,24 @@ export default new (class QueryResultsService extends G3WObject {
             show:    !layer.filter.pagination // show action when filter with pagination is not set
           }),
           init({ layer, feature, index, action } = {}) {
+            this.unwatch = VM.$watch(() => layer.filter.pagination, bool => this.state.show = !bool ); // listen filter layer pagination change
             if (!feature) {
               return console.trace('Invalid feature');
             }
             const _layer                = getCatalogLayerById(layer.id);
             const fid                   = feature.attributes[G3W_FID] || feature.id;
             action.state.toggled[index] = feature.selection.selected;
-            if (_layer && feature.selection.selected && !_layer.hasSelectionFid(fid)) {
+            if (_layer && !_layer.state.filter.active && feature.selection.selected && !_layer.hasSelectionFid(fid)) {
               _layer.addOlSelectionFeature({ id: fid, feature }).selected = true;
               _layer.includeSelectionFid(fid, false);
             }
           },
+          clear() {
+            this.unwatch && this.unwatch(); // remove action when destroy
+          },
           change({ features }) {
             // wait for pagination change request
             setTimeout(() => {
-              this.state.show = !layer.filter.pagination; // show action when filter with pagination is not set or is set and current index is paginated
               features.forEach((_, index) => undefined === this.state.toggled[index] && VM.$set(this.state.toggled, index, false))
             })
           },

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -847,7 +847,8 @@ export default new (class QueryResultsService extends G3WObject {
             const _layer                = getCatalogLayerById(layer.id);
             const fid                   = feature.attributes[G3W_FID] || feature.id;
             action.state.toggled[index] = feature.selection.selected;
-            if (_layer && !_layer.state.filter.active && feature.selection.selected && !_layer.hasSelectionFid(fid)) {
+            //In case of filter pagination, no need to set selection on map
+            if (_layer && !_layer.state.filter.pagination && feature.selection.selected && !_layer.hasSelectionFid(fid)) {
               _layer.addOlSelectionFeature({ id: fid, feature }).selected = true;
               _layer.includeSelectionFid(fid, false);
             }
@@ -1542,7 +1543,7 @@ export default new (class QueryResultsService extends G3WObject {
     const query         = GUI.getService('queryresults'); //get query service
     const action        = query.getActionLayerById({ layer, id: 'selection' }); //get selction action
     const index         = (layer.features || []).findIndex(f => f == feature); // find feature index when selection is set to single feature
-    const toggled       = layer.selection.active; 
+    const toggled       = layer.features.every(f => f.selection.selected); // check if all features are selected  
     const catalog_layer = layer.external ? layer : getCatalogLayerById(layer.id);
     const features      = [].concat(feature || layer.features || []);
 
@@ -1561,7 +1562,7 @@ export default new (class QueryResultsService extends G3WObject {
     });
 
     // handle pagination
-    if (!layer.external && !feature && toggled) {
+    if (!layer.external && !feature && toggled && layer.filter.pagination) {
       await catalog_layer.clearSelectionFids();
       return;
     }
@@ -1664,8 +1665,8 @@ export default new (class QueryResultsService extends G3WObject {
 
     // set layer selection state
 
-    // PROJECT LAYER
-    if (catalog_layer.state.filter.active) {
+    // PROJECT LAYER and not all toggled
+    if (catalog_layer.state.filter.active && !toggled) {
       fids.forEach((_, idx) => {
         // index of feature to remove
         const i = feature ? index : idx;

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -447,6 +447,12 @@ export default new (class QueryResultsService extends G3WObject {
             _setRelationField(node);
           }
         }
+
+        //@since 4.0.4 need to set active false
+        if (is_layer && !['wms', 'wcs', 'wmst'].includes(sourceType)) {
+          layer.state.selection.active = false;
+        }
+        
         // layerObj
         return {
           id,
@@ -482,7 +488,7 @@ export default new (class QueryResultsService extends G3WObject {
           relationsattributes:       (is_layer || is_vector || is_string)                       ? []                     : undefined,
           hasdownloadablerelations:  !external && layer.hasDowloadableRelations(), //@since 3.11.7
           filter:                    (is_layer && !['wms', 'wcs', 'wmst'].includes(sourceType)) ? layer.state.filter     : {},
-          selection:                 (is_vector && layer.selection) || { active: false }, //@since 4.0.4 init false if not extrnal
+          selection:                 (is_layer && !['wms', 'wcs', 'wmst'].includes(sourceType) && layer.state.selection) || (is_vector && layer.selection) || { active: false },
           title:                     (is_layer && layer.getTitle()) || (is_vector && layer.get('name')) || (is_string && name && (name.length > 4 ? name.slice(0, name.length - 4).join(' ') : layer)) || undefined,
           atlas:                     this._atlas.filter(a => a.atlas.qgs_layer_id === id),
           rawdata:                   rawdata  || null,
@@ -1562,6 +1568,7 @@ export default new (class QueryResultsService extends G3WObject {
       f.selection.selected = action.state.toggled[i];
     });
 
+
     // handle pagination
     if (!layer.external && !feature && toggled && layer.filter.pagination) {
       await catalog_layer.clearSelectionFids();
@@ -1678,7 +1685,6 @@ export default new (class QueryResultsService extends G3WObject {
         action.state.toggled = Object.entries(action.state.toggled).reduce((a, t, i) => Object.assign(a, { [i]: t }), {});
       });
     }
-
     catalog_layer.state.selection.active = Object.values(action.state.toggled).some(t => t);
 
     //remove Highlight geometry layer fetures

--- a/src/services/queryresults.js
+++ b/src/services/queryresults.js
@@ -447,11 +447,6 @@ export default new (class QueryResultsService extends G3WObject {
             _setRelationField(node);
           }
         }
-
-        //@since 4.0.4 need to set active false
-        if (is_layer && !['wms', 'wcs', 'wmst'].includes(sourceType)) {
-          layer.state.selection.active = false;
-        }
         
         // layerObj
         return {
@@ -765,7 +760,6 @@ export default new (class QueryResultsService extends G3WObject {
       this.state.currentactiontools[layer.id]        = Vue.observable({ ...Array((layer.features || []).length).fill(null) });
       this.state.currentactionfeaturelayer[layer.id] = Vue.observable({ ...Array((layer.features || []).length).fill(null) });
       this.state.layersactions[layer.id]             = this.state.layersactions[layer.id] || [];
-
       this.state.layersactions[layer.id].push(...([
 
         // zoom to geometry
@@ -846,11 +840,10 @@ export default new (class QueryResultsService extends G3WObject {
             show:    !layer.filter.pagination // show action when filter with pagination is not set
           }),
           init({ layer, feature, index, action } = {}) {
-            this.unwatch = VM.$watch(() => layer.filter.pagination, bool => this.state.show = !bool ); // listen filter layer pagination change
+            this.unwatch = VM.$watch(() => layer.filter.active, bool => this.state.show = !bool ); // listen filter layer pagination change
             if (!feature) {
               return console.trace('Invalid feature');
             }
-            layer.selection.active      = layer.features.every(f => f.selection.selected); //@since 4.0.4 set active base on features
             const _layer                = getCatalogLayerById(layer.id);
             const fid                   = feature.attributes[G3W_FID] || feature.id;
             action.state.toggled[index] = feature.selection.selected;
@@ -1633,7 +1626,7 @@ export default new (class QueryResultsService extends G3WObject {
       );
 
       // set selection property (external layer)
-      catalog_layer.selection.active = Object.values(action.state.toggled).some(t => t);;
+      catalog_layer.selection.active = catalog_layer.selection.features.some(f => f.selection.selected);;
       
       return;
     }
@@ -1685,7 +1678,8 @@ export default new (class QueryResultsService extends G3WObject {
         action.state.toggled = Object.entries(action.state.toggled).reduce((a, t, i) => Object.assign(a, { [i]: t }), {});
       });
     }
-    catalog_layer.state.selection.active = Object.values(action.state.toggled).some(t => t);
+    //@since 4.0.4 set active base on toggled or selection fids
+    catalog_layer.state.selection.active = Object.values(action.state.toggled).some(t => t) || catalog_layer.state.selectionFids.size > 0;
 
     //remove Highlight geometry layer fetures
     GUI.getService('map').clearHighlightGeometry();


### PR DESCRIPTION
## Test project: https://v310.g3wsuite.it/en/map/g3w-suite-demo/qdjango/38/#

Rules:

1. In case of filter pagination active (search with autofilter and with pagination), only clear selection and save filter are active and visible and in a attribute table, inverse selection is disable and is not possible to unselect single feature as query result
2. In case of filter active, no pagination, is possible to clear select, toggle filter, save filter, but not unselect single feature
3. In query result is possible to activate filter, if selection is active and at least one feature of a layer on result is selected

Filter with pagination (search with autofilter) after get result doesn't create or add selection feature on map because non all features are get but only features visible on first page. So in this case filter can't show because removing filter mean show selected feature, if geometry, on map but these feature are not all get due pagination.
At the end, when a filter has a pagination, only **clear selection** need to be possible

## Before

1. Run a search with pagination and autofilter
4. we get wrong features after opening attribute table of filtered layer


<img width="1918" height="580" alt="Screenshot_20251016_102206" src="https://github.com/user-attachments/assets/d37e4569-9cfa-4947-8318-d8040e22be4b" />


<img width="1918" height="266" alt="Screenshot_20251016_102446" src="https://github.com/user-attachments/assets/5cf0dbef-9d02-4717-b1f6-7235cee32047" />


## After

<img width="1918" height="266" alt="Screenshot_20251016_102317" src="https://github.com/user-attachments/assets/7cb8dd2a-c7bf-4234-9501-3b0e9f3c8b07" />
