### PR TITLE
Refactor `isMobile` mobile detection logic

### DIFF
--- a/src/g3w-vendors.js
+++ b/src/g3w-vendors.js
@@ -80,7 +80,11 @@ Object.assign(globalThis, {
   Vue,
   /** @deprecated since 3.11.0 */
   isMobile: {
-    get any() { return ('ontouchstart' in window || navigator.maxTouchPoints > 0) && window.matchMedia('(any-pointer: coarse)').matches; }
+    get any() {
+      return undefined !== window.orientation ||
+        navigator?.userAgentData?.mobile ||
+        (('ontouchstart' in window || navigator.maxTouchPoints > 0) && window.matchMedia('(any-pointer: coarse)').matches);
+    }
   },
   /** @deprecated since 3.11.0 */
   $script(url, callback) {

--- a/src/g3w-vendors.js
+++ b/src/g3w-vendors.js
@@ -80,7 +80,7 @@ Object.assign(globalThis, {
   Vue,
   /** @deprecated since 3.11.0 */
   isMobile: {
-    get any() { return window.matchMedia('(hover: none) and (pointer: coarse)').matches; }
+    get any() { return ('ontouchstart' in window || navigator.maxTouchPoints > 0) && window.matchMedia('(any-pointer: coarse)').matches; }
   },
   /** @deprecated since 3.11.0 */
   $script(url, callback) {


### PR DESCRIPTION
## Motivation

Some mobile devices support multiple inputs (touch + stylus/mouse). The old `hover: none` logic fails because the browser detects hover capabilities.