### PR TITLE
Start migrating built-in `v-select2` to custom HTMLElement `<x-select>`

### DIFF
--- a/src/components/x-select.js
+++ b/src/components/x-select.js
@@ -120,7 +120,7 @@ class XSelect extends HTMLElement {
           });
       })).observe(this, { childList: true });
 
-      document.addEventListener('click', this.#onClickOutside.bind(this));
+      document.addEventListener('pointerup', this.#onClickOutside.bind(this));
       window.addEventListener('scroll', () => { if(this.isOpen) this.#updatePosition(); }, true);
       window.addEventListener('resize', () => { if(this.isOpen) this.#updatePosition(); });
 

--- a/src/components/x-select.js
+++ b/src/components/x-select.js
@@ -1,0 +1,404 @@
+/**
+ * @file inspired by "select2" (v4.0.4)
+ */
+
+/**
+ * Custom HTMLElement `<x-option>`
+ * 
+ * @since 4.1.0
+ */
+class XOption extends HTMLElement {
+  connectedCallback() {
+    this.setAttribute('role', 'option');
+    this.setAttribute('tabindex', '-1');
+    this.setAttribute('aria-selected', 'false');
+  }
+}
+
+/**
+ * Custom HTMLElement `<x-select>`
+ * 
+ * @since 4.1.0
+ */
+class XSelect extends HTMLElement {
+
+  constructor() {
+    super();
+    this.isOpen = false;
+    this.selectedValues = [];
+    this.activeOption = null;
+  }
+
+  get value() {
+    return this.getAttribute('value') || '';
+  }
+
+  set value(val) {
+    if (this.value === val) {
+      return;
+    }
+    this.setAttribute('value', val);
+    this.#syncFromValue(val);
+  }
+
+  #syncFromValue(val) {
+    const opt = Array.from(this.querySelectorAll('x-option')).find(o => (o.getAttribute('value') ?? o.textContent.trim()) === val);
+    if (opt) {
+      this.#applySelection(opt);
+    }
+  }
+
+  connectedCallback() {
+
+    Promise.resolve().then(() => {
+
+      const originalOptions = Array.from(this.querySelectorAll('x-option'));
+
+      this.innerHTML = /* html */`
+        <div class="x-select-trigger" tabindex="0" role="combobox" aria-expanded="false" aria-haspopup="listbox">
+          <div class="x-selected-content"></div>
+          <i class="triangle"></i>
+        </div>
+        <div class="x-options-container" popover="manual" role="listbox" ${ this.hasAttribute('multiple') ? 'aria-multiselectable="true"' : '' }>
+          ${ this.hasAttribute('searchable') || this.hasAttribute('multiple') ? '<div class="x-search-box"><input type="text" placeholder="Search..."></div>' : '' }
+          <div class="x-options-list"></div>
+        </div>
+      `;
+
+      this.trigger   = this.querySelector('.x-select-trigger');
+      this.content   = this.querySelector('.x-selected-content');
+      this.container = this.querySelector('.x-options-container');
+      this.list      = this.querySelector('.x-options-list');
+      this.input     = this.querySelector('.x-search-box input');
+
+      originalOptions.forEach(opt => {
+        this.list.appendChild(opt);
+        opt.onclick = (e) => { e.stopPropagation(); this.select(opt); };
+      });
+
+      this.container.onkeydown = (e) => this.#onContainerKeydown(e);
+
+      if (this.input) {
+        this.input.oninput = (e) => {
+          const value = e.target.value;
+          this.#search(value);
+          // open dropdown
+          if (!this.isOpen) {
+            this.open();
+          }
+          // emit custom "search-input" event (eg. for AJAX search)
+          this.dispatchEvent(new CustomEvent('search-input', { 
+            detail: { value },
+            bubbles: true,
+            composed: true
+          }));
+        };
+        // suppress 'change' event on parent `<x-select>`
+        this.input.onchange = (e) => { e.stopPropagation(); };
+        this.input.onkeydown = (e) => this.#onSearchKeydown(e);
+      }
+
+      this.trigger.onclick = (e) => { e.stopPropagation(); if (!this.isDisabled) this.toggle(); };
+      this.trigger.onkeydown = (e) => { if (!this.isDisabled) this.#onTriggerKeydown(e); };
+
+      // make reactive: "disabled" attribute
+      (new MutationObserver(() => this.#onDisabled())).observe(this, {
+        attributes: true,
+        attributeFilter: ['disabled']
+      });
+      this.#onDisabled();
+
+      // make reactive: "<x-option>" elements
+      (new MutationObserver(() => {
+        Array
+          .from(this.querySelectorAll(':scope > x-option'))
+          .forEach(opt => {
+            if (!this.list.contains(opt)) {
+              this.list.appendChild(opt);
+              opt.onclick = (e) => { e.stopPropagation(); this.select(opt); };
+            }
+          });
+      })).observe(this, { childList: true });
+
+      document.addEventListener('click', this.#onClickOutside.bind(this));
+      window.addEventListener('scroll', () => { if(this.isOpen) this.#updatePosition(); }, true);
+      window.addEventListener('resize', () => { if(this.isOpen) this.#updatePosition(); });
+
+      if (this.getAttribute('value')) {                       // inital value (from <x-select value="some value">)
+        this.#syncFromValue(this.getAttribute('value'));
+      } else if (this.querySelector('x-option[selected]')) {  // inital value (from <x-option selected>)
+        const opt = this.querySelector('x-option[selected]');
+        if (opt) {
+          this.select(opt);
+        }
+      } else {                                                // initial value (from first available <x-option>)
+        const opt = Array.from(this.querySelectorAll('x-option')).find(opt => !opt.hasAttribute('disabled')) 
+        if (opt) this.select(opt);
+        else this.render();
+      }
+    });
+  }
+
+  #onClickOutside(e) {
+    if (!this.contains(e.target)) {
+      this.close();
+    }
+  }
+
+  #onDisabled() {
+    this.isDisabled                  = this.hasAttribute('disabled');
+    this.trigger.style.opacity       = this.isDisabled ? '0.5' : '1';
+    this.trigger.style.cursor        = this.isDisabled ? 'not-allowed' : 'pointer';
+    this.trigger.style.pointerEvents = this.isDisabled ? 'none' : 'auto';
+  }
+
+  #search(query) {
+    const term    = query.toLowerCase();
+    this.querySelectorAll('x-option').forEach(opt => { opt.toggleAttribute('hidden', !opt.textContent.toLowerCase().includes(term)); });
+  }
+
+  #onSearchKeydown(e) {
+    const currentValue = this.input.value.trim();
+
+    if (e.key === 'Enter' && currentValue && (this.hasAttribute('createTag') || this.getAttribute('createTag') === 'true')) {
+      e.preventDefault();
+
+      // create a new (dynamic) option
+      if (!Array.from(this.querySelectorAll('x-option')).find(o => (o.getAttribute('value') ?? o.textContent.trim()) === currentValue)) {
+        const opt = document.createElement('x-option');
+        opt.setAttribute('value', currentValue);
+        opt.textContent = currentValue;
+        opt.onclick = (e) => { e.stopPropagation(); this.select(opt); };
+        this.list.appendChild(opt);
+      }
+
+      // select the option
+      const opt = Array.from(this.querySelectorAll('x-option')).find(o => (o.getAttribute('value') ?? o.textContent.trim()) === currentValue);
+      if (opt) {
+        this.select(opt);
+      }
+    }
+  }
+
+  #onTriggerKeydown(e) {
+    switch (e.key) {
+      case 'Enter':
+      case ' ':         e.preventDefault(); this.toggle();                                       break;
+      case 'ArrowDown': e.preventDefault(); if (!this.isOpen) this.open(); this.#focus('first'); break;
+      case 'ArrowUp':   e.preventDefault(); if (!this.isOpen) this.open(); this.#focus('last');  break;
+      case 'Escape':    if (this.isOpen) { e.preventDefault(); this.close(); }                   break;
+    }
+  }
+
+  #onContainerKeydown(e) {
+    const options = Array.from(this.querySelectorAll('x-option:not([hidden])'));
+    if (0 === options.length) {
+      return;
+    }
+    switch (e.key) {
+      case 'ArrowDown': e.preventDefault(); this.#focus(1);                           break;
+      case 'ArrowUp':   e.preventDefault(); this.#focus(-1);                          break;
+      case 'Enter':     e.preventDefault(); if (this.activeOption) this.select(this.activeOption); break;
+      case 'Escape':    e.preventDefault(); this.close(); this.trigger.focus();                    break;
+      case 'Tab':       this.close();                                                              break; // Allow tab to move out
+    }
+  }
+
+  #focus(direction) {
+    const options = Array.from(this.querySelectorAll('x-option:not([hidden])'));
+
+    if ('first' === direction) {
+      if (options.length > 0) {
+        this.#setActiveOption(options.at(0));
+      }
+      return; 
+    }
+
+    if ('last' === direction) {
+      if (options.length > 0) {
+        this.#setActiveOption(options.at(-1));
+      }
+      return;
+    }
+
+    if (!this.activeOption) {
+      this.#setActiveOption(options.at(0));
+      return;
+    }
+
+    const currentIndex = options.indexOf(this.activeOption);
+    let newIndex = currentIndex + direction;
+    if (newIndex < 0) newIndex = options.length - 1;
+    if (newIndex >= options.length) newIndex = 0;
+    this.#setActiveOption(options.at(newIndex));
+  }
+
+  #setActiveOption(option) {
+    if (this.activeOption) {
+      this.activeOption.setAttribute('aria-selected', this.activeOption.hasAttribute('selected') ? 'true' : 'false');
+    }
+    this.activeOption = option;
+    this.trigger.setAttribute('aria-activedescendant', option.id || (option.id = 'option-' + Math.random().toString(36).substr(2, 9)));
+    option.setAttribute('aria-selected', 'true');
+    option.focus();
+  }
+
+  #updatePosition() {
+    const rect = this.trigger.getBoundingClientRect();
+    this.container.style.top = `${rect.bottom + 2}px`;
+    this.container.style.left = `${rect.left}px`;
+    this.container.style.setProperty('--select-width', `${rect.width}px`);
+  }
+
+  #applySelection(opt) {
+    const val = opt.getAttribute('value') ?? opt.textContent.trim();
+
+    // single-select
+    if (!this.hasAttribute('multiple')) {
+      this.querySelectorAll('x-option').forEach(o => {
+        o.removeAttribute('selected');
+        o.setAttribute('aria-selected', 'false');
+      });
+      this.selectedValues = [{ value: val, html: opt.innerHTML }];
+      opt.setAttribute('selected', '');
+      opt.setAttribute('aria-selected', 'true');
+    }
+
+    // multi-select
+    if (this.hasAttribute('multiple')) {
+      if (opt.hasAttribute('selected')) {
+        opt.removeAttribute('selected');
+        opt.setAttribute('aria-selected', 'false');
+        this.selectedValues = this.selectedValues.filter(v => v.value !== val);
+      } else {
+        opt.setAttribute('selected', '');
+        opt.setAttribute('aria-selected', 'true');
+        this.selectedValues.push({ value: val, html: opt.innerHTML });
+      }
+    }
+
+    this.render();
+  }
+
+  select(opt) {
+    this.#applySelection(opt);
+
+    if (!this.hasAttribute('multiple')) {
+      this.close();
+    }
+
+    const newValue = this.selectedValues.map(v => v.value).join(',');
+    this.setAttribute('value', newValue);
+    this.dispatchEvent(new CustomEvent('change', { bubbles: true, detail: { value: newValue } }));
+  }
+
+  toggle() {
+    if (this.isOpen) {
+      this.close();
+    } else {
+      this.open();
+    }
+  }
+
+  open() { 
+    this.isOpen = true; 
+    this.trigger.setAttribute('aria-expanded', 'true');
+    this.trigger.classList.add('open');
+    this.#updatePosition(); 
+    this.container.showPopover(); 
+    if (this.input) {
+      this.input.value = '';                    // reset search box
+      this.#search('');
+      setTimeout(() => this.input.focus(), 50); // auto focus
+    } else {
+      this.#focus('first');
+    }
+  }
+
+  close() {
+    this.isOpen = false; 
+    this.trigger.setAttribute('aria-expanded', 'false');
+    this.trigger.classList.remove('open');
+    this.trigger.removeAttribute('aria-activedescendant');
+    if (this.activeOption) {
+      this.activeOption.setAttribute('aria-selected', this.activeOption.hasAttribute('selected') ? 'true' : 'false');
+      this.activeOption = null;
+    }
+    this.container.hidePopover(); 
+  }
+
+  render() {
+    if (!this.content) {
+      return;
+    }
+
+    // single-select
+    if (!this.hasAttribute('multiple')) {
+      this.content.innerHTML = this.selectedValues.length ? this.selectedValues[0].html : 'Seleziona...';
+    }
+
+    // multi-select
+    if (this.hasAttribute('multiple')) {
+      this.content.innerHTML = this.selectedValues.length ? this.selectedValues.map((v, i) => 
+        `<span class="x-selected-badge"><span class="x-remove" data-index="${i}">×</span>${v.html}</span>`
+      ).join('') : 'Seleziona...';
+      this.content.querySelectorAll('.x-remove').forEach(btn => {
+        btn.onclick = (e) => {
+          e.stopPropagation();
+          const val = this.selectedValues[parseInt(btn.getAttribute('data-index'))].value;
+          const opt = Array.from(this.querySelectorAll('x-option')).find(o => (o.getAttribute('value') ?? o.textContent.trim()) === val);
+          if (opt) {
+            this.select(opt);
+          }
+        };
+      });
+    }
+  }
+
+  /**
+   * reloads the current HTML from the selected option and updates the trigger
+   */
+  refresh() {
+    this.#syncFromValue(this.value);
+  }
+}
+
+customElements.define('x-option', XOption);
+customElements.define('x-select', XSelect);
+
+// document.body.insertAdjacentHTML('afterbegin', /* html */`
+// <x-select multiple>
+//   <x-option>Nothing</x-option>
+//   <x-option value="1">Some option</x-option>
+//   <x-option value="2">Another option</x-option>
+//   <x-option value="3" disabled>A disabled option</x-option>
+//   <x-option value="4">Potato</x-option>
+// </x-select>
+// `);
+
+// document.body.insertAdjacentHTML('afterbegin', /* html */`
+// <x-select>
+//   <x-option>Nothing</x-option>
+//   <x-option value="1" selected>Some option</x-option>
+//   <x-option value="2">Another option</x-option>
+//   <x-option value="3" disabled>A disabled option</x-option>
+//   <x-option value="4">Potato</x-option>
+// </x-select>
+// `);
+
+document.head.insertAdjacentHTML('beforeend', /* html */`<style id ="x-select-css">
+  x-select                          { display: inline-block; position: relative; width:100%; font-family: inherit; }
+  .x-select-trigger                 { border: 1px solid #ccc; background: white; padding: 6px 12px; display: flex; align-items: center; min-height: 34px; cursor: pointer; box-sizing: border-box; }
+  .x-selected-content               { flex: 1; display: flex; flex-wrap: wrap; gap: 5px; align-items: center; pointer-events: none; overflow: hidden; }
+  .x-selected-badge                 { display: inline-flex; align-items: center; background: var(--skin-color, #007bff); color: white; padding: 1px 10px; border-radius: 4px; pointer-events: auto; }
+  .x-selected-badge .x-remove       { margin-right: 5px; cursor: pointer; font-weight: bold; }
+  .x-options-container              { margin: 0; padding: 0; border: 1px solid #ccc; background: white; z-index: 9999; max-height: 300px; overflow-y: auto; box-shadow: 0 4px 12px rgba(0,0,0,0.15); position: fixed; width: var(--select-width); display: none; }
+  .x-options-container:popover-open { display: block; }
+  .x-search-box                     { padding: 8px; border-bottom: 1px solid #eee; position: sticky; top: 0; background: white; z-index: 1; }
+  .x-search-box input               { width: 100%; padding: 6px; border: 1px solid #ddd; border-radius: 4px; box-sizing: border-box; outline: none; }
+  x-option                          { padding: 8px 12px; display: flex; align-items: center; cursor: pointer; color: #333; }
+  x-option[hidden]                  { display: none; }
+  x-option:hover                    { background: #f8f9fa; }
+  x-option[selected]                { background: var(--skin-color, #007bff) !important; color: white !important; }
+  .triangle                         { margin-left: 8px; border-left: 5px solid transparent; border-right: 5px solid transparent; border-top: 5px solid #666; }
+</style>`);

--- a/src/g3w-globals.js
+++ b/src/g3w-globals.js
@@ -107,6 +107,8 @@ import InputUnique                                 from 'components/InputUnique.
 //Fields
 import Fields, { FieldsService }                   from 'components/g3w-fields';
 
+import 'components/x-select';
+
 const deprecate                   = require('util-deprecate');
 
 /**

--- a/src/static/map-controls/geocoding.js
+++ b/src/static/map-controls/geocoding.js
@@ -642,21 +642,21 @@ class GeocodingControl extends ol.control.Control {
                 style               = "width: 100%; display: flex"
                 @click.prevent.stop = ""
               >
-                <select
-                  v-select2 = "'layerId'"
-                  :search   = "false"
+                <x-select
                   style     = "flex-grow: 1;"
-                  class     = "form-control"
+                  :value    = "layerId"
                   :disabled = "!has_layers"
+                  @change   = "layerId = $event.target.value"
                 >
-                  <option
-                    v-for   = "layer in config.layers"
-                    :key    = "layer.id"
-                    :value  = "layer.id">
+                  <x-option
+                    v-for  = "layer in config.layers"
+                    :key   = "layer.id"
+                    :value = "layer.id"
+                  >
                     <b>{{ layer.name }}</b>
-                  </option>
-                  <option v-if = "!has_layers" v-t = "config.nolayers"></option>
-                </select>
+                  </x-option>
+                  <x-option v-if = "!has_layers" :value="null">{{ $t(config.nolayers) }}</x-option>
+                </x-select>
                 <button
                   v-if        = "has_layers"
                   style       = "border-radius: 0 3px 3px 0;"

--- a/src/static/map-controls/measure.js
+++ b/src/static/map-controls/measure.js
@@ -80,9 +80,11 @@ class MeasureControl extends MapControl {
                 data: () => ({ types: this.types, type: this.types[0] }),
                 template: /* html */ `
                   <div style = "width: 100%; padding: 5px;">
-                    <select ref = "select" style = "width: 100%" :search = "false" v-select2 = "'type'">
-                      <option v-for = "type in types" :value = "type" v-t = "'measure_types.' + type"></option>
-                    </select>
+                    <x-select :value="type" @change="type = $event.target.value">
+                      <x-option v-for="_type in types" :key="_type" :value="_type">
+                      {{ $t('measure_types.' + _type) }}
+                      </x-option>
+                    </x-select>
                   </div>`,
                 watch: {
                   // change measure interaction

--- a/src/static/map-controls/queryby.js
+++ b/src/static/map-controls/queryby.js
@@ -11,7 +11,6 @@ const ApplicationState   = g3w.state;
 const GUI                = g3w.app;
 const MapControl         = g3w.Control;
 const {
-  getCatalogLayerById,
   PickCoordinatesInteraction,
   throttle,
 } = g3w.utils;
@@ -129,15 +128,28 @@ export class QueryBy extends MapControl {
                 </a>
                 <!-- SPATIAL METHOD -->
                 <div style = "padding: 5px;">
-                  <select :search = "false" v-select2 = "'method'">
-                    <option v-for = "method in methods" :value = "method" v-t = "'mapcontrols.queryby.methods.' + method"></option>
-                  </select>
+                  <x-select :value="method" @change="method = $event.target.value">
+                    <x-option v-for="_method in methods" :key="_method" :value="_method">
+                    {{ $t('mapcontrols.queryby.methods.' + _method) }}
+                    </x-option>
+                  </x-select>
                 </div>
                 <!-- QUERY TYPE -->
                 <div style = "padding: 5px;">
-                  <select :search = "false" v-select2 = "'type'" :templateSelection = "templateType" :templateResult = "templateType">
-                    <option v-for = "type in types" :value = "type" v-t = "'mapcontrols.queryby.' + type + '.tooltip'"></option>
-                  </select>
+                  <x-select :value="type" @change="type = $event.target.value">
+                    <x-option v-for="_type in types" :key="_type" :value="_type">
+                      <i :class="({
+                        'querybbox':          'far fa-square',
+                        'querybycircle':      'far fa-circle',
+                        'querybydrawpolygon': 'fas fa-draw-polygon',
+                        'querybypolygon':     'fa fa-hand-pointer',
+                        'querybyfreehand':    'fas fa-pen-fancy',
+                      })[_type]"
+                    ></i>
+                    &nbsp;&nbsp;
+                    {{ $t('mapcontrols.queryby.' + _type + '.tooltip') }}
+                    </x-option>
+                  </x-select>
                 </div>
                 <!-- RADIUS TYPE IN METERS-->
                 <div v-if = "'querybycircle' === type" style = "padding: 5px;">
@@ -163,11 +175,19 @@ export class QueryBy extends MapControl {
                 <!-- SELECTED LAYER -->
                 <div style = "padding: 5px;">
                   <label v-t = "'mapcontrols.queryby.layer'"></label>
-                  <select v-if = "!reloading" ref = "layer" :select2_value = "selectedLayer" v-select2 = "'selectedLayer'" :templateSelection = "templateLayer" :templateResult = "templateLayer">
-                    <option v-t = "all" :value = "'__ALL__'"></option>
-                    <option v-for = "layer in layers" :value = "layer.getId()" :selected = "selectedLayer === layer.getId()">{{ layer.get('name') }}</option>
-                    <option :value = "'__NEW__'" v-t = "'mapcontrols.queryby.new'"></option>
-                  </select>
+                  <x-select 
+                    v-if    ="!reloading" 
+                    :value  = "selectedLayer" 
+                    @change = "selectedLayer = $event.target.value"
+                    ref     = "layer"
+                    searchable
+                  >
+                    <x-option :value="'__ALL__'">{{ $t(all) }}</x-option>
+                    <x-option v-for="(layer, index) in layers" :key="layer.getId() + '_' + index" :value="layer.getId()">
+                      <i :class="g3wtemplate.getFontClass(layer.isVisible() ? 'eye' : 'eye-close')"></i>&nbsp;&nbsp;{{ layer.get('name') }}
+                    </x-option>
+                    <x-option :value="'__NEW__'">{{ $t('mapcontrols.queryby.new') }}</x-option>
+                  </x-select>
                 </div>
                 <!-- HELP TEXT -->
                 <div ref = "help" v-t = "help"></div>
@@ -287,24 +307,6 @@ export class QueryBy extends MapControl {
                 this.control.setEnable(_hasVisible(this.control));
                 this.reloading = false;
               },
-              templateType(state) {
-                if (!state.id) { return state.text }
-                return $(/*html*/`<span><i class="${ ({
-                  'querybbox':          'far fa-square',
-                  'querybycircle':      'far fa-circle',
-                  'querybydrawpolygon': 'fas fa-draw-polygon',
-                  'querybypolygon':     'fa fa-hand-pointer',
-                  'querybyfreehand':    'fas fa-pen-fancy',
-                })[state.id] }"></i>&nbsp;&nbsp;${state.text}</span>`);
-              },
-              templateLayer(state) {
-                if (!state.id || '__NEW__' === state.id) { return state.text; }
-                const externalLayers = GUI.getExternalLayers('vector').map(l => l._externalLayer);
-                const layer = getCatalogLayerById(state.id) || externalLayers.find(l => state.id === l.get('id'));
-                /** @FIXME layer is undefined when removing an external layer */
-                const icon = ('__ALL__' === state.id || !layer ? '' : /*html */ `<i class="${ GUI.getFontClass( layer.isVisible() ? 'eye' : 'eye-close') }"></i>&nbsp;&nbsp;`)
-                return $(/*html*/`<span>${ icon }${ state.text }</span>`);  
-              } 
             },
             mounted() {
               CONTROLS['queryby'].usermessage = this;
@@ -490,11 +492,12 @@ export class QueryBy extends MapControl {
         const control = CONTROLS[t];
         return (control.layers || []).map(layer => Vue.watch(
           () => layer.state?.visible ?? layer.visible,
-          () => {
+          async () => {
+            await Vue.nextTick();
+
             // toggle "eye" / "eye-close" icon
-            if (this.usermessage) {
-              $(this.usermessage.$refs.layer).trigger('change');
-            }
+            this.usermessage?.$refs?.layer?.refresh();
+
             // toggle control interaction
             control.setEnable(control.isToggled() && _hasVisible(control));
             control._interaction.setActive(control.getEnable());

--- a/src/static/map-controls/queryby.js
+++ b/src/static/map-controls/queryby.js
@@ -266,7 +266,7 @@ export class QueryBy extends MapControl {
                   }
 
                   // perform request again
-                  if ('__NEW__' !== value && 'querybypolygon' !== this.type) {
+                  if ('__NEW__' !== value) {
                     this.reset();
                   }
                 }

--- a/src/static/map-controls/screenshot.js
+++ b/src/static/map-controls/screenshot.js
@@ -40,6 +40,9 @@ const state = {
   template:        print?.[0]?.name,
   atlas:           print?.[0]?.atlas,
   atlas_values:    [],
+  atlas_search:    '',
+  atlas_options:   [],
+  atlas_loading:   false,
   rotation:        0,
   scale:           null,
   inner:           [0, 0, 0, 0],
@@ -67,15 +70,15 @@ template: /*html*/`
 
     <!-- CHOOSE A TEMPLATE -->
     <label for = "templates">{{ $t('Template') }}</label>
-    <select
-      id             = "templates"
-      class          = "form-control"
-      v-select2      = "'template'"
-      :select2_value = "template"
-      :style         = "{ marginBottom: atlas && '10px' }"
+    <x-select
+      id      = "templates"
+      :value  = "template"
+      @change = "template = $event.target.value"
+      :style  = "{ marginBottom: atlas && '10px' }"
+      searchable
     >
-      <option v-for = "p in print" :value = "p.name" v-t = "p.label || p.name"></option>
-    </select>
+      <x-option v-for = "p in print" :key="p.name" :value = "p.name">{{ $t(p.label || p.name) }}</x-option>
+    </x-select>
 
     <!-- ADVANCED SETTINGS -->
     <details v-if = "is_customizable" class = "custom-settings">
@@ -104,47 +107,45 @@ template: /*html*/`
 
       <!-- PRINT SCALE -->
       <label for = "scale">{{ $t('Scale') }}</label>
-      <select
-        id             = "scale"
-        class          = "form-control"
-        v-disabled     = "!has_maps"
-        v-select2      = "'scale'"
-        :select2_value = "scale"
-        :createTag     = "true"
-        @change        = "changeScale"
-        ref            = "scales"
+      <x-select
+        id         = "scale"
+        v-disabled = "!has_maps"
+        :value     = "scale"
+        @change    = "onScaleChange"
+        createTag
+        searchable
       >
-        <option v-for = "scale in scales" :value = "scale.value">{{ scale.label }}</option>
-      </select>
+        <x-option v-for = "s in scales" :key = "s.value" :value = "s.value">
+          {{ s.label }}
+        </x-option>
+      </x-select>
 
       <!-- PRINT FORMAT -->
       <label for = "format">{{ $t('Format') }}</label>
-      <select
-        id             = "format"
-        class          = "form-control"
-        v-select2      = "'format'"
-        :select2_value = "format"
+      <x-select
+        id         = "format"
+        :value     = "format"
+        @change    = "format = $event.target.value"
+        searchable
       >
-        <option value = "png">PNG</option>
-        <option value = "jpg">JPG</option>
-        <option value = "svg">SVG</option>
-        <option value = "pdf">PDF</option>
-        <option value = "geopdf">GEOPDF</option>
-      </select>
+        <x-option value = "png">PNG</x-option>
+        <x-option value = "jpg">JPG</x-option>
+        <x-option value = "svg">SVG</x-option>
+        <x-option value = "pdf">PDF</x-option>
+        <x-option value = "geopdf">GEOPDF</x-option>
+      </x-select>
 
       <!-- PRINT DPI -->
       <label for = "dpi">{{ $t('Resolution') }}</label>
-      <select
-        id             = "dpi"
-        class          = "form-control"
-        v-select2      = "'dpi'"
-        :select2_value = "dpi"
-        @change        = "changeDpi"
-        :createTag     = "true"
-        ref            = "dpi"
+      <x-select
+        id        = "dpi"
+        :value    = "dpi"
+        @change   = "onDpiChange"
+        createTag
+        searchable
       >
-        <option v-for = "dpi in dpis" :value = "dpi">{{ dpi }} dpi</option>
-      </select>
+        <x-option v-for = "d in dpis" :key = "d" :value = "d">{{ d }} dpi</x-option>
+      </x-select>
 
       <!-- PRINT LABEL -->
       <div
@@ -157,7 +158,7 @@ template: /*html*/`
             v-for = "label in labels"
             :key  = "label.id"
           >
-            <label :for = "'g3w_label_id_input_'+ label.id"> {{ label.id }}</label>
+            <label :for = "'g3w_label_id_input_' + label.id"> {{ label.id }}</label>
             <input
               :id     = "'g3w_label_id_input_' + label.id"
               class   = "form-control"
@@ -173,11 +174,18 @@ template: /*html*/`
     <!-- ORIGINAL SOURCE: src/componentsPrintSelectAtlasFieldValues.vue@v3.9.3 -->
     <template v-if = "!is_screenshot && atlas && has_autocomplete">
       <label  for = "print_atlas_autocomplete"><span>{{ atlas.field_name }}</span></label>
-      <select
-        id    = "print_atlas_autocomplete"
-        :name = "atlas.field_name"
-        class = "form-control"
-      ></select>
+      <x-select
+        :key            = "template"
+        id              = "print_atlas_autocomplete"
+        :value          = "atlas_values.join(',')"
+        @change         = "onAtlasChange"
+        @search-input   = "atlas_search = $event.detail.value"
+        multiple
+        searchable
+      >
+        <x-option v-for = "option in atlas_options" :key = "option" :value = "option">{{ option }}</x-option>
+      </x-select>
+      <div v-if = "atlas_loading" style = "font-size: 0.85em; color: #999; margin-top: 4px;">{{ $t('Searching ...') }}</div>
     </template>
 
     <!-- PRINT ATLAS -->
@@ -194,18 +202,17 @@ template: /*html*/`
     <!-- SCREENSHOT FORMAT -->
     <template v-if = "is_screenshot">
       <label for = "format">{{ $t('Format') }}</label>
-      <select
-        id        = "format"
-        ref       = "select"
-        style     = "width: 100%;"
-        :search   = "false"
-        v-select2 = "'screenshot_type'"
+      <x-select
+        id     = "format"
+        :value = "screenshot_type"
+        @change = "screenshot_type = $event.target.value"
       >
-        <option
-          v-for  = "type in screenshot_types"
-          :value = "type"
-        >{{ $t(({ screenshot: 'PNG', geoscreenshot: 'GeoTIFF'})[type]) }}</option>
-      </select>
+        <x-option
+          v-for     = "type in screenshot_types"
+          :key      = "type"
+          :value    = "type"
+        >{{ $t(({ screenshot: 'PNG', geoscreenshot: 'GeoTIFF'})[type]) }}</x-option>
+      </x-select>
     </template>
 
     <!-- SUBMIT BUTTON -->
@@ -402,13 +409,6 @@ template: /*html*/`
           return;
         }
 
-        // destroy select2 dom element and remove all events
-        if (this.select2) {
-          this.select2.select2('destroy');
-          this.select2.off();
-          this.select2 = null;
-        }
-
         Object.assign(this, {
           disabled:     false,
           maps:         print.maps,
@@ -419,7 +419,9 @@ template: /*html*/`
 
         //In case of current atlas template just init select
         if (this.atlas) {
-          this.initSelect2Field();
+          this.atlas_search = '';
+          this.atlas_options = [];
+          this.atlas_values = [];
           return;
         }
         this.showPrintArea(!this.is_screenshot);
@@ -430,7 +432,8 @@ template: /*html*/`
     async has_autocomplete(b) {
       if (b) {
         await this.$nextTick();
-        this.initSelect2Field();
+        this.atlas_search = '';
+        this.atlas_options = [];
       }
     },
 
@@ -469,6 +472,30 @@ template: /*html*/`
         await this.$nextTick();
         this._skip_atlas_check = false;
         this.disabled = '' === value.trim();
+      }
+    },
+
+    /**
+     * Perform atlas search
+     */
+    atlas_search: {
+      async handler(atlas_search) {
+        try {
+          if (!this.atlas || !atlas_search || atlas_search.length < 1) {
+            this.atlas_options = [];
+            return;
+          }
+          this.atlas_loading = true;
+          this.atlas_options = (await getCatalogLayerById(this.atlas.qgs_layer_id).getFilterData({
+            suggest: `${this.atlas.field_name}|${atlas_search}`,
+            unique:  this.atlas.field_name,
+          }));
+        } catch (e) {
+          console.warn('Atlas search error:', e);
+          this.atlas_options = [];
+        } finally {
+          this.atlas_loading = false;
+        }
       }
     },
 
@@ -512,12 +539,13 @@ template: /*html*/`
     /**
      * On scale change set print area
      */
-    changeScale() {
+    onScaleChange(event) {
+      this.scale = event.target.value;
+      
       // custom scale provided by user (eg. "1:2300")
       try {
-        if (this.scale.includes(':')) {
+        if (this.scale && this.scale.includes(':')) {
           const scale = Number(this.scale.split(':')[1].trim());
-          this.$refs.scales.children.at(-1).value = scale;
           this.scale = scale;
         }
       } catch(e) {
@@ -532,11 +560,8 @@ template: /*html*/`
 
       // eg. when is less than minimum scale permission
       if (this.scale < 0) {
-        this.state.scale = this.state.scales.at(-1).value;
+        this.scale = this.scales[this.scales.length - 1].value;
       }
-
-      // update select2 value
-      $(this.$refs.scales).val(this.scale).trigger('change');
 
       if (this.scale) {
         this._setPrintArea();
@@ -546,12 +571,12 @@ template: /*html*/`
     /**
      * @since 3.10.0
      */
-    changeDpi() {
-      // check dpi if si a NaN
+    onDpiChange(event) {
+      this.dpi = event.target.value;
+      
+      // check dpi if is a NaN
       if (Number.isNaN(Number(this.dpi))) {
         this.dpi = this.dpis[0];
-        //set value
-        $(this.$refs.dpi).val(this.dpi).trigger('change');
       }
     },
 
@@ -766,9 +791,6 @@ template: /*html*/`
      * @param { boolean } show when true it will close content
      */
     showPrintArea(show) {
-      if (!show && this.select2) {
-        this.select2.val(null).trigger('change');
-      }
       if (!show) {
         this.atlas_values = [];
         this.print_extent = null;
@@ -849,48 +871,16 @@ template: /*html*/`
       this.scales.forEach(s => this.resolutions[s.value] = getResolutionFromScale(s.value, units));
     },
 
-    initSelect2Field() {
-      this.select2 = $('#print_atlas_autocomplete').select2({
-        width: '100%',
-        multiple: true,
-        minimumInputLength: 1,
-        ajax: {
-          delay: 500,
-          transport: async (d, ok, ko) => {
-            try {
-              ok({
-                results: (await getCatalogLayerById(this.atlas.qgs_layer_id).getFilterData({
-                  suggest: `${this.atlas.field_name}|${d.data.q}`,
-                  unique: this.atlas.field_name,
-                })).map(v => ({ id: v, text: v }))
-              });
-            } catch(e) {
-              console.warn(e);
-              ko(e);
-            }
-          }
-        },
-        /**
-         * @param { Object } params
-         * @param params.term the term that is used for searching
-         * @param { Object } data
-         * @param data.text the text that is displayed for the data object
-         */
-        matcher: (params, data) => {
-          const search = params.term ? params.term.toLowerCase() : params.term;
-          if ('' === (search || '').toString().trim())                             { return data; }        // no search terms → get all of the data
-          if (data.text.toLowerCase().includes(search) && undefined !== data.text) { return { ...data }; } // the searched term
-          return null;                                                                                     // hide the term
-        },
-        language: {
-          noResults:     () => _('No results'),
-          errorLoading:  () => _('Error Loading Data'),
-          searching:     () => _('Searching ...'),
-          inputTooShort: d => `${_('Please enter')} ${d.minimum - d.input.length} ${_('or more characters')}`,
-        },
-      });
-      this.select2.on('select2:select',   e => { this.atlas_values.push(e.params.data.id); });
-      this.select2.on('select2:unselect', e => { this.atlas_values = this.atlas_values.filter(v => v != e.params.data.id); }); // NB: != instead of !== because sometime we need to compare "numbers" with "strings"
+    onAtlasChange(event) {
+      const selected = event.target.value;
+      if (selected) {
+        this.atlas_values = selected.split(',').filter(v => v);
+        // Resetta la ricerca per forzare l'utente a digitare di nuovo
+        this.atlas_search = '';
+        this.atlas_options = [];
+        // Chiudi la dropdown
+        event.target.close();
+      }
     },
 
     /**
@@ -954,9 +944,10 @@ template: /*html*/`
    */
   async mounted() {
     await this.$nextTick();
-    // when default print template is "atlas" → initialize select2
+    // when default print template is "atlas" → initialize autocomplete
     if (this.atlas) {
-      this.initSelect2Field();
+      this.atlas_search = '';
+      this.atlas_options = [];
     }
 
     document.body.appendChild(this.$refs.dialog);
@@ -1060,17 +1051,6 @@ document.head.insertAdjacentHTML(
 <style>
 .print-modal label:not(:first-of-type) {
   margin-top: 8px;
-}
-
-.print-modal .select2-container--open {
-  width: 100%;
-}
-.print-modal .select2-container--open input.select2-search__field {
-  color: #555;
-  width: 100%;
-}
-.print-modal .select2.select2-container {
-  display: block;
 }
 
 .print-modal .print-labels-content {

--- a/src/utils/createVectorLayerFromFile.js
+++ b/src/utils/createVectorLayerFromFile.js
@@ -78,9 +78,19 @@ export async function createVectorLayerFromFile({ name, type, crs, mapCrs, data,
       hooks: {
         footer: {
           template: /* html */
-          `<select v-select2 = "errors[0].value" class = "skin-color" :search = "false" style = "width:100%">
-            <option v-for = "e in errors" :key = "e.row" :value = "e.value">[{{ e.row}}] {{e.value}}</option>
-          </select>`,
+          `<x-select
+            style    = "width:100%"
+            :value   = "errors[0].value"
+            @change  = "errors[0].value = $event.target.value"
+            class    = "skin-color"
+          >
+            <x-option
+              v-for     = "e in errors"
+              :key      = "e.row"
+              :value    = "e.value"
+            >[{{ e.row}}] {{e.value}}</x-option>
+          </x-select>`,
+
           data: () => ({ errors }),
         }
       },


### PR DESCRIPTION
## Motivation
Historically, as per **g3w-client v4.0.x**, "combobox" inputs are handled by [select2](https://select2.org/).

That library relies heavily on jQuery, and requires a lot of hacking (and headaches) to work flawlessly with Vue.

In this PR we try to replace it (at least for the simplest forms) with an our own custom element `<x-select>`

Related to:

- https://github.com/g3w-suite/g3w-client/issues/117
- https://github.com/g3w-suite/g3w-client/issues/98

## What to test

All the `<x-select>` elements are within these forms:

### • Print / Screenshot control

<img width="411" height="770" alt="image" src="https://github.com/user-attachments/assets/4d5f44be-fe13-46ae-8484-9d50776fccda" />

### • Measure control

<img width="415" height="134" alt="image" src="https://github.com/user-attachments/assets/1932bf1a-855e-4bc7-95af-d95d54867e11" />

### • Queryby control

<img width="413" height="344" alt="image" src="https://github.com/user-attachments/assets/ca3b9193-5042-44b3-8154-760ab3306484" />

### • Geocoding control

<img width="616" height="224" alt="image" src="https://github.com/user-attachments/assets/02fa7eac-ea4f-43ac-9a9c-7458fc85256c" />
