### PR TITLE
🐛 Take in account search or column filter when change page or order field

### DIFF
--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -529,7 +529,7 @@ export default {
         field:      Object.entries(columns).length ? (Object.entries(columns).filter(([_, v]) => v).map(([i, v], index, arr) => `${this.state.headers[i].name}|ilike|${v}${index < arr.length - 1 ? '|AND' : ''}`).join(',') || undefined) : this.search.field,
         page,
         page_size: length,
-        search:    search || this.search.search,
+        search:    (search ?? this.search.search) || undefined,
         in_bbox:   this.state.geolayer.in_bbox,
         ordering:  ('asc' === this.ordering[1] ? '' : '-') + this.state.headers[ordering].name,
         formatter: 1,

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -288,8 +288,7 @@ export default {
       this.reload({ length });
     },
     async 'search.page'(page) {
-      const { search, field } = this.search;
-      this.reload({ field, search, page });
+      this.reload({ page });
     },
   },
 
@@ -467,14 +466,13 @@ export default {
      * @param { number } index column index
      */
     sortColumn(index) {
-      const { search, field } = this.search;
       if (index === this.ordering[0]) {
         this.ordering[1] = 'asc' === this.ordering[1] ? 'desc' : 'asc';
       } else {
         this.ordering[0] = index;
         this.ordering[1] = 'asc';
       }
-      this.reload({ search, field, ordering: index });
+      this.reload({ ordering: index });
     },
 
     /**
@@ -507,7 +505,6 @@ export default {
      * Fetch data from server
      * 
      * @param { Object } opts
-     * @param { string } opts.field
      * @param { number } opts.ordering
      * @param { number } opts.length
      * @param opts.columns
@@ -515,7 +512,6 @@ export default {
      * @param { number } opts.page current page
      */
     async getData({
-      field,
       ordering  = 0,
       length    = this.layer.getAttributeTablePageLength() || PAGELENGTHS[1],
       columns   = {},
@@ -533,10 +529,10 @@ export default {
       this.layer.setAttributeTablePageLength(length);
 
       this.search = {
-        field:     field ?? (Object.entries(columns).filter(([_, v]) => v).map(([i, v], index, arr) => `${this.state.headers[i].name}|ilike|${v}${index < arr.length - 1 ? '|AND' : ''}`).join(',') || undefined),
+        field:     this.search.field ?? (Object.entries(columns).filter(([_, v]) => v).map(([i, v], index, arr) => `${this.state.headers[i].name}|ilike|${v}${index < arr.length - 1 ? '|AND' : ''}`).join(',') || undefined),
         page,
         page_size: length,
-        search:    search || null,
+        search:    search || this.search.search,
         in_bbox:   this.state.geolayer.in_bbox,
         ordering:  ('asc' === this.ordering[1] ? '' : '-') + this.state.headers[ordering].name,
         formatter: 1,

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -33,6 +33,7 @@
       :placeholder = "$t('dosearch')"
       style        = "margin-left: auto !important; margin-right: 1ch;"
       @keyup       = "globalSearch"
+      @input       = "globalSearch"
     />
 
     <!-- TABLE CONTENT -->

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -529,7 +529,7 @@ export default {
       this.layer.setAttributeTablePageLength(length);
 
       this.search = {
-        field:     this.search.field ?? (Object.entries(columns).filter(([_, v]) => v).map(([i, v], index, arr) => `${this.state.headers[i].name}|ilike|${v}${index < arr.length - 1 ? '|AND' : ''}`).join(',') || undefined),
+        field:      Object.entries(columns).length ? (Object.entries(columns).filter(([_, v]) => v).map(([i, v], index, arr) => `${this.state.headers[i].name}|ilike|${v}${index < arr.length - 1 ? '|AND' : ''}`).join(',') || undefined) : this.search.field,
         page,
         page_size: length,
         search:    search || this.search.search,

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -599,7 +599,7 @@ export default {
     this.layer.on('unselectionall',    this.unSelectAll);
     this.layer.on('filtertokenchange', this.reload);
 
-    this.globalSearch = debounce(e => this.getData({ field: this.search.field, search: e.target.value }));
+    this.globalSearch = debounce(e => this.getData({ search: e.target.value }));
 
     GUI.closeSideBar();
 

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -56,7 +56,7 @@
         <tr>
           <th v-disabled       = "disableSelectAll">
             <label @click.stop = "setSelection('all')">
-              <input type = "checkbox" :checked = "all " />
+              <input type = "checkbox" :checked = "all" />
             </label>
           </th>
           <th v-for = "(header, i) in state.headers">
@@ -558,7 +558,7 @@ export default {
         this.state.features.splice(0);
         this.state.features.push(...features);
         
-        this.all = this.layer.state.filter.active || this.layer.state.selection.fids.has('__ALL__') || (this.state.selectAll && this.state.features.every(f => f.selected));
+        this.all = this.layer.state.filter.active || this.layer.state.selection.fids.has('__ALL__') || this.state.features.every(f => f.selected);
         
       } catch(e) {
         console.warn(e);

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -288,7 +288,8 @@ export default {
       this.reload({ length });
     },
     async 'search.page'(page) {
-      this.reload({ page });
+      const { search, field } = this.search;
+      this.reload({ field, search, page });
     },
   },
 
@@ -466,13 +467,14 @@ export default {
      * @param { number } index column index
      */
     sortColumn(index) {
+      const { search, field } = this.search;
       if (index === this.ordering[0]) {
         this.ordering[1] = 'asc' === this.ordering[1] ? 'desc' : 'asc';
       } else {
         this.ordering[0] = index;
         this.ordering[1] = 'asc';
       }
-      this.reload({ ordering: index });
+      this.reload({ search, field, ordering: index });
     },
 
     /**
@@ -505,6 +507,7 @@ export default {
      * Fetch data from server
      * 
      * @param { Object } opts
+     * @param { string } opts.field
      * @param { number } opts.ordering
      * @param { number } opts.length
      * @param opts.columns
@@ -512,6 +515,7 @@ export default {
      * @param { number } opts.page current page
      */
     async getData({
+      field,
       ordering  = 0,
       length    = this.layer.getAttributeTablePageLength() || PAGELENGTHS[1],
       columns   = {},
@@ -529,7 +533,7 @@ export default {
       this.layer.setAttributeTablePageLength(length);
 
       this.search = {
-        field:     Object.entries(columns).filter(([_, v]) => v).map(([i, v], index, arr) => `${this.state.headers[i].name}|ilike|${v}${index < arr.length - 1 ? '|AND' : ''}`).join(',') || undefined,
+        field:     field ?? (Object.entries(columns).filter(([_, v]) => v).map(([i, v], index, arr) => `${this.state.headers[i].name}|ilike|${v}${index < arr.length - 1 ? '|AND' : ''}`).join(',') || undefined),
         page,
         page_size: length,
         search:    search || null,
@@ -580,7 +584,12 @@ export default {
      * @since 4.1.0
      */
     async reload(opts = {}) {
-      this.getData(opts).then(() => this.disableSelectAll = 0 === this.state.features.length);
+      try {
+        await this.getData(opts);
+        this.disableSelectAll = 0 === this.state.features.length;
+      } catch(e) {
+        console.warn(e);
+      } 
     },
 
   },
@@ -594,7 +603,7 @@ export default {
     this.layer.on('unselectionall',    this.unSelectAll);
     this.layer.on('filtertokenchange', this.reload);
 
-    this.globalSearch = debounce(e => this.getData({ search: e.target.value }));
+    this.globalSearch = debounce(e => this.getData({ field: this.search.field, search: e.target.value }));
 
     GUI.closeSideBar();
 

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -195,8 +195,8 @@
           <option v-for = "p in pages" :selected = "p == search.page">{{ p }}</option>
         </select>
         {{ $t(' of ') + pages }}
-        <button v-if="pages > 1" title="Backward" data-placement="top" @click.stop = "search.page = Number(search.page) - 1" class = "btn" v-disabled = "1 == search.page">🞀</button>
-        <button v-if="pages > 1" title="Forward"  data-placement="top" @click.stop = "search.page = Number(search.page) + 1" class = "btn" v-disabled = "pages == search.page">🞂</button>
+        <button v-if="pages > 1" title="Backward" data-placement="top" @click.stop = "search.page = Number(search.page) - 1; reload({ page: search.page });" class = "btn" v-disabled = "1 == search.page">🞀</button>
+        <button v-if="pages > 1" title="Forward"  data-placement="top" @click.stop = "search.page = Number(search.page) + 1; reload({ page: search.page });" class = "btn" v-disabled = "pages == search.page">🞂</button>
       </div>
 
     </div>
@@ -286,9 +286,6 @@ export default {
   watch: {
     async 'search.page_size'(length) {
       this.reload({ length });
-    },
-    async 'search.page'(page) {
-      this.reload({ page });
     },
   },
 

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -195,8 +195,8 @@
           <option v-for = "p in pages" :selected = "p == search.page">{{ p }}</option>
         </select>
         {{ $t(' of ') + pages }}
-        <button v-if="pages > 1" title="Backward" data-placement="top" @click.stop = "search.page = Number(search.page) - 1; reload({ page: search.page });" class = "btn" v-disabled = "1 == search.page">🞀</button>
-        <button v-if="pages > 1" title="Forward"  data-placement="top" @click.stop = "search.page = Number(search.page) + 1; reload({ page: search.page });" class = "btn" v-disabled = "pages == search.page">🞂</button>
+        <button v-if="pages > 1" title="Backward" data-placement="top" @click.stop = "reload({ page: Number(search.page) - 1 });" class = "btn" v-disabled = "1 == search.page">🞀</button>
+        <button v-if="pages > 1" title="Forward"  data-placement="top" @click.stop = "reload({ page: Number(search.page) + 1 });" class = "btn" v-disabled = "pages == search.page">🞂</button>
       </div>
 
     </div>


### PR DESCRIPTION
Project https://dev.g3wsuite.it/en/map/g3w-suite-demo/qdjango/39/

In case of filter column, when change page, table get all features without take in account previous column filter.
The same issue is related to:

- change order column
- global serach

We need to pass on each server request previous search parameters if set.

set column filter: "toscana"

### Before

<img width="1536" height="933" alt="Screenshot_20260416_110324" src="https://github.com/user-attachments/assets/78784d08-db59-49ad-adc6-080f6de47073" />

after change page, request doesn't take in account previous filter


<img width="1536" height="933" alt="Screenshot_20260416_110510" src="https://github.com/user-attachments/assets/fc06472b-4391-46ec-9cae-c7316f6f4b38" />


### After


<img width="1570" height="1003" alt="Screenshot_20260416_110614" src="https://github.com/user-attachments/assets/18bec7b3-5d19-497c-8d96-af8e5e7988d5" />
