### PR TITLE
Sidear panel cropped on mobile

### DIFF
--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -676,6 +676,7 @@ export default new (class GUI extends Emitter {
       });
     })();
     resize_observer.observe(document.querySelector('.content-wrapper'));
+    resize_observer.observe(document.querySelector('.navbar'));
     document.querySelector('.main-sidebar').addEventListener('transitionend', () => this._layout());
     document.querySelector('.content-wrapper').addEventListener('transitionend', () => this._layout());
 


### PR DESCRIPTION
## Issue description

Imporve `GUI._layout()` to ensures that the `resize_observer` also observes the `.navbar` element, which will help the application respond to size changes in the navigation bar.

## Before

<img width="484" height="461" alt="Screenshot_20260522_140621" src="https://github.com/user-attachments/assets/4ef7c3a7-80ce-46ee-a9f7-851d92a1724c" />


## After


<img width="484" height="461" alt="Screenshot_20260522_140516" src="https://github.com/user-attachments/assets/6f444905-7e12-4845-b942-3984c9529598" />
