### PR TITLE
✨Reset map theme when layer/ group change

### DIFF
--- a/src/components/Catalog.vue
+++ b/src/components/Catalog.vue
@@ -386,10 +386,12 @@ export default {
     getLegendSrc(change = false) {
       // skip if not active
       if ('tab' !== this.legend_position) { return }
-
       this.state.layerstrees.forEach(t => {
         let layers = this._traverseVisibleLayers(t.tree);
+        //set visbility of legend tab
         this.showlegend = this.showlegend || layers.length > 0;
+        // skip if not active not get urls to avoid to get legend when legend tab is not active
+        if ('legend' !== this.activeTab) { return; }
         t.tree.forEach(async tree => {
           try {
             if (
@@ -560,10 +562,10 @@ export default {
      * @since 3.11.0
      */
     async setLayersTreePropertiesFromMapTheme({ map_theme, layerstree }) {
-      const project = ApplicationState.project;
-      layerstree = undefined !== layerstree ? layerstree : project.state.layerstree;
+      const project  = ApplicationState.project;
+      layerstree     = undefined !== layerstree ? layerstree : project.state.layerstree;
       /** map theme config */
-      const theme = await this.getMapThemeFromThemeName(map_theme);
+      const theme    = await this.getMapThemeFromThemeName(map_theme);
       // create a chages need to apply map_theme changes to map and TOC
       const changes  = { layers: {} }; // key is the layer id and object has style, visibility change (Boolean)
       const promises = [];
@@ -595,16 +597,18 @@ export default {
               // if it has a style settled
               if (node.style) {
                 const promise = new Promise(resolve => {
-                  const setCurrentStyleAndResolvePromise = node => {
-                    if (changes.layers[node.id] === undefined) changes.layers[node.id] = {
-                      visibility: false,
-                      style:      false
+                  const setCurrentStyleAndResolvePromise = async node => {
+                    if (changes.layers[node.id] === undefined) {
+                      changes.layers[node.id] = {
+                        visibility: false,
+                        style:      false
+                      }
                     };
-                    changes.layers[node.id].style = project.getLayerById(node.id).changeCurrentStyle(node.style);
+                    changes.layers[node.id].style = await project.getLayerById(node.id).changeCurrentStyle(node.style);
                     resolve();
                   };
                   if (project.getLayersStore()) { setCurrentStyleAndResolvePromise(node) }
-                  else { (node => setTimeout(() => setCurrentStyleAndResolvePromise(node)))(node) }// case of starting project creation
+                  else { (node => setTimeout(() => setCurrentStyleAndResolvePromise(node)))(node) } // case of starting project creation
                 });
                 promises.push(promise);
               }
@@ -630,8 +634,13 @@ export default {
      * @fires VM~layer-change-style
      */
     async changeMapTheme(map_theme) {
-      GUI.closeContent();
+      //in the case of save new custom map theme, no need to emit event
+      //in case of remove custom map theme at moment se as default
+      if (null === map_theme) { return; }
 
+      GUI.closeContent();
+      //set change map_theme
+      ApplicationState.map_theme.change = true;     
       // change map theme
       this.state.layerstrees[0].checked = true;
 
@@ -644,7 +653,7 @@ export default {
       // get all layers with styles
       const layers  = Object.keys(changes).filter(id => changes[id].style);
       const styles  = (await this.getMapThemeFromThemeName(map_theme)).styles;
-
+  
       // clear categories
       layers.forEach(id => {
         if (!changes[id].visible) {
@@ -656,6 +665,9 @@ export default {
 
       // apply styles on each layer
       layers.forEach(id => VM.$emit('layer-change-style', { layerId: id, style: styles[id] }));
+
+      //set change map_theme
+      ApplicationState.map_theme.change = false;   
 
     },
 

--- a/src/components/CatalogChangeMapThemes.vue
+++ b/src/components/CatalogChangeMapThemes.vue
@@ -16,11 +16,11 @@
           <i :class = "$fa(collapsed ? 'eye-close' : 'eye')"       style = "padding: 0 0 0 4px;"></i>
           <!-- Text of current theme -->
           <span
-            v-if  = "active_theme"
+            v-if  = "active_theme.theme"
             class = "current_map_theme treeview-label g3w-long-text"
           >
             <span v-t:pre = "'THEME'">:</span>
-            <span class = "skin-color" style = "font-size: 1.1em;">{{ active_theme }}</span>
+            <span class = "skin-color" style = "font-size: 1.1em;">{{ active_theme.theme }}</span>
           </span>
           <!-- Choose a theme -->
           <b
@@ -90,7 +90,7 @@
                     name     = "radio"
                     :id      = "`g3w-map_theme-${i}`"
                     :value   = "map_theme.theme"
-                    v-model  = "active_theme"
+                    v-model  = "active_theme.theme"
                   />
                   <span class = "g3w-long-text">{{ map_theme.theme }}</span>
                 </label>
@@ -132,7 +132,7 @@
                       name     = "radio"
                       :id      = "`g3w-map_theme-${i}-user`"
                       :value   = "map_theme.theme"
-                      v-model  = "active_theme"
+                      v-model  = "active_theme.theme"
                     />
                     <span class = "g3w-long-text">{{ map_theme.theme }}</span>
                   </label>
@@ -143,7 +143,7 @@
                    class           = "action sidebar-button sidebar-button-icon"
                    style           = "padding: 5px;"
                    v-t-tooltip:top = "'update'"
-                   v-disabled      = "active_theme !== map_theme.theme"
+                   v-disabled      = "active_theme.theme !== map_theme.theme"
                  >
                   <i
                     :class = "$fa('save')"
@@ -203,9 +203,8 @@ export default {
   },
 
   data() {
-    const theme = Object.values(this.map_themes).flat().find(mt => mt.default);
     return {
-      active_theme: (theme && theme.theme) || null,
+      active_theme:  ApplicationState.map_theme,
       collapsed:    'collapsed' === ApplicationState.project.state.toc_themes_init_status,
       // user themes
       custom_theme: {
@@ -310,7 +309,7 @@ export default {
         // close dialog
         this.show_form    = false;
         //set as current active name map theme
-        this.active_theme = this.custom_theme.value;
+        this.active_theme.theme = this.custom_theme.value;
         //need to wait watch
         await this.$nextTick();
         //set custom map theme value to null. Reset value
@@ -375,7 +374,7 @@ export default {
           // show a success message to user
           GUI.showUserMessage({ type: 'success', message: 'Theme deleted successfully', autoclose: true })
           // in the case of deleted current map theme set current theme to null
-          if (theme === this.active_theme) { this.active_theme = null;}
+          if (theme === this.active_theme.theme) { this.active_theme.theme = null;}
         } catch(e) {
           console.warn(e);
           GUI.showUserMessage({ type: 'alert', message: e.error || 'info.server_error' });
@@ -387,12 +386,9 @@ export default {
 
   watch: {
 
-    'active_theme': {
+    'active_theme.theme': {
       immediate: false,
       handler(map_theme) {
-        //in the case of save new custom map theme, no need to emit event
-        //in case of remove custom map theme at moment se as default
-        if (null === map_theme || map_theme === this.custom_theme.value) { return }
         this.$emit('change-map-theme', map_theme);
       }
     },

--- a/src/components/CatalogContextMenu.vue
+++ b/src/components/CatalogContextMenu.vue
@@ -671,10 +671,16 @@
         }
       },
 
-      setLayerStyle(index) {
+      async setLayerStyle(index) {
         this.layer_style = this.layer.styles[index].name;
-        //change layer style
-        getCatalogLayerById(this.layer.id).changeCurrentStyle(this.layer_style);
+        try {
+          //change layer style
+          await getCatalogLayerById(this.layer.id).changeCurrentStyle(this.layer_style);
+          ApplicationState.map_theme.theme = null; // @since 4.0.7 on group or layer change , set map_theme null
+        } catch(e) { 
+          console.warn(e)  
+        }
+       
         this.closeMenu();
       },
 

--- a/src/components/CatalogLayerLegend.vue
+++ b/src/components/CatalogLayerLegend.vue
@@ -190,7 +190,8 @@
       },
 
       showHideLayerCategory(index) {
-        this.categories[index].checked = !this.categories[index].checked;
+        this.categories[index].checked   = !this.categories[index].checked;
+        ApplicationState.map_theme.theme = null; // @since 4.0.7 set map_theme null on ckick on category
         //emit chang layer on map to refresh tiles
         this.getProjectLayer().change();
         

--- a/src/components/CatalogTristateTree.vue
+++ b/src/components/CatalogTristateTree.vue
@@ -270,7 +270,7 @@ export default {
       controltoggled: false,
       n_childs:       null,
       filtered:       false,
-      logged:         undefined !== ApplicationState.user.id, //@since 3.10.0
+      logged:         undefined !== ApplicationState.user.id, //@since 3.10.0,
     }
   },
 
@@ -346,6 +346,10 @@ export default {
         this.handleGroupChecked(this.layerstree);
       } else {
         this.handleLayerChecked(this.layerstree);
+      }
+      //@since 4.0.7 In case of map theme change and layers tree is not root, reset map theme
+      if (!this.layerstree.root && !ApplicationState.map_theme.change) {
+        ApplicationState.map_theme.theme = null; // @since 4.0.7 on group or layer change , set map_theme null
       }
     }
 

--- a/src/index.prod.js
+++ b/src/index.prod.js
@@ -303,6 +303,9 @@ $.ajaxSetup({
 
   Object.assign(ApplicationState.project, project);
 
+  /**@since 4.0.7 set map_theme of application */
+  ApplicationState.map_theme.theme = Object.values(project.state.map_themes).flat().find(mt => mt.default)?.theme || null;
+  
   // set in first position (map and catalog)
   const store = project.getLayersStore();
   ApplicationState.catalog[store.getId()] = store;

--- a/src/map/layers/layer.js
+++ b/src/map/layers/layer.js
@@ -2579,8 +2579,9 @@ class Layer extends G3WObject {
    * @since 4.0.0
    */
   async changeCurrentStyle(style) {
+    const { current } = (this.config.styles.find(s => style === s.name) || {});
     //check if style is current set on layer. If not change
-    if (!(this.config.styles.find(s => style === s.name) || {}).current) {
+    if (!current) {
       try {
         //get feature count for a specific style
         await this.getStyleFeatureCount(style);
@@ -2595,6 +2596,11 @@ class Layer extends G3WObject {
       } catch(e) {
         console.warn(e);    
       }
+    }
+
+    /**@since 4.0.7 in case of categories need to set style true change */
+    if (current && (this.getCategories() || []).length > 1) {
+      return true;
     }
     //return false because style is current or in case of error
     return false;

--- a/src/store/application.js
+++ b/src/store/application.js
@@ -248,6 +248,12 @@ const STATE = Vue.observable({
   /** @since 3.11.0 */
   highlightlayers: false,
 
+  /** @since 4.0.7  current map theme as object beacuse we can add new reactive proprties in the future*/
+  map_theme: {
+    theme:  null, //store the current map theme
+    change: false, //store the change of map theme
+  },
+
 });
 
 export default STATE;


### PR DESCRIPTION
When a map theme is set

<img width="441" height="507" alt="Screenshot_20260217_095430" src="https://github.com/user-attachments/assets/e3a104bc-a2a5-4e64-bf33-2a74bdfc8e0a" />

If we apply change on TOC layer/group (check/uncheck)

<img width="441" height="507" alt="Screenshot_20260217_095605" src="https://github.com/user-attachments/assets/dab63721-0c1e-4be1-8a8d-cede285cce38" />

or change layer style

<img width="492" height="569" alt="Screenshot_20260217_095649" src="https://github.com/user-attachments/assets/484f3f38-fdde-4973-82de-55df85e37477" />

**Before**

Map theme doesn't reset

<img width="492" height="569" alt="Screenshot_20260217_095732" src="https://github.com/user-attachments/assets/5c884623-f48f-4372-b062-82bd867679df" />


**After**

Map theme is reset

<img width="492" height="475" alt="Screenshot_20260217_095832" src="https://github.com/user-attachments/assets/5e8d9ffd-6aed-431c-820e-770c5afc35d9" />
