### PR TITLE
Remove check qtimeseries and gdal from infoformat

### DIFF
--- a/src/g3w-layer.js
+++ b/src/g3w-layer.js
@@ -1819,10 +1819,6 @@ export class Layer extends Emitter {
     if (this.isMulti() && !this.isXYZ()) {
       return 'application/vnd.ogc.gml';
     }
-    // In the case of NETCDF (qtime series)
-    if (true === this.state.qtimeseries || 'gdal' === this.getSourceType()) {
-      return 'application/json';
-    }
     if (this.state.infoformat && '' !== this.state.infoformat  && 'wfs' !== ogcService) {
       return this.state.infoformat;
     }


### PR DESCRIPTION
Show only the firs result layer response with wrong number of features related to empty response from others layer

Before
<img width="1407" height="591" alt="Screenshot_20260309_152753" src="https://github.com/user-attachments/assets/da7cfe52-258d-4679-80f7-4d4ffbe0435b" />


**After**

<img width="1407" height="511" alt="Screenshot_20260309_152555" src="https://github.com/user-attachments/assets/7cf63f01-b8b8-4eee-832d-862a4d32aa23" />
