### PR TITLE
Missing alphanumerical layers on metadata

### DIFF
--- a/src/components/ModalMetadata.vue
+++ b/src/components/ModalMetadata.vue
@@ -320,7 +320,7 @@
             let value = project.metadata && project.metadata[field] ? project.metadata[field] : project[field];
             if (value) {
               //In case of layers that has geometry and no epsg, filter according to filter of project layers
-              if ('layers' === field) { value = value.filter(l => 'NoGeometry' !== l.geometry && l.crs && l.crs.epsg) } 
+              if ('layers' === field) { value = value.filter(l => 'NoGeometry' === l.geometrytype || ('NoGeometry' !== l.geometrytype && l.crs && l.crs.epsg)) } 
               f[field] = { value, label: `metadata.${name}.fields.${field}` };
             }
             return f;


### PR DESCRIPTION
Looking metadata information layers:

<img width="497" height="85" alt="Screenshot_20251218_101855" src="https://github.com/user-attachments/assets/af4a8f0b-ea21-4b5e-9bf8-d146247eca17" />

<img width="364" height="244" alt="Screenshot_20251218_101812" src="https://github.com/user-attachments/assets/0d4cd15c-2491-4aec-9b16-6e3a948f569d" />

On layers tab, alphanumerical layers are missing

**Before**

<img width="1103" height="414" alt="Screenshot_20251218_102010" src="https://github.com/user-attachments/assets/a84e5727-83c5-4a46-8ae6-0fb664282ecb" />

**After**

<img width="1089" height="861" alt="Screenshot_20251218_101717" src="https://github.com/user-attachments/assets/318bdcba-0207-41dc-bfe6-2547ba2e33af" />
