### PR TITLE
Keep map control toggled when opening attribute table

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -616,12 +616,6 @@ export default {
   },
 
   async mounted() {
-  
-    // un-toggle map controls
-    this.last_map_control = GUI.getMapControls().find(c => c?.control?.isToggled?.());
-    if (this.last_map_control) {
-      this.last_map_control.control.toggle();
-    }
 
     this.reload();
 

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -634,13 +634,6 @@ export default {
 
   async beforeDestroy() {
 
-    // restore any previous active map control
-    if (false === this?.last_map_control?.control?.isToggled()) {
-     this.last_map_control.control.toggle();
-    }
-
-    this.last_map_control = null;
-
     this.layer.off('unselectionall',    this.unSelectAll);
     this.layer.off('filtertokenchange', this.reload);
 


### PR DESCRIPTION
When open attribute table


<img width="508" height="614" alt="Screenshot_20260407_103407" src="https://github.com/user-attachments/assets/5aa93544-2797-48cd-af44-d0ebbcff2fd9" />

If map control is active (toggled)

<img width="304" height="311" alt="Screenshot_20260407_103513" src="https://github.com/user-attachments/assets/a907fdc6-2bbc-4bfb-aba6-6ccfdb542c4f" />


### Before

Map control is deactivated (untoggled)

<img width="1570" height="979" alt="Screenshot_20260407_103600" src="https://github.com/user-attachments/assets/d3e83f03-072f-4c20-b4a0-c8c28a7f88c8" />


### After

Map control is leave active (toggled)

<img width="1570" height="979" alt="Screenshot_20260407_103643" src="https://github.com/user-attachments/assets/21edd46a-4347-43ef-8403-f82d5fd5aef9" />
