### PR TITLE
Optimize `GUI~_layout()` and `ResizeObserver` rendering

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -1143,9 +1143,14 @@ export default {
     async onResize(e) {
       const sidebar = document.getElementById('g3w-view-content');
       const panel   = ApplicationState.layout[ApplicationState.layout.__current].rightpanel;
+      const wrapper = document.querySelector('.content-wrapper');
+      let frame;
       let rect, dx, dy;
 
       this.state.content.disabled = true;
+      if (wrapper) {
+        wrapper.dataset.manualResize = '1';
+      }
 
       const mousemove = e => {
         e.preventDefault();
@@ -1153,8 +1158,6 @@ export default {
 
         dx   = e.pageX - rect.left - window.scrollX;
         dy   = e.pageY - rect.top - window.scrollY;
-
-        const wrapper = document.querySelector('.content-wrapper');
 
         panel.width  = Math.min(Math.max(
           Math.round((200               / wrapper.clientWidth)  * 100),
@@ -1166,23 +1169,16 @@ export default {
           Math.round(((rect.height -dy) / wrapper.clientHeight) * 100),
         ), 90);
 
-        const { viewW, viewH } = GUI.getViewportSizes();
-
-        const h_split = 'h' === this.state.split;
-        const v_split = 'v' === this.state.split;
-        
-        // percentage of secondary view (content)
-        const scale = (h_split ? panel.width : panel.height) /100;
-
-        // size "content"
-        Object.assign(this.state.content.sizes, {
-          width:  (h_split ?  (viewW * scale) : viewW),
-          height: (v_split ? (viewH * scale) : viewH),
-        });
+        cancelAnimationFrame(frame);
+        frame = requestAnimationFrame(() => GUI._layout());
       };
 
       const mouseup = async e => {
         document.removeEventListener('mousemove', mousemove);
+        cancelAnimationFrame(frame);
+        if (wrapper) {
+          delete wrapper.dataset.manualResize;
+        }
         if (!this.disabled && 'h' === this.state.split && panel.width > 65) {
           GUI.hideSidebar();
         }

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -1166,8 +1166,7 @@ export default {
           Math.round(((rect.height -dy) / wrapper.clientHeight) * 100),
         ), 90);
 
-        const viewW = document.querySelector('#app').getBoundingClientRect().width - document.querySelector('.main-sidebar').getBoundingClientRect().width - document.querySelector('.main-sidebar').getBoundingClientRect().left - window.scrollX;
-        const viewH = window.innerHeight - document.querySelector('.navbar').offsetHeight;
+        const { viewW, viewH } = GUI.getViewportSizes();
 
         const h_split = 'h' === this.state.split;
         const v_split = 'v' === this.state.split;

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -568,7 +568,10 @@
     <!-- MAIN (content) -->
     <div
       class  = "content-wrapper"
-      :style = "{ paddingTop: ApplicationState.iframe ? 0 : null }"
+      :style = "{
+        paddingTop: ApplicationState.iframe ? 0 : null,
+        height: `calc(100% - ${ApplicationState.iframe ? 0 : 50}px)`
+      }"
     > 
       <bar-loader style = "position: absolute; z-index: 1;" :loading = "state.content.loading && 0 === state.contentsdata.length"/>
       <transition name = "fade" :duration = "{ enter: 500, leave: 500 }">
@@ -1143,61 +1146,46 @@ export default {
     async onResize(e) {
       const sidebar = document.getElementById('g3w-view-content');
       const panel   = ApplicationState.layout[ApplicationState.layout.__current].rightpanel;
-      const wrapper = document.querySelector('.content-wrapper');
-      const minDeltaPx = 1;
-      let frame;
       let rect, dx, dy;
-      let prevPageX = e.pageX;
-      let prevPageY = e.pageY;
 
       this.state.content.disabled = true;
-      if (wrapper) {
-        wrapper.dataset.manualResize = '1';
-      }
 
       const mousemove = e => {
         e.preventDefault();
-        const h_split = 'h' === this.state.split;
-        const v_split = 'v' === this.state.split;
-
-        if ((h_split && Math.abs(e.pageX - prevPageX) < minDeltaPx) || (v_split && Math.abs(e.pageY - prevPageY) < minDeltaPx)) {
-          return;
-        }
-
         rect = sidebar.getBoundingClientRect();
 
         dx   = e.pageX - rect.left - window.scrollX;
         dy   = e.pageY - rect.top - window.scrollY;
 
-        const width = Math.min(Math.max(
+        const wrapper = document.querySelector('.content-wrapper');
+
+        panel.width  = Math.min(Math.max(
           Math.round((200               / wrapper.clientWidth)  * 100),
           Math.round(((rect.width  -dx) / wrapper.clientWidth)  * 100),
         ), 90);
 
-        const height = Math.min(Math.max(
+        panel.height = Math.min(Math.max(
           Math.round((200               / wrapper.clientHeight) * 100),
           Math.round(((rect.height -dy) / wrapper.clientHeight) * 100),
         ), 90);
 
-        if (width === panel.width && height === panel.height) {
-          return;
-        }
+        const { viewW, viewH } = GUI.getViewportSizes();
 
-        panel.width  = width;
-        panel.height = height;
-        prevPageX    = e.pageX;
-        prevPageY    = e.pageY;
+        const h_split = 'h' === this.state.split;
+        const v_split = 'v' === this.state.split;
+        
+        // percentage of secondary view (content)
+        const scale = (h_split ? panel.width : panel.height) /100;
 
-        cancelAnimationFrame(frame);
-        frame = requestAnimationFrame(() => GUI._layout());
+        // size "content"
+        Object.assign(this.state.content.sizes, {
+          width:  (h_split ?  (viewW * scale) : viewW),
+          height: (v_split ? (viewH * scale) : viewH),
+        });
       };
 
       const mouseup = async e => {
         document.removeEventListener('mousemove', mousemove);
-        cancelAnimationFrame(frame);
-        if (wrapper) {
-          delete wrapper.dataset.manualResize;
-        }
         if (!this.disabled && 'h' === this.state.split && panel.width > 65) {
           GUI.hideSidebar();
         }

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -1144,8 +1144,11 @@ export default {
       const sidebar = document.getElementById('g3w-view-content');
       const panel   = ApplicationState.layout[ApplicationState.layout.__current].rightpanel;
       const wrapper = document.querySelector('.content-wrapper');
+      const minDeltaPx = 1;
       let frame;
       let rect, dx, dy;
+      let prevPageX = e.pageX;
+      let prevPageY = e.pageY;
 
       this.state.content.disabled = true;
       if (wrapper) {
@@ -1154,20 +1157,36 @@ export default {
 
       const mousemove = e => {
         e.preventDefault();
+        const h_split = 'h' === this.state.split;
+        const v_split = 'v' === this.state.split;
+
+        if ((h_split && Math.abs(e.pageX - prevPageX) < minDeltaPx) || (v_split && Math.abs(e.pageY - prevPageY) < minDeltaPx)) {
+          return;
+        }
+
         rect = sidebar.getBoundingClientRect();
 
         dx   = e.pageX - rect.left - window.scrollX;
         dy   = e.pageY - rect.top - window.scrollY;
 
-        panel.width  = Math.min(Math.max(
+        const width = Math.min(Math.max(
           Math.round((200               / wrapper.clientWidth)  * 100),
           Math.round(((rect.width  -dx) / wrapper.clientWidth)  * 100),
         ), 90);
 
-        panel.height = Math.min(Math.max(
+        const height = Math.min(Math.max(
           Math.round((200               / wrapper.clientHeight) * 100),
           Math.round(((rect.height -dy) / wrapper.clientHeight) * 100),
         ), 90);
+
+        if (width === panel.width && height === panel.height) {
+          return;
+        }
+
+        panel.width  = width;
+        panel.height = height;
+        prevPageX    = e.pageX;
+        prevPageY    = e.pageY;
 
         cancelAnimationFrame(frame);
         frame = requestAnimationFrame(() => GUI._layout());

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -1888,7 +1888,8 @@ export default new (class GUI extends Emitter {
 
     const contents        = document.querySelector('#contents');
     const content_wrapper = document.querySelector('.content-wrapper');
-    const viewW           = document.querySelector('#app').getBoundingClientRect().width - document.querySelector(".main-sidebar").getBoundingClientRect().width - document.querySelector('.main-sidebar').getBoundingClientRect().left - window.scrollX;
+    const sidebar         = document.querySelector('.main-sidebar').getBoundingClientRect();
+    const viewW           = document.querySelector('#app').getBoundingClientRect().width - sidebar.width - sidebar.left - window.scrollX;
     const viewH           = window.innerHeight - document.querySelector('.navbar').offsetHeight;
     const panel           = layout[layout.__current].rightpanel;
 

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -1850,7 +1850,7 @@ export default new (class GUI extends Emitter {
     const app             = document.querySelector('#app');
     const viewport        = content_wrapper || app || document.documentElement;
     return {
-      viewW: viewport?.getBoundingClientRect().width || window.innerWidth,
+      viewW: viewport.getBoundingClientRect().width || window.innerWidth,
       viewH: window.innerHeight - (navbar?.offsetHeight || 0),
     };
   }
@@ -1873,10 +1873,10 @@ export default new (class GUI extends Emitter {
 
     const contents        = document.querySelector('#contents');
     const content_wrapper = document.querySelector('.content-wrapper');
-    const { viewW, viewH } = this.getViewportSizes();
     if (!content_wrapper || !contents) {
       return;
     }
+    const { viewW, viewH } = this.getViewportSizes();
     const panel           = layout[layout.__current].rightpanel;
 
     const opts = {

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -1847,10 +1847,12 @@ export default new (class GUI extends Emitter {
   getViewportSizes() {
     const content_wrapper = document.querySelector('.content-wrapper');
     const navbar          = document.querySelector('.navbar');
+    const app             = document.querySelector('#app');
+    const viewport        = content_wrapper || app || document.documentElement;
     return {
       content_wrapper,
-      viewW: content_wrapper.getBoundingClientRect().width,
-      viewH: window.innerHeight - navbar.offsetHeight,
+      viewW: viewport.getBoundingClientRect().width,
+      viewH: window.innerHeight - (navbar?.offsetHeight || 0),
     };
   }
 
@@ -1872,6 +1874,9 @@ export default new (class GUI extends Emitter {
 
     const contents        = document.querySelector('#contents');
     const { content_wrapper, viewW, viewH } = this.getViewportSizes();
+    if (!content_wrapper || !contents) {
+      return;
+    }
     const panel           = layout[layout.__current].rightpanel;
 
     const opts = {

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -677,30 +677,6 @@ export default new (class GUI extends Emitter {
     })();
     resize_observer.observe(document.querySelector('.content-wrapper'));
 
-    const sidebarFix = new ResizeObserver(() => {
-      const contents = document.querySelector('#contents');
-      const panel    = document.querySelector('#g3w-view-content');
-
-      contents.style.height = panel.offsetHeight
-        - (panel.querySelector('.close-panel-block')?.offsetHeight || 0)
-        - (panel.querySelector('.content_breadcrumb')?.offsetHeight || 0)
-        - (contents.children[0] ? 50 : 0) + 'px'; // vertical padding
-
-      // workaround for qplotly?
-      if (contents.children[0]) {
-        contents.children[0].style.height = contents.style.height;
-      }
-
-      panel.style.padding = contents.children[0] ? '15px' : null;
-
-      const viewH = window.innerHeight - document.querySelector('.navbar').offsetHeight;
-      document.querySelector(".content-wrapper").style.height = `${viewH}px`;
-      document.querySelector(".main-sidebar").style.height    = `${viewH}px`;
-      document.querySelector(".sidebar-panel").style.height   = `${viewH}px`;
-    });
-
-    sidebarFix.observe(document.querySelector('#g3w-view-content'));
-
     this._layout();
 
     // remove "permalink_code" from URL
@@ -1938,6 +1914,26 @@ export default new (class GUI extends Emitter {
       width:  ApplicationState.map.sizes.width,
       height: ApplicationState.map.sizes.height
     });
+
+    // sidebar panel fix
+    const contents_el = document.querySelector('#contents');
+    const panel_el    = document.querySelector('#g3w-view-content');
+    if (contents_el && panel_el) {
+      contents_el.style.height = panel_el.offsetHeight
+        - (panel_el.querySelector('.close-panel-block')?.offsetHeight || 0)
+        - (panel_el.querySelector('.content_breadcrumb')?.offsetHeight || 0)
+        - (contents_el.children[0] ? 50 : 0) + 'px'; // vertical padding
+
+      // workaround for qplotly?
+      if (contents_el.children[0]) {
+        contents_el.children[0].style.height = contents_el.style.height;
+      }
+
+      panel_el.style.padding = contents_el.children[0] ? '15px' : null;
+
+      document.querySelector(".main-sidebar").style.height  = `${viewH}px`;
+      document.querySelector(".sidebar-panel").style.height = `${viewH}px`;
+    }
 
     ApplicationState.contentsdata.forEach(d => {                           // re-layout each component stored into the stack
       try {

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -1934,16 +1934,17 @@ export default new (class GUI extends Emitter {
       document.querySelector(".sidebar-panel").style.height = `${viewH}px`;
     }
 
-    ApplicationState.contentsdata.forEach(d => {                           // re-layout each component stored into the stack
-      try {
-        if ('function' == typeof d.content.layout) {
+    // re-layout each component stored into the stack
+    ApplicationState.contentsdata
+      .filter(d => 'function' == typeof d.content.layout)
+      .forEach(d => {                           
+        try {  
           d.content.layout(ApplicationState.content.sizes.width, parseFloat(contents.style.height));
+        } catch(e) {
+          this.showUserMessage({ type: 'warning', message: e.toString(), autoclose: true });
+          setTimeout(() => this._layout(), 1000);
         }
-      } catch(e) {
-        this.showUserMessage({ type: 'warning', message: e.toString(), autoclose: true });
-        setTimeout(() => this._layout(), 1000);
-      }
-    });
+      });
     
     this.emit('resize');
 

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -1856,8 +1856,8 @@ export default new (class GUI extends Emitter {
       this._layout.secondary = param;
     }
 
-    const sec             =  this._layout.secondary;
-
+    const sec             = this._layout.secondary;
+    
     const layout          = ApplicationState.layout;
 
     const contents        = document.querySelector('#contents');
@@ -1918,10 +1918,10 @@ export default new (class GUI extends Emitter {
     // sidebar panel fix
     const panel_el = document.querySelector('#g3w-view-content');
     if (panel_el) {
-      contents.style.height = panel_el.offsetHeight
+      contents.style.height = `${panel_el.offsetHeight
         - (panel_el.querySelector('.close-panel-block')?.offsetHeight || 0)
         - (panel_el.querySelector('.content_breadcrumb')?.offsetHeight || 0)
-        - (content_child ? 50 : 0) + 'px'; // vertical padding
+        - (content_child ? 50 : 0)}px`; // vertical padding
 
       // workaround for qplotly?
       if (content_child) {

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -1936,8 +1936,6 @@ export default new (class GUI extends Emitter {
         contents.children[0].style.height = contents.style.height;
       }
 
-      panel_el.style.padding = contents.children[0] ? '15px' : null;
-
       document.querySelector(".main-sidebar").style.height  = `${viewH}px`;
       document.querySelector(".sidebar-panel").style.height = `${viewH}px`;
     }

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -677,14 +677,7 @@ export default new (class GUI extends Emitter {
     })();
     resize_observer.observe(document.querySelector('.content-wrapper'));
 
-    this._layout();
-
-    // remove "permalink_code" from URL
-    const url = new URL(window.location);
-    url.searchParams.delete('permalink_code');
-    window.history.replaceState(null, null, url);
-
-    const sidebarFix = () => {
+    const sidebarFix = new ResizeObserver(() => {
       const contents = document.querySelector('#contents');
       const panel    = document.querySelector('#g3w-view-content');
 
@@ -693,7 +686,7 @@ export default new (class GUI extends Emitter {
         - (panel.querySelector('.content_breadcrumb')?.offsetHeight || 0)
         - (contents.children[0] ? 50 : 0) + 'px'; // vertical padding
 
-        // workaround for qplotly?
+      // workaround for qplotly?
       if (contents.children[0]) {
         contents.children[0].style.height = contents.style.height;
       }
@@ -704,10 +697,16 @@ export default new (class GUI extends Emitter {
       document.querySelector(".content-wrapper").style.height = `${viewH}px`;
       document.querySelector(".main-sidebar").style.height    = `${viewH}px`;
       document.querySelector(".sidebar-panel").style.height   = `${viewH}px`;
+    });
 
-      requestAnimationFrame(sidebarFix);
-    };
-    requestAnimationFrame(sidebarFix);
+    sidebarFix.observe(document.querySelector('#g3w-view-content'));
+
+    this._layout();
+
+    // remove "permalink_code" from URL
+    const url = new URL(window.location);
+    url.searchParams.delete('permalink_code');
+    window.history.replaceState(null, null, url);
 
     // initialize iframe services
     if (ApplicationState.iframe) {

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -670,15 +670,14 @@ export default new (class GUI extends Emitter {
     // handle window and sidebar resize
     const resize_observer = (() => {
       let frame;
-      return new ResizeObserver((entries) => {
-        if (entries.some(({ target }) => '1' === target?.dataset?.manualResize)) {
-          return;
-        }
+      return new ResizeObserver(() => {
         cancelAnimationFrame(frame);
         frame = requestAnimationFrame(() => { this._layout(); });
       });
     })();
     resize_observer.observe(document.querySelector('.content-wrapper'));
+    document.querySelector('.main-sidebar').addEventListener('transitionend', () => this._layout());
+    document.querySelector('.content-wrapper').addEventListener('transitionend', () => this._layout());
 
     this._layout();
 

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -1861,6 +1861,7 @@ export default new (class GUI extends Emitter {
     const layout          = ApplicationState.layout;
 
     const contents        = document.querySelector('#contents');
+    const content_child   = contents.children[0];
     const content_wrapper = document.querySelector('.content-wrapper');
     const navbar          = document.querySelector('.navbar');
     const viewW           = content_wrapper.getBoundingClientRect().width;
@@ -1920,14 +1921,14 @@ export default new (class GUI extends Emitter {
       contents.style.height = panel_el.offsetHeight
         - (panel_el.querySelector('.close-panel-block')?.offsetHeight || 0)
         - (panel_el.querySelector('.content_breadcrumb')?.offsetHeight || 0)
-        - (contents.children[0] ? 50 : 0) + 'px'; // vertical padding
+        - (content_child ? 50 : 0) + 'px'; // vertical padding
 
       // workaround for qplotly?
-      if (contents.children[0]) {
-        contents.children[0].style.height = contents.style.height;
+      if (content_child) {
+        content_child.style.height = contents.style.height;
       }
 
-      panel_el.style.padding = contents.children[0] ? '15px' : null;
+      panel_el.style.padding = content_child ? '15px' : null;
 
       document.querySelector(".main-sidebar").style.height  = `${viewH}px`;
       document.querySelector(".sidebar-panel").style.height = `${viewH}px`;

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -670,7 +670,10 @@ export default new (class GUI extends Emitter {
     // handle window and sidebar resize
     const resize_observer = (() => {
       let frame;
-      return new ResizeObserver(() => {
+      return new ResizeObserver((entries) => {
+        if (entries.some(({ target }) => '1' === target?.dataset?.manualResize)) {
+          return;
+        }
         cancelAnimationFrame(frame);
         frame = requestAnimationFrame(() => { this._layout(); });
       });

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -675,8 +675,7 @@ export default new (class GUI extends Emitter {
         frame = requestAnimationFrame(() => { this._layout(); });
       });
     })();
-    resize_observer.observe(document.body);
-    resize_observer.observe(document.querySelector('.main-sidebar'));
+    resize_observer.observe(document.querySelector('.content-wrapper'));
 
     this._layout();
 
@@ -1889,9 +1888,7 @@ export default new (class GUI extends Emitter {
     const contents        = document.querySelector('#contents');
     const content_wrapper = document.querySelector('.content-wrapper');
     const navbar          = document.querySelector('.navbar');
-    const sidebar         = document.querySelector('.main-sidebar').getBoundingClientRect();
-    const appW            = document.querySelector('#app').getBoundingClientRect().width;
-    const viewW           = appW - sidebar.width - sidebar.left - window.scrollX;
+    const viewW           = content_wrapper.getBoundingClientRect().width;
     const viewH           = window.innerHeight - navbar.offsetHeight;
     const panel           = layout[layout.__current].rightpanel;
 

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -1850,7 +1850,7 @@ export default new (class GUI extends Emitter {
     const app             = document.querySelector('#app');
     const viewport        = content_wrapper || app || document.documentElement;
     return {
-      viewW: viewport.getBoundingClientRect().width,
+      viewW: viewport?.getBoundingClientRect().width || window.innerWidth,
       viewH: window.innerHeight - (navbar?.offsetHeight || 0),
     };
   }

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -1861,7 +1861,6 @@ export default new (class GUI extends Emitter {
     const layout          = ApplicationState.layout;
 
     const contents        = document.querySelector('#contents');
-    const content_child   = contents.children[0];
     const content_wrapper = document.querySelector('.content-wrapper');
     const navbar          = document.querySelector('.navbar');
     const viewW           = content_wrapper.getBoundingClientRect().width;
@@ -1918,34 +1917,34 @@ export default new (class GUI extends Emitter {
     // sidebar panel fix
     const panel_el = document.querySelector('#g3w-view-content');
     if (panel_el) {
-      contents.style.height = `${panel_el.offsetHeight
+      contents.style.height = panel_el.offsetHeight
         - (panel_el.querySelector('.close-panel-block')?.offsetHeight || 0)
         - (panel_el.querySelector('.content_breadcrumb')?.offsetHeight || 0)
-        - (content_child ? 50 : 0)}px`; // vertical padding
+        - (contents.children[0] ? 50 : 0) + 'px'; // vertical padding
 
       // workaround for qplotly?
-      if (content_child) {
-        content_child.style.height = contents.style.height;
+      if (contents.children[0]) {
+        contents.children[0].style.height = contents.style.height;
       }
 
-      panel_el.style.padding = content_child ? '15px' : null;
+      panel_el.style.padding = contents.children[0] ? '15px' : null;
 
       document.querySelector(".main-sidebar").style.height  = `${viewH}px`;
       document.querySelector(".sidebar-panel").style.height = `${viewH}px`;
     }
 
     // re-layout each component stored into the stack
-    ApplicationState.contentsdata
-      .filter(d => 'function' == typeof d.content.layout)
-      .forEach(d => {                           
-        try {  
+    ApplicationState.contentsdata.forEach(d => {
+      try {
+        if ('function' == typeof d.content.layout) {
           d.content.layout(ApplicationState.content.sizes.width, parseFloat(contents.style.height));
-        } catch(e) {
-          this.showUserMessage({ type: 'warning', message: e.toString(), autoclose: true });
-          setTimeout(() => this._layout(), 1000);
         }
-      });
-    
+      } catch(e) {
+        this.showUserMessage({ type: 'warning', message: e.toString(), autoclose: true });
+        setTimeout(() => this._layout(), 1000);
+      }
+    });
+
     this.emit('resize');
 
     window.localStorage.setItem('SIDEBAR', JSON.stringify(panel));

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -1850,7 +1850,6 @@ export default new (class GUI extends Emitter {
     const app             = document.querySelector('#app');
     const viewport        = content_wrapper || app || document.documentElement;
     return {
-      content_wrapper,
       viewW: viewport.getBoundingClientRect().width,
       viewH: window.innerHeight - (navbar?.offsetHeight || 0),
     };
@@ -1873,7 +1872,8 @@ export default new (class GUI extends Emitter {
     const layout          = ApplicationState.layout;
 
     const contents        = document.querySelector('#contents');
-    const { content_wrapper, viewW, viewH } = this.getViewportSizes();
+    const content_wrapper = document.querySelector('.content-wrapper');
+    const { viewW, viewH } = this.getViewportSizes();
     if (!content_wrapper || !contents) {
       return;
     }

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -1847,11 +1847,9 @@ export default new (class GUI extends Emitter {
   getViewportSizes() {
     const content_wrapper = document.querySelector('.content-wrapper');
     const navbar          = document.querySelector('.navbar');
-    const app             = document.querySelector('#app');
-    const viewport        = content_wrapper || app || document.documentElement;
     return {
-      viewW: viewport.getBoundingClientRect().width || window.innerWidth,
-      viewH: window.innerHeight - (navbar?.offsetHeight || 0),
+      viewW: content_wrapper.getBoundingClientRect().width || window.innerWidth,
+      viewH: window.innerHeight - navbar.offsetHeight,
     };
   }
 
@@ -1871,13 +1869,10 @@ export default new (class GUI extends Emitter {
     
     const layout          = ApplicationState.layout;
 
-    const contents        = document.querySelector('#contents');
-    const content_wrapper = document.querySelector('.content-wrapper');
-    if (!content_wrapper || !contents) {
-      return;
-    }
+    const contents         = document.querySelector('#contents');
+    const content_wrapper  = document.querySelector('.content-wrapper');
     const { viewW, viewH } = this.getViewportSizes();
-    const panel           = layout[layout.__current].rightpanel;
+    const panel            = layout[layout.__current].rightpanel;
 
     const opts = {
       split: ApplicationState.split,

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -1882,15 +1882,17 @@ export default new (class GUI extends Emitter {
       this._layout.secondary = param;
     }
 
-    const sec =  this._layout.secondary;
+    const sec             =  this._layout.secondary;
 
-    const layout = ApplicationState.layout;
+    const layout          = ApplicationState.layout;
 
     const contents        = document.querySelector('#contents');
     const content_wrapper = document.querySelector('.content-wrapper');
+    const navbar          = document.querySelector('.navbar');
     const sidebar         = document.querySelector('.main-sidebar').getBoundingClientRect();
-    const viewW           = document.querySelector('#app').getBoundingClientRect().width - sidebar.width - sidebar.left - window.scrollX;
-    const viewH           = window.innerHeight - document.querySelector('.navbar').offsetHeight;
+    const appW            = document.querySelector('#app').getBoundingClientRect().width;
+    const viewW           = appW - sidebar.width - sidebar.left - window.scrollX;
+    const viewH           = window.innerHeight - navbar.offsetHeight;
     const panel           = layout[layout.__current].rightpanel;
 
     const opts = {
@@ -1944,7 +1946,7 @@ export default new (class GUI extends Emitter {
     ApplicationState.contentsdata.forEach(d => {                           // re-layout each component stored into the stack
       try {
         if ('function' == typeof d.content.layout) {
-          d.content.layout(ApplicationState.content.sizes.width, contents.style.height.replace('px',''));
+          d.content.layout(ApplicationState.content.sizes.width, parseFloat(contents.style.height));
         }
       } catch(e) {
         this.showUserMessage({ type: 'warning', message: e.toString(), autoclose: true });

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -1844,6 +1844,16 @@ export default new (class GUI extends Emitter {
     dialog.showModal();
   }
 
+  getViewportSizes() {
+    const content_wrapper = document.querySelector('.content-wrapper');
+    const navbar          = document.querySelector('.navbar');
+    return {
+      content_wrapper,
+      viewW: content_wrapper.getBoundingClientRect().width,
+      viewH: window.innerHeight - navbar.offsetHeight,
+    };
+  }
+
   /**
    * load components of viewport after right size setting
    * 
@@ -1861,10 +1871,7 @@ export default new (class GUI extends Emitter {
     const layout          = ApplicationState.layout;
 
     const contents        = document.querySelector('#contents');
-    const content_wrapper = document.querySelector('.content-wrapper');
-    const navbar          = document.querySelector('.navbar');
-    const viewW           = content_wrapper.getBoundingClientRect().width;
-    const viewH           = window.innerHeight - navbar.offsetHeight;
+    const { content_wrapper, viewW, viewH } = this.getViewportSizes();
     const panel           = layout[layout.__current].rightpanel;
 
     const opts = {

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -1884,7 +1884,6 @@ export default new (class GUI extends Emitter {
     const scale = is_full ? 1 : ((h_split ? panel.width: panel.height) /100);
 
     contents.parentElement.classList.toggle('full-size', is_full);
-    
 
     // size "content"
     Object.assign(ApplicationState.content.sizes, {
@@ -1916,20 +1915,19 @@ export default new (class GUI extends Emitter {
     });
 
     // sidebar panel fix
-    const contents_el = document.querySelector('#contents');
-    const panel_el    = document.querySelector('#g3w-view-content');
-    if (contents_el && panel_el) {
-      contents_el.style.height = panel_el.offsetHeight
+    const panel_el = document.querySelector('#g3w-view-content');
+    if (panel_el) {
+      contents.style.height = panel_el.offsetHeight
         - (panel_el.querySelector('.close-panel-block')?.offsetHeight || 0)
         - (panel_el.querySelector('.content_breadcrumb')?.offsetHeight || 0)
-        - (contents_el.children[0] ? 50 : 0) + 'px'; // vertical padding
+        - (contents.children[0] ? 50 : 0) + 'px'; // vertical padding
 
       // workaround for qplotly?
-      if (contents_el.children[0]) {
-        contents_el.children[0].style.height = contents_el.style.height;
+      if (contents.children[0]) {
+        contents.children[0].style.height = contents.style.height;
       }
 
-      panel_el.style.padding = contents_el.children[0] ? '15px' : null;
+      panel_el.style.padding = contents.children[0] ? '15px' : null;
 
       document.querySelector(".main-sidebar").style.height  = `${viewH}px`;
       document.querySelector(".sidebar-panel").style.height = `${viewH}px`;

--- a/src/static/app.css
+++ b/src/static/app.css
@@ -637,6 +637,7 @@ ul.sidebar-menu > li a:hover                                       { color: hsl(
 .sidebar-mini:not(.sidebar-collapse) .g3w-view.content.full-size                 { padding-left: 45px !important; }
 
 .g3w-view.content                                                                { z-index: 1; container-name: g3w-view-content; container-type: size; }
+.g3w-view.content:has(> .contents:not(:empty))                                   { padding: 15px; }
 .g3w-view.content.split-h:not(.g3w-disabled)                                     { transition: width .3s ease-in-out; }
 .g3w-view.content.split-v:not(.g3w-disabled)                                     { transition: height .3s ease-in-out; }
 .g3w-view.content .preview                                                       { width: 100%; margin-top: 0; display:flex; align-items: center;}


### PR DESCRIPTION
- remove `sidebarFix()` and its heavy `requestAnimationFrame` loop.
- consolidate layout sizing within `GUI~_layout()` function
- refactor `ResizeObserver` to strictly target `.content-wrapper` to prevent redundant triggers.