### PR TITLE
Prevent unnecessary updates to fields without dependencies in `saveDefaultExpressionFields`

### DIFF
--- a/src/components/g3w-form.js
+++ b/src/components/g3w-form.js
@@ -824,26 +824,22 @@ export class FormService extends Emitter {
   };
 
   /**
-   * Method to get default expression of field that has no dependencies fields listen when save form
-   * @returns {Promise<void>}
-   *
+   * Runs during form submission. Evaluates and assigns default expressions to fields without dependencies.
+   * 
    * @since 3.8.0
    */
   async saveDefaultExpressionFieldsNotDependencies() {
-    //@since 4.1.0 check whether there are updated fields that listen to updates and are not vector join fields
-    const noJoinFieldChanges = this.state.fields.some(f => f.update && !f.vectorjoin_id);
-    if (0 === this.default_expression_fields_on_update.length || !noJoinFieldChanges) { return }
     try {
-      //@since 3.11.0 get unique field names that has dependencies from another fields
-      const fields_with_dependencies = new Set(Object.values(this.default_expression_fields_dependencies).flat());
-      //get all fields with default expression without dependencies
-      const fields_without_dependencies = this.default_expression_fields_on_update
-        .filter(({ name }) => !fields_with_dependencies.has(name))
-      //set property value of field by default expression result from server
-      await Promise.allSettled(fields_without_dependencies
-        .map(field => new Promise(async (resolve, reject) => {
+      // skip when there are no default expression fields or if no form fields need an update (excluding vector joins)
+      if (0 === this.default_expression_fields_on_update.length || !this.state.fields.some(f => f.update && !f.vectorjoin_id)) {
+        return;
+      }
+      const fields_with_dependencies    = new Set(Object.values(this.default_expression_fields_dependencies).flat());
+      const fields_without_dependencies = this.default_expression_fields_on_update.filter(({ name }) => !fields_with_dependencies.has(name))
+      // wait until default expression is resolved and set value to field
+      await Promise.allSettled(
+        fields_without_dependencies.map(field => new Promise(async (resolve, reject) => {
             try {
-              //await until default expression is resolved and set value to field
               await getDefaultExpression({
                 field,
                 feature:      this.feature,
@@ -861,6 +857,6 @@ export class FormService extends Emitter {
     } catch(e) {
       console.warn(e);
     }
+  }
 
-  };
 }

--- a/src/components/g3w-form.js
+++ b/src/components/g3w-form.js
@@ -830,8 +830,9 @@ export class FormService extends Emitter {
    * @since 3.8.0
    */
   async saveDefaultExpressionFieldsNotDependencies() {
-    if (0 === this.default_expression_fields_on_update.length) { return }
-
+    //@since 4.1.0 get all fields with default expression that listen on update and has no dependencies with other fields
+    const noJoinFieldChanges = this.state.fields.filter(f => f.update && !f.vectorjoin_id);
+    if (0 === this.default_expression_fields_on_update.length || 0 === noJoinFieldChanges.length) { return }
     try {
       //@since 3.11.0 get unique field names that has dependencies from another fields
       const fields_with_dependencies = new Set(Object.values(this.default_expression_fields_dependencies).flat());

--- a/src/components/g3w-form.js
+++ b/src/components/g3w-form.js
@@ -830,9 +830,9 @@ export class FormService extends Emitter {
    * @since 3.8.0
    */
   async saveDefaultExpressionFieldsNotDependencies() {
-    //@since 4.1.0 get updated fields that listen to updates and are not vector join fields
-    const noJoinFieldChanges = this.state.fields.filter(f => f.update && !f.vectorjoin_id);
-    if (0 === this.default_expression_fields_on_update.length || 0 === noJoinFieldChanges.length) { return }
+    //@since 4.1.0 check whether there are updated fields that listen to updates and are not vector join fields
+    const noJoinFieldChanges = this.state.fields.some(f => f.update && !f.vectorjoin_id);
+    if (0 === this.default_expression_fields_on_update.length || !noJoinFieldChanges) { return }
     try {
       //@since 3.11.0 get unique field names that has dependencies from another fields
       const fields_with_dependencies = new Set(Object.values(this.default_expression_fields_dependencies).flat());

--- a/src/components/g3w-form.js
+++ b/src/components/g3w-form.js
@@ -830,7 +830,7 @@ export class FormService extends Emitter {
    * @since 3.8.0
    */
   async saveDefaultExpressionFieldsNotDependencies() {
-    //@since 4.1.0 get all fields with default expression that listen on update and has no dependencies with other fields
+    //@since 4.1.0 get updated fields that listen to updates and are not vector join fields
     const noJoinFieldChanges = this.state.fields.filter(f => f.update && !f.vectorjoin_id);
     if (0 === this.default_expression_fields_on_update.length || 0 === noJoinFieldChanges.length) { return }
     try {


### PR DESCRIPTION
## Summary of changes

This pull request updates the logic in the `FormService` class to improve how fields with default expressions and no dependencies are handled during updates. The main change ensures that only fields that both listen for updates and do not participate in vector joins are processed, preventing unnecessary operations and potential errors.

**Improvements to field update logic:**

- Updated `saveDefaultExpressionFieldsNotDependencies` to filter for fields that listen to updates and are not part of a vector join, and to exit early if there are no such fields or no default expression fields to update.

## How to test

**Project**: https://dev.g3wsuite.it/en/map/g3w-suite-demo/qdjango/158/

**Layer**: `padre_join`

**Fields**: `x`, `y_` with no field dependency

```json
{
    "name": "x",
    "type": "integer",
    "label": "x",
    "editable": true,
    "validate": {},
    "pk": false,
    "default": "",
    "input": {
        "type": "range",
        "options": {
            "values": [
                {
                    "min": -2147483648,
                    "max": 2147483647,
                    "Step": 1,
                    "default": null
                }
            ],
            "default_expression": {
                "expression": "$x",
                "referenced_columns": [],
                "referenced_functions": [
                    "$x"
                ],
                "apply_on_update": true
            }
        }
    }
}

```

```json
{
    "name": "y",
    "type": "integer",
    "label": "y",
    "editable": true,
    "validate": {},
    "pk": false,
    "default": "",
    "input": {
        "type": "range",
        "options": {
            "values": [
                {
                    "min": -2147483648,
                    "max": 2147483647,
                    "Step": 1,
                    "default": null
                }
            ],
            "default_expression": {
                "expression": "$y",
                "referenced_columns": [],
                "referenced_functions": [
                    "$y"
                ],
                "apply_on_update": true
            }
        }
    }
}
```

Join field _figlio_join_name_ (attribute `"vectorjoin_id": "padre_join_c078fe56_65b1_4b80_ab1b_1b063688dc29_vectorjoin_0"`)

```json
{
    "name": "figlio_join_name",
    "type": "varchar",
    "label": "figlio_join_name",
    "editable": true,
    "validate": {},
    "pk": false,
    "default": "",
    "input": {
        "type": "text",
        "options": {}
    },
    "vectorjoin_id": "padre_join_c078fe56_65b1_4b80_ab1b_1b063688dc29_vectorjoin_0"
}
```

### Before

Update join field

<img width="1343" height="821" alt="Screenshot_20260511_114243" src="https://github.com/user-attachments/assets/60e704b7-ad88-414d-9b66-f50ee5433b4b" />

Upddate x, y (Wrong)

<img width="457" height="699" alt="Screenshot_20260511_114322" src="https://github.com/user-attachments/assets/292abccc-051f-4dc9-933c-d8191cc35ec2" />


### After

x, y are not changed

<img width="457" height="545" alt="Screenshot_20260511_114613" src="https://github.com/user-attachments/assets/452ce52e-315b-4351-b684-e6d23b84c75d" />

