### PR TITLE
Chain filtering relations filter right values on select

### DIFF
--- a/src/components/InputSelect.vue
+++ b/src/components/InputSelect.vue
@@ -492,10 +492,13 @@
                       }
                     }))
                   }
-                } catch (e) {
+                } catch(e) {
                   console.warn(e);
                 }
               }
+              //need to reset values of input select
+              this.state.input.options.values.splice(0);
+              await this.$nextTick();
               this.state.input.options.values = (
                 (await layer.getFilterData({
                   fformatter : referencingField[0],
@@ -506,11 +509,9 @@
                                  .join('|AND,')
                 })).data || []).map(([value, key]) => ({ key, value }));
               //in the case of values length
-              if (this.state.input.options.values.length > 0) {
-                this.state.value = this.state.input.options.values[0].value;
-                this.select2.val(this.state.value).trigger('change');
-                await this.changeSelect(this.state.value);
-              }
+              this.state.value = this.state.input.options.values?.[0]?.value ?? null;
+              this.select2.val(this.state.value).trigger('change');
+              await this.changeSelect(this.state.value);
               //stop loading
               this.setLoading(false);
             })


### PR DESCRIPTION
Closes: #921 

Project: https://dev.g3wsuite.it/en/map/test-tudor/qdjango/323/

Initial value

<img width="376" height="463" alt="Screenshot_20260421_160045" src="https://github.com/user-attachments/assets/ab691439-5a28-47ae-904a-36c9fc2a45d1" />

If i change **Material** value

### Before

Old value is still visible on list 

<img width="376" height="463" alt="Screenshot_20260421_160234" src="https://github.com/user-attachments/assets/57435bf7-b846-451c-8a2b-84c35d247a10" />

###After

<img width="376" height="463" alt="Screenshot_20260421_160143" src="https://github.com/user-attachments/assets/82ffc05c-afb5-4a8f-bbf2-8e5dfa2e1157" />



