### PR TITLE
🐛 Exclude Join relation (type: ONE) from download

### DIFF
--- a/src/map/layers/layer.js
+++ b/src/map/layers/layer.js
@@ -1013,7 +1013,10 @@ class Layer extends G3WObject {
    * @since 3.11.7  
    */
   hasDowloadableRelations() { 
-    return this.getRelations().getArray().length > 0 && !!this.getRelations().getArray().find(r => getCatalogLayerById(r.getChild()).getDownloadableFormats().filter(f => 'pdf' !== f).length > 0); }
+    return !!this.getRelations().getArray()
+      .filter(r => 'MANY' === r.getType()) //@since 4.0.6 filter onlye MANY (1:N) relation type. Exclude Join (ONE) relation type
+      .find(r => getCatalogLayerById(r.getChild()).getDownloadableFormats().filter(f => 'pdf' !== f).length > 0); 
+  }
 
   /**
    * @param download url

--- a/src/utils/downloadFeatures.js
+++ b/src/utils/downloadFeatures.js
@@ -128,7 +128,7 @@ export async function downloadFeatures(type, layer, features = [], action, index
 
         </dialog>
       `.trim()
-    }).content.firstChild;
+    }).content.firstChild;down_with_relations
 
     dialog.addEventListener("click", e => {
       if (e.target === dialog) {
@@ -141,7 +141,8 @@ export async function downloadFeatures(type, layer, features = [], action, index
         ApplicationState.download = true;
         try {
           const format              = dialog.querySelector('[name="format"]').value;
-          const down_with_relations = Number(dialog.querySelector('[name="down_with_relations"]').value);
+          //@since 4.0.6 Check if lauet has relation downloadble otherwise force to 0
+          const down_with_relations = 1 * Boolean(catalog_layer?.hasDowloadableRelations?.()) * Number(dialog.querySelector('[name="down_with_relations"]').value);
           let blob, filename;
 
           if ('external-url' === format) {


### PR DESCRIPTION
Form result content, when click on download action, exclude relation in join (type ONE) from download

<img width="566" height="218" alt="Screenshot_20260129_115831" src="https://github.com/user-attachments/assets/76f35ca1-cb57-41b6-bd66-aa5a31673155" />

**Before**

<img width="590" height="516" alt="Screenshot_20260129_120047" src="https://github.com/user-attachments/assets/310ecfc7-9f58-4d88-add0-4f6fa14b6127" />


**After**

<img width="590" height="516" alt="Screenshot_20260129_115917" src="https://github.com/user-attachments/assets/5438102a-0830-4fb9-a694-487a83ed1f99" />
