### PR TITLE
🐛 Doesn't show link button on link field value

### DIFF
--- a/src/components/Relation.vue
+++ b/src/components/Relation.vue
@@ -139,7 +139,7 @@
                   title:   table.title,
                   layerid: table.layerId,
                   feature: table.features[index],
-                  fields:  table.fields.map((field, i) => Object.assign(field, { value: row[i], query: true, input: { type: `${getFieldType(field)}` } })),
+                  fields:  table.fields.map((field, i) => Object.assign(field, { value: row[i]})).map(field => Object.assign(field, { query: true, input: { type: `${getFieldType(field)}` } })),
                   tabs:    table.formStructure
                   })"
                 v-t-tooltip:right.create = "`sdk.tooltips.relations.row_to_form`"


### PR DESCRIPTION
Click on table icon, show form structure feature

<img width="1017" height="408" alt="Screenshot_20260202_113616" src="https://github.com/user-attachments/assets/ea9606cb-92d9-415e-807a-63ee970943d4" />


**Before:**

Show string value instead a button

<img width="560" height="501" alt="Screenshot_20260202_113805" src="https://github.com/user-attachments/assets/6f29867e-e219-47db-9eed-6a637eb4b6c2" />


**After:**

<img width="1017" height="408" alt="Screenshot_20260202_113716" src="https://github.com/user-attachments/assets/3d2ded75-09de-48fc-a0be-e59c0c46fae1" />
