### PR TITLE
Make use of `ResizeObserver` instead of `"resize"` and `"transitionend"` events

### DIFF
--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -668,10 +668,10 @@ export default new (class GUI extends Emitter {
     ApplicationState.sidebar.width = document.querySelector('.main-sidebar').offsetWidth;;
 
     // handle main window resize
-    window.addEventListener('resize', () => { requestAnimationFrame(() => { this._layout(); }); });
+    new ResizeObserver(debounce(() => this._layout(), 0)).observe(document.body);
 
     // handle main sidebar resize
-    document.querySelector('.main-sidebar').addEventListener('transitionend', () => { requestAnimationFrame(() => { this._layout(); }); });
+    new ResizeObserver(() => this._layout()).observe(document.querySelector('.main-sidebar'));
 
     this._layout();
 

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -667,11 +667,11 @@ export default new (class GUI extends Emitter {
 
     ApplicationState.sidebar.width = document.querySelector('.main-sidebar').offsetWidth;;
 
-    // handle main window resize
-    new ResizeObserver(() => this._layout()).observe(document.body);
-
-    // handle main sidebar resize
-    new ResizeObserver(() => this._layout()).observe(document.querySelector('.main-sidebar'));
+    // handle main window resize and main sidebar resize (shared frame to avoid multiple _layout() calls per frame)
+    let _layoutRaf;
+    const scheduleLayout = () => { cancelAnimationFrame(_layoutRaf); _layoutRaf = requestAnimationFrame(() => this._layout()); };
+    new ResizeObserver(scheduleLayout).observe(document.body);
+    new ResizeObserver(scheduleLayout).observe(document.querySelector('.main-sidebar'));
 
     this._layout();
 

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -668,7 +668,7 @@ export default new (class GUI extends Emitter {
     ApplicationState.sidebar.width = document.querySelector('.main-sidebar').offsetWidth;;
 
     // handle main window resize
-    new ResizeObserver(debounce(() => this._layout(), 0)).observe(document.body);
+    new ResizeObserver(() => this._layout()).observe(document.body);
 
     // handle main sidebar resize
     new ResizeObserver(() => this._layout()).observe(document.querySelector('.main-sidebar'));

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -667,11 +667,16 @@ export default new (class GUI extends Emitter {
 
     ApplicationState.sidebar.width = document.querySelector('.main-sidebar').offsetWidth;;
 
-    // handle main window resize and main sidebar resize (shared frame to avoid multiple _layout() calls per frame)
-    let _layoutRaf;
-    const scheduleLayout = () => { cancelAnimationFrame(_layoutRaf); _layoutRaf = requestAnimationFrame(() => this._layout()); };
-    new ResizeObserver(scheduleLayout).observe(document.body);
-    new ResizeObserver(scheduleLayout).observe(document.querySelector('.main-sidebar'));
+    // handle window and sidebar resize
+    const resize_observer = (() => {
+      let frame;
+      return new ResizeObserver(() => {
+        cancelAnimationFrame(frame);
+        frame = requestAnimationFrame(() => { this._layout(); });
+      });
+    })();
+    resize_observer.observe(document.body);
+    resize_observer.observe(document.querySelector('.main-sidebar'));
 
     this._layout();
 


### PR DESCRIPTION
This update replaces the window resize event and main sidebar transitionend event with ResizeObserver to enhance layout management.


## BEFORE

https://github.com/user-attachments/assets/e442a158-f2ab-4159-8071-1ffee5ec6fe3

## AFTER

https://github.com/user-attachments/assets/8f9e77e2-f35e-4236-b2fe-8dea5a674408



