### PR TITLE
Run default expression on fields on update with no field dependencies

### DIFF
--- a/src/components/g3w-form.js
+++ b/src/components/g3w-form.js
@@ -830,7 +830,7 @@ export class FormService extends Emitter {
    * @since 3.8.0
    */
   async saveDefaultExpressionFieldsNotDependencies() {
-    if (0 === this.default_expression_fields_on_update.length) { return }
+    if (0 === this.default_expression_fields_on_update.length || 0 === this.state.fields.filter(f => f.update).length) { return }
 
     try {
       //@since 3.11.0 get unique field names that has dependencies from another fields


### PR DESCRIPTION
Change value with default expression filed on update, only if some other fields are change
This is necessary because otherwise in case, for example i change relation features of parent features without any change of parent feature fields, after save changes, it call every time server default expression also with no changes