### PR TITLE
In case of simple text value, avoid to wrap it with `<p>` tags (InputHTML widget)

### DIFF
--- a/src/components/InputTextHtml.vue
+++ b/src/components/InputTextHtml.vue
@@ -12,8 +12,7 @@
 
 <script>
   import Input from 'components/g3w-input';
-
-  const Quill = require('quill').default;
+  import Quill from 'quill';
 
   //@since 4.1.0 check if value has tag HTML to set content in quill editor
   const hasTagHTML = value => {
@@ -26,52 +25,7 @@
     name: "input-html",
 
     mixins: [ Input ],
-    methods: {
-      setupTableCustomTools() {
-        /**
-         * Column left
-         */
-        const buttonColumnLeft = this.$el.querySelector('.ql-column-left');
-        buttonColumnLeft.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-left-square" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h12zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z"/><path d="M10.205 12.456A.5.5 0 0 0 10.5 12V4a.5.5 0 0 0-.832-.374l-4.5 4a.5.5 0 0 0 0 .748l4.5 4a.5.5 0 0 0 .537.082z"/></svg>'
-        buttonColumnLeft.title = "Add column left";
 
-        /**
-         * Column Right
-         */
-        const buttonColumnRight = this.$el.querySelector('.ql-column-right');
-        buttonColumnRight.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-right-square" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h12zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z"/><path d="M5.795 12.456A.5.5 0 0 1 5.5 12V4a.5.5 0 0 1 .832-.374l4.5 4a.5.5 0 0 1 0 .748l-4.5 4a.5.5 0 0 1-.537.082z"/></svg>';
-        buttonColumnRight.title = "Add column right";
-
-        /**
-         * Column Remove
-         * */
-        const buttonColumnRemove = this.$el.querySelector('.ql-column-remove');
-        buttonColumnRemove.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-x-square" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h12zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z"/><path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"/></svg>';
-        buttonColumnRemove.title = "Remove column";
-
-        /**
-         * Row above
-         */
-
-        const buttonRowAbove = this.$el.querySelector('.ql-row-above');
-        buttonRowAbove.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-up-square" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h12zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z"/><path d="M3.544 10.705A.5.5 0 0 0 4 11h8a.5.5 0 0 0 .374-.832l-4-4.5a.5.5 0 0 0-.748 0l-4 4.5a.5.5 0 0 0-.082.537z"/></svg>';
-        buttonRowAbove.title = "Add row above";
-        /**
-         * Row below
-         */
-
-        const buttonRowBelow = this.$el.querySelector('.ql-row-below');
-        buttonRowBelow.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-down-square" viewBox="0 0 16 16"><path d="M3.626 6.832A.5.5 0 0 1 4 6h8a.5.5 0 0 1 .374.832l-4 4.5a.5.5 0 0 1-.748 0l-4-4.5z"/><path d="M0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2zm15 0a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V2z"/></svg>'
-        buttonRowBelow.title = "Add row below";
-
-        /**
-         * Row remove
-         */
-        const buttonRowRemove= this.$el.querySelector('.ql-row-remove');
-        buttonRowRemove.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-dash-square" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h12zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z"/><path d="M4 8a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7A.5.5 0 0 1 4 8z"/></svg>';
-        buttonRowRemove.title = "Remove row";
-      }
-    },
     created() {
 
       /**
@@ -88,19 +42,19 @@
       this.state.edit_states.push(this.edit_state);
     },
     async mounted() {
-      const toolbarOptions = [
-        [{ header: [1, 2, 3, 4, 5, 6,  false] }],
-        [{ 'align': ''}, {'align': 'center'}, {'align': 'right'}, {'align': 'justify'}],
-        [{ 'color': [] }, { 'background': [] }],
-        ['bold', 'italic', 'underline', { 'list': 'ordered' }, { 'list': 'bullet' }, 'link', 'clean', 'html'],
-        ['table', 'column-left', 'column-right', 'column-remove', 'row-above', 'row-below', 'row-remove'],
-      ];
       await this.$nextTick();
       this.quill = new Quill(this.$refs.quill_editor, {
+        theme: 'snow',
         modules: {
           table: true,
           toolbar: {
-            container: toolbarOptions,
+            container: [
+              [{ header: [1, 2, 3, 4, 5, 6,  false] }],
+              [{ 'align': ''}, {'align': 'center'}, {'align': 'right'}, {'align': 'justify'}],
+              [{ 'color': [] }, { 'background': [] }],
+              ['bold', 'italic', 'underline', { 'list': 'ordered' }, { 'list': 'bullet' }, 'link', 'clean', 'html'],
+              ['table', 'column-left', 'column-right', 'column-remove', 'row-above', 'row-below', 'row-remove'],
+            ],
             handlers: {
               html: () => {
                 this.edit_state.show_html = !this.edit_state.show_html;
@@ -126,11 +80,10 @@
               'row-below':     () => this.table.insertRowBelow(),
               'row-remove':    () => this.table.deleteRow()
             },
-
-          }
+          },
         },
-        theme: 'snow'
       });
+
       if (this.state.value && hasTagHTML(this.state.value)) {
         this.quill.container.firstChild.innerHTML = this.state.value;
       } else {
@@ -138,7 +91,42 @@
       }
       
       this.table = this.quill.getModule('table');
-      this.setupTableCustomTools();
+
+      // CUSTOM TOOL: column left
+      Object.assign(this.$el.querySelector('.ql-column-left'), {
+        innerHTML: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-left-square" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h12zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z"/><path d="M10.205 12.456A.5.5 0 0 0 10.5 12V4a.5.5 0 0 0-.832-.374l-4.5 4a.5.5 0 0 0 0 .748l4.5 4a.5.5 0 0 0 .537.082z"/></svg>',
+        title: 'Add column left',
+      });
+
+      // CUSTOM TOOL: column right
+      Object.assign(this.$el.querySelector('.ql-column-right'), {
+        innerHTML: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-right-square" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h12zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z"/><path d="M5.795 12.456A.5.5 0 0 1 5.5 12V4a.5.5 0 0 1 .832-.374l4.5 4a.5.5 0 0 1 0 .748l-4.5 4a.5.5 0 0 1-.537.082z"/></svg>',
+        title: 'Add column right',
+      });
+
+      // CUSTOM TOOL: column remove
+      Object.assign(this.$el.querySelector('.ql-column-remove'), {
+        innerHTML: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-x-square" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h12zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z"/><path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"/></svg>',
+        title: 'Remove column',
+      });
+
+      // CUSTOM TOOL: row above
+      Object.assign(this.$el.querySelector('.ql-row-above'), {
+        innerHTML: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-up-square" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h12zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z"/><path d="M3.544 10.705A.5.5 0 0 0 4 11h8a.5.5 0 0 0 .374-.832l-4-4.5a.5.5 0 0 0-.748 0l-4 4.5a.5.5 0 0 0-.082.537z"/></svg>',
+        title: 'Add row above',
+      });
+
+      // CUSTOM TOOL: row below
+      Object.assign(this.$el.querySelector('.ql-row-below'), {
+        innerHTML: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-down-square" viewBox="0 0 16 16"><path d="M3.626 6.832A.5.5 0 0 1 4 6h8a.5.5 0 0 1 .374.832l-4 4.5a.5.5 0 0 1-.748 0l-4-4.5z"/><path d="M0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2zm15 0a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V2z"/></svg>',
+        title: 'Add row below',
+      });
+
+      // CUSTOM TOOL: row remove
+      Object.assign(this.$el.querySelector('.ql-row-remove'), {
+        innerHTML: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-dash-square" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h12zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z"/><path d="M4 8a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7A.5.5 0 0 1 4 8z"/></svg>',
+        title: 'Remove row',
+      });
 
       this.handler = () => {
         this.state.value = this.edit_state.show_html ? this.quill.container.firstChild.innerText : this.quill.container.firstChild.innerHTML;

--- a/src/components/InputTextHtml.vue
+++ b/src/components/InputTextHtml.vue
@@ -89,37 +89,37 @@
 
       // CUSTOM TOOL: column left
       Object.assign(this.$el.querySelector('.ql-column-left'), {
-        innerHTML: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-left-square" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h12zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z"/><path d="M10.205 12.456A.5.5 0 0 0 10.5 12V4a.5.5 0 0 0-.832-.374l-4.5 4a.5.5 0 0 0 0 .748l4.5 4a.5.5 0 0 0 .537.082z"/></svg>',
+        innerHTML: '<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16"><path d="m14 1 1 1v12l-1 1H2l-1-1V2l1-1zM2 0 0 2v12l2 2h12l2-2V2l-2-2z"/><path d="M10 12V4H9L5 8z"/></svg>',
         title: 'Add column left',
       });
 
       // CUSTOM TOOL: column right
       Object.assign(this.$el.querySelector('.ql-column-right'), {
-        innerHTML: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-right-square" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h12zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z"/><path d="M5.795 12.456A.5.5 0 0 1 5.5 12V4a.5.5 0 0 1 .832-.374l4.5 4a.5.5 0 0 1 0 .748l-4.5 4a.5.5 0 0 1-.537.082z"/></svg>',
+        innerHTML: '<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16"><path d="m14 1 1 1v12l-1 1H2l-1-1V2l1-1zM2 0 0 2v12l2 2h12l2-2V2l-2-2z"/><path d="M6 12V4l5 4z"/></svg>',
         title: 'Add column right',
       });
 
       // CUSTOM TOOL: column remove
       Object.assign(this.$el.querySelector('.ql-column-remove'), {
-        innerHTML: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-x-square" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h12zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z"/><path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708z"/></svg>',
+        innerHTML: '<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"/><path d="M4.6 4.6a.5.5 0 0 1 .8 0L8 7.3l2.6-2.7a.5.5 0 0 1 .8.8L8.7 8l2.7 2.6a.5.5 0 0 1-.8.8L8 8.7l-2.6 2.7a.5.5 0 0 1-.8-.8L7.3 8 4.6 5.4a.5.5 0 0 1 0-.8"/></svg>',
         title: 'Remove column',
       });
 
       // CUSTOM TOOL: row above
       Object.assign(this.$el.querySelector('.ql-row-above'), {
-        innerHTML: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-up-square" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h12zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z"/><path d="M3.544 10.705A.5.5 0 0 0 4 11h8a.5.5 0 0 0 .374-.832l-4-4.5a.5.5 0 0 0-.748 0l-4 4.5a.5.5 0 0 0-.082.537z"/></svg>',
+        innerHTML: '<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16"><path d="m14 1 1 1v12l-1 1H2l-1-1V2l1-1zM2 0 0 2v12l2 2h12l2-2V2l-2-2z"/><path d="M4 11h8v-1L8 6z"/></svg>',
         title: 'Add row above',
       });
 
       // CUSTOM TOOL: row below
       Object.assign(this.$el.querySelector('.ql-row-below'), {
-        innerHTML: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-caret-down-square" viewBox="0 0 16 16"><path d="M3.626 6.832A.5.5 0 0 1 4 6h8a.5.5 0 0 1 .374.832l-4 4.5a.5.5 0 0 1-.748 0l-4-4.5z"/><path d="M0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V2zm15 0a1 1 0 0 0-1-1H2a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V2z"/></svg>',
+        innerHTML: '<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16"><path d="M4 7V6h8v1l-4 4z"/><path d="m0 2 2-2h12l2 2v12l-2 2H2l-2-2zm15 0-1-1H2L1 2v12l1 1h12l1-1z"/></svg>',
         title: 'Add row below',
       });
 
       // CUSTOM TOOL: row remove
       Object.assign(this.$el.querySelector('.ql-row-remove'), {
-        innerHTML: '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-dash-square" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h12zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z"/><path d="M4 8a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7A.5.5 0 0 1 4 8z"/></svg>',
+        innerHTML: '<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"/><path d="m4 8 .5-.5h7a.5.5 0 0 1 0 1h-7z"/></svg>',
         title: 'Remove row',
       });
 

--- a/src/components/InputTextHtml.vue
+++ b/src/components/InputTextHtml.vue
@@ -97,42 +97,36 @@
       Object.assign(this.$el.querySelector('.ql-column-left'), {
         innerHTML: '<svg fill="currentColor" viewBox="0 0 16 16"><path d="m14 1 1 1v12l-1 1H2l-1-1V2l1-1zM2 0 0 2v12l2 2h12l2-2V2l-2-2z"/><path d="M10 12V4H9L5 8z"/></svg>',
         title: 'Add column left',
-        dataset: { placement: 'top' },
       });
 
       // CUSTOM TOOL: column right
       Object.assign(this.$el.querySelector('.ql-column-right'), {
         innerHTML: '<svg fill="currentColor" viewBox="0 0 16 16"><path d="m14 1 1 1v12l-1 1H2l-1-1V2l1-1zM2 0 0 2v12l2 2h12l2-2V2l-2-2z"/><path d="M6 12V4l5 4z"/></svg>',
         title: 'Add column right',
-        dataset: { placement: 'top' },
       });
 
       // CUSTOM TOOL: column remove
       Object.assign(this.$el.querySelector('.ql-column-remove'), {
         innerHTML: '<svg fill="currentColor" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"/><path d="M4.6 4.6a.5.5 0 0 1 .8 0L8 7.3l2.6-2.7a.5.5 0 0 1 .8.8L8.7 8l2.7 2.6a.5.5 0 0 1-.8.8L8 8.7l-2.6 2.7a.5.5 0 0 1-.8-.8L7.3 8 4.6 5.4a.5.5 0 0 1 0-.8"/></svg>',
         title: 'Remove column',
-        dataset: { placement: 'top' },
       });
 
       // CUSTOM TOOL: row above
       Object.assign(this.$el.querySelector('.ql-row-above'), {
         innerHTML: '<svg fill="currentColor" viewBox="0 0 16 16"><path d="m14 1 1 1v12l-1 1H2l-1-1V2l1-1zM2 0 0 2v12l2 2h12l2-2V2l-2-2z"/><path d="M4 11h8v-1L8 6z"/></svg>',
         title: 'Add row above',
-        dataset: { placement: 'top' },
       });
 
       // CUSTOM TOOL: row below
       Object.assign(this.$el.querySelector('.ql-row-below'), {
         innerHTML: '<svg fill="currentColor" viewBox="0 0 16 16"><path d="M4 7V6h8v1l-4 4z"/><path d="m0 2 2-2h12l2 2v12l-2 2H2l-2-2zm15 0-1-1H2L1 2v12l1 1h12l1-1z"/></svg>',
         title: 'Add row below',
-        dataset: { placement: 'top' },
       });
 
       // CUSTOM TOOL: row remove
       Object.assign(this.$el.querySelector('.ql-row-remove'), {
         innerHTML: '<svg fill="currentColor" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"/><path d="m4 8 .5-.5h7a.5.5 0 0 1 0 1h-7z"/></svg>',
         title: 'Remove row',
-        dataset: { placement: 'top' },
       });
 
       this.handler = () => {

--- a/src/components/InputTextHtml.vue
+++ b/src/components/InputTextHtml.vue
@@ -81,39 +81,49 @@
 
       this.table = this.quill.getModule('table');
 
+      // a11y: help text (button tooltip)
+      this.$el.querySelector('.ql-formats button[aria-label="align: "]').ariaLabel = 'align: left';
+      this.$el.querySelector('.ql-formats .ql-color.ql-picker').title = 'color: text';
+      this.$el.querySelector('.ql-formats .ql-background.ql-picker').title = 'color: background';
+      this.$el.querySelectorAll('.ql-formats button').forEach(btn => btn.title = btn.ariaLabel);
+
+      // CUSTOM TOOL: html
+      this.$el.querySelector('.ql-html').innerHTML   = 'html';
+      this.$el.querySelector('.ql-html').style.width = 'unset';
+
       // CUSTOM TOOL: column left
       Object.assign(this.$el.querySelector('.ql-column-left'), {
-        innerHTML: '<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16"><path d="m14 1 1 1v12l-1 1H2l-1-1V2l1-1zM2 0 0 2v12l2 2h12l2-2V2l-2-2z"/><path d="M10 12V4H9L5 8z"/></svg>',
+        innerHTML: '<svg fill="currentColor" viewBox="0 0 16 16"><path d="m14 1 1 1v12l-1 1H2l-1-1V2l1-1zM2 0 0 2v12l2 2h12l2-2V2l-2-2z"/><path d="M10 12V4H9L5 8z"/></svg>',
         title: 'Add column left',
       });
 
       // CUSTOM TOOL: column right
       Object.assign(this.$el.querySelector('.ql-column-right'), {
-        innerHTML: '<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16"><path d="m14 1 1 1v12l-1 1H2l-1-1V2l1-1zM2 0 0 2v12l2 2h12l2-2V2l-2-2z"/><path d="M6 12V4l5 4z"/></svg>',
+        innerHTML: '<svg fill="currentColor" viewBox="0 0 16 16"><path d="m14 1 1 1v12l-1 1H2l-1-1V2l1-1zM2 0 0 2v12l2 2h12l2-2V2l-2-2z"/><path d="M6 12V4l5 4z"/></svg>',
         title: 'Add column right',
       });
 
       // CUSTOM TOOL: column remove
       Object.assign(this.$el.querySelector('.ql-column-remove'), {
-        innerHTML: '<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"/><path d="M4.6 4.6a.5.5 0 0 1 .8 0L8 7.3l2.6-2.7a.5.5 0 0 1 .8.8L8.7 8l2.7 2.6a.5.5 0 0 1-.8.8L8 8.7l-2.6 2.7a.5.5 0 0 1-.8-.8L7.3 8 4.6 5.4a.5.5 0 0 1 0-.8"/></svg>',
+        innerHTML: '<svg fill="currentColor" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"/><path d="M4.6 4.6a.5.5 0 0 1 .8 0L8 7.3l2.6-2.7a.5.5 0 0 1 .8.8L8.7 8l2.7 2.6a.5.5 0 0 1-.8.8L8 8.7l-2.6 2.7a.5.5 0 0 1-.8-.8L7.3 8 4.6 5.4a.5.5 0 0 1 0-.8"/></svg>',
         title: 'Remove column',
       });
 
       // CUSTOM TOOL: row above
       Object.assign(this.$el.querySelector('.ql-row-above'), {
-        innerHTML: '<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16"><path d="m14 1 1 1v12l-1 1H2l-1-1V2l1-1zM2 0 0 2v12l2 2h12l2-2V2l-2-2z"/><path d="M4 11h8v-1L8 6z"/></svg>',
+        innerHTML: '<svg fill="currentColor" viewBox="0 0 16 16"><path d="m14 1 1 1v12l-1 1H2l-1-1V2l1-1zM2 0 0 2v12l2 2h12l2-2V2l-2-2z"/><path d="M4 11h8v-1L8 6z"/></svg>',
         title: 'Add row above',
       });
 
       // CUSTOM TOOL: row below
       Object.assign(this.$el.querySelector('.ql-row-below'), {
-        innerHTML: '<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16"><path d="M4 7V6h8v1l-4 4z"/><path d="m0 2 2-2h12l2 2v12l-2 2H2l-2-2zm15 0-1-1H2L1 2v12l1 1h12l1-1z"/></svg>',
+        innerHTML: '<svg fill="currentColor" viewBox="0 0 16 16"><path d="M4 7V6h8v1l-4 4z"/><path d="m0 2 2-2h12l2 2v12l-2 2H2l-2-2zm15 0-1-1H2L1 2v12l1 1h12l1-1z"/></svg>',
         title: 'Add row below',
       });
 
       // CUSTOM TOOL: row remove
       Object.assign(this.$el.querySelector('.ql-row-remove'), {
-        innerHTML: '<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"/><path d="m4 8 .5-.5h7a.5.5 0 0 1 0 1h-7z"/></svg>',
+        innerHTML: '<svg fill="currentColor" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"/><path d="m4 8 .5-.5h7a.5.5 0 0 1 0 1h-7z"/></svg>',
         title: 'Remove row',
       });
 
@@ -146,11 +156,3 @@
     }
   };
 </script>
-<style>
-  button.ql-html {
-    width: 40px !important;
-  }
-  button.ql-html:after {
-    content: "html";
-  }
-</style>

--- a/src/components/InputTextHtml.vue
+++ b/src/components/InputTextHtml.vue
@@ -15,6 +15,11 @@
 
   const Quill = require('quill').default;
 
+  //@since 4.1.0 check if value has tag HTML to set content in quill editor
+  const hasTagHTML = value => {
+    return Array.from(new DOMParser().parseFromString(value, 'text/html')?.body?.childNodes ?? []).some(node => node.nodeType === 1);
+  }
+
   export default {
 
     /** @since 3.8.6 */
@@ -126,8 +131,12 @@
         },
         theme: 'snow'
       });
-      this.quill.container.firstChild.innerHTML = this.state.value;
-
+      if (this.state.value && hasTagHTML(this.state.value)) {
+        this.quill.container.firstChild.innerHTML = this.state.value;
+      } else {
+        this.quill.setText(this.state.value);
+      }
+      
       this.table = this.quill.getModule('table');
       this.setupTableCustomTools();
 

--- a/src/components/InputTextHtml.vue
+++ b/src/components/InputTextHtml.vue
@@ -15,11 +15,6 @@
 
   const Quill = require('quill').default;
 
-  //@since 4.1.0 check if value has tag HTML to set content in quill editor
-  const hasTagHTML = value => {
-    return Array.from(new DOMParser().parseFromString(value, 'text/html')?.body?.childNodes ?? []).some(node => node.nodeType === 1);
-  }
-
   export default {
 
     /** @since 3.8.6 */
@@ -98,6 +93,9 @@
       await this.$nextTick();
       this.quill = new Quill(this.$refs.quill_editor, {
         modules: {
+          clipboard: {
+            matchVisual: false,
+          },
           table: true,
           toolbar: {
             container: toolbarOptions,
@@ -131,12 +129,10 @@
         },
         theme: 'snow'
       });
-      if (this.state.value && hasTagHTML(this.state.value)) {
-        this.quill.container.firstChild.innerHTML = this.state.value;
-      } else {
-        this.quill.setText(this.state.value);
-      }
-      
+
+      //set value in quill editor
+      this.quill.clipboard.dangerouslyPasteHTML(0, this.state.value);
+
       this.table = this.quill.getModule('table');
       this.setupTableCustomTools();
 

--- a/src/components/InputTextHtml.vue
+++ b/src/components/InputTextHtml.vue
@@ -61,15 +61,9 @@
                 } else {
                   this.quill.container.firstChild.innerHTML = this.quill.container.firstChild.innerText;
                 }
-                for (const qlformat of this.$el.querySelectorAll('.ql-formats')) {
-                  for (const child of qlformat.children) {
-                    if (!child.classList.contains('ql-html')) {
-                      child.classList.toggle('g3w-disabled');
-                    } else {
-                      child.classList.toggle('skin-color');
-                    }
-                  }
-                }
+                this.$el.querySelectorAll('.ql-formats > *').forEach(child => {
+                  child.classList.toggle(child.classList.contains('ql-html') ? 'skin-color' : 'g3w-disabled');
+                });
               },
               'column-left':   () => this.table.insertColumnLeft(),
               'column-right':  () => this.table.insertColumnRight(),

--- a/src/components/InputTextHtml.vue
+++ b/src/components/InputTextHtml.vue
@@ -84,8 +84,10 @@
       // a11y: help text (button tooltip)
       this.$el.querySelector('.ql-formats button[aria-label="align: "]').ariaLabel = 'align: left';
       this.$el.querySelector('.ql-formats .ql-color.ql-picker').title = 'color: text';
+      this.$el.querySelector('.ql-formats .ql-color.ql-picker').dataset.placement = 'top';
       this.$el.querySelector('.ql-formats .ql-background.ql-picker').title = 'color: background';
-      this.$el.querySelectorAll('.ql-formats button').forEach(btn => btn.title = btn.ariaLabel);
+      this.$el.querySelector('.ql-formats .ql-background.ql-picker').dataset.placement = 'top';
+      this.$el.querySelectorAll('.ql-formats button').forEach(btn => { btn.title = btn.ariaLabel; btn.dataset.placement = 'top'; });
 
       // CUSTOM TOOL: html
       this.$el.querySelector('.ql-html').innerHTML   = 'html';
@@ -95,36 +97,42 @@
       Object.assign(this.$el.querySelector('.ql-column-left'), {
         innerHTML: '<svg fill="currentColor" viewBox="0 0 16 16"><path d="m14 1 1 1v12l-1 1H2l-1-1V2l1-1zM2 0 0 2v12l2 2h12l2-2V2l-2-2z"/><path d="M10 12V4H9L5 8z"/></svg>',
         title: 'Add column left',
+        dataset: { placement: 'top' },
       });
 
       // CUSTOM TOOL: column right
       Object.assign(this.$el.querySelector('.ql-column-right'), {
         innerHTML: '<svg fill="currentColor" viewBox="0 0 16 16"><path d="m14 1 1 1v12l-1 1H2l-1-1V2l1-1zM2 0 0 2v12l2 2h12l2-2V2l-2-2z"/><path d="M6 12V4l5 4z"/></svg>',
         title: 'Add column right',
+        dataset: { placement: 'top' },
       });
 
       // CUSTOM TOOL: column remove
       Object.assign(this.$el.querySelector('.ql-column-remove'), {
         innerHTML: '<svg fill="currentColor" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"/><path d="M4.6 4.6a.5.5 0 0 1 .8 0L8 7.3l2.6-2.7a.5.5 0 0 1 .8.8L8.7 8l2.7 2.6a.5.5 0 0 1-.8.8L8 8.7l-2.6 2.7a.5.5 0 0 1-.8-.8L7.3 8 4.6 5.4a.5.5 0 0 1 0-.8"/></svg>',
         title: 'Remove column',
+        dataset: { placement: 'top' },
       });
 
       // CUSTOM TOOL: row above
       Object.assign(this.$el.querySelector('.ql-row-above'), {
         innerHTML: '<svg fill="currentColor" viewBox="0 0 16 16"><path d="m14 1 1 1v12l-1 1H2l-1-1V2l1-1zM2 0 0 2v12l2 2h12l2-2V2l-2-2z"/><path d="M4 11h8v-1L8 6z"/></svg>',
         title: 'Add row above',
+        dataset: { placement: 'top' },
       });
 
       // CUSTOM TOOL: row below
       Object.assign(this.$el.querySelector('.ql-row-below'), {
         innerHTML: '<svg fill="currentColor" viewBox="0 0 16 16"><path d="M4 7V6h8v1l-4 4z"/><path d="m0 2 2-2h12l2 2v12l-2 2H2l-2-2zm15 0-1-1H2L1 2v12l1 1h12l1-1z"/></svg>',
         title: 'Add row below',
+        dataset: { placement: 'top' },
       });
 
       // CUSTOM TOOL: row remove
       Object.assign(this.$el.querySelector('.ql-row-remove'), {
         innerHTML: '<svg fill="currentColor" viewBox="0 0 16 16"><path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"/><path d="m4 8 .5-.5h7a.5.5 0 0 1 0 1h-7z"/></svg>',
         title: 'Remove row',
+        dataset: { placement: 'top' },
       });
 
       this.handler = () => {


### PR DESCRIPTION
To avoid input html change when a value of property of feature handled by input html widget is simple text with no html tag, it necessary avoid that quill.js library warp plain text with <p> TEXT </p>

It is possible to test with this feature

https://dev.g3wsuite.it/api/embed/k427xp/

### Before


<img width="1143" height="1053" alt="Screenshot_20260408_113513" src="https://github.com/user-attachments/assets/8c11c072-7f13-424d-9733-7049d53822c7" />


### After

<img width="1917" height="1053" alt="Screenshot_20260408_113353" src="https://github.com/user-attachments/assets/b515d7d8-259d-4f3c-abaa-f8afa3d56887" />
