### PR TITLE
Add support for external `arcgismapserver` source type

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -821,7 +821,6 @@
               @click         = "closeContent"
               title          = "close"
               data-placement = "bottom"
-              :class         = "{'mobile': isMobile()}"
               class          = "action-button action-button-close skin-color-dark fas fa-times"
             ></button>
           </div>

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -313,9 +313,9 @@
                 v-if   = "layer.rawdata"
                 class  = "queryresults-text-html"
                 :class    = "{ text: layer.infoformat === 'text/plain' }"
-                :key         = "`${layer.id}_${layer.infoformat}_${(layer.rawdata || '').length}_${(layer.rawdata || '').charCodeAt(0) || 0}`"
-                style        = "width: 100%; border: none;"
-                sandbox   = "allow-same-origin"
+                :key      = "`${layer.id}_${layer.infoformat}_${(layer.rawdata || '').length}_${(layer.rawdata || '').charCodeAt(0) || 0}`"
+                style     = "width: 100%; border: none;"
+                sandbox   = "allow-same-origin allow-popups allow-scripts"
                 scrolling = "no"
                 @load     = "setRawdataIframeContent($event, layer)"
               ></iframe>

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -676,14 +676,10 @@
           // recalculate content height and update the iframe dimensions (to avoid vertical scrollbars within iframe)
           const measure   = () => {
             // Keep only horizontal scrollbar inside iframe content.
-            if (doc.documentElement) {
-              doc.documentElement.style.overflowX = 'text/plain' === layer.infoformat ? 'hidden' : 'auto';
-              doc.documentElement.style.overflowY = 'hidden';
-            }
-            if (doc.body) {
-              doc.body.style.overflowX = 'text/plain' === layer.infoformat ? 'hidden' : 'auto';
-              doc.body.style.overflowY = 'hidden';
-            }
+            doc.documentElement.style.overflowX = 'text/plain' === layer.infoformat ? 'hidden' : 'auto';
+            doc.body.style.overflowX            = 'text/plain' === layer.infoformat ? 'hidden' : 'auto';
+            doc.documentElement.style.overflowY = 'hidden';
+            doc.body.style.overflowY            = 'hidden';
 
             // Calculate absolute bottom position of the lowest child element in <body>
             const bodyRect = doc.body?.getBoundingClientRect?.();
@@ -715,13 +711,8 @@
 
           // watch for dynamic layout changes inside the iframe
           const observer = new ResizeObserver(measure);
-
-          if (doc.documentElement) {
-            observer.observe(doc.documentElement);
-          }
-          if (doc.body) {
-            observer.observe(doc.body);
-          }
+          observer.observe(doc.documentElement);
+          observer.observe(doc.body);
 
           // store the observer instance on the iframe element for future cleanup access
           iframe.__g3wResizeObserver = observer;

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -71,10 +71,11 @@
               <div class="query-layer-actions" style = "display: flex; gap: 2.5px; padding-right: 10px;">
                 <!-- INFO FORMATS -->
                 <select
-                  v-if      = "(layer.infoformats || []).length"
-                  class     = "form-control"
-                  @change   = "changeInfoFormat(layer, $event.target.value)"
-                  :disabled = "layer.loading"
+                  v-if        = "(layer.infoformats || []).length"
+                  class       = "form-control"
+                  @change     = "changeInfoFormat(layer, $event.target.value)"
+                  @click.stop = ""
+                  :disabled   = "layer.loading"
                 >
                   <option
                     v-for     = "format in layer.infoformats"

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -666,11 +666,23 @@
           }
 
           const data = 'text/plain' === layer.infoformat
-            ? `<pre style="margin:0; white-space:pre; overflow-x:auto; overflow-y:hidden;">${String(layer.rawdata || '')
+            ? `<pre style="margin:0; white-space:pre-wrap; overflow-wrap:anywhere; word-break:break-word; overflow-x:hidden; overflow-y:hidden;">${String(layer.rawdata || '')
               .replace(/&/g, '&amp;')
               .replace(/</g, '&lt;')
               .replace(/>/g, '&gt;')}</pre>`
             : (layer.rawdata || '');
+
+          const getElementHeight = el => {
+            if (!el) {
+              return 0;
+            }
+            return Math.max(
+              el.scrollHeight || 0,
+              el.offsetHeight || 0,
+              el.clientHeight || 0,
+              el.getBoundingClientRect?.().height || 0,
+            );
+          };
 
           const measure = () => {
             const _doc = iframe.contentDocument;
@@ -679,26 +691,75 @@
             }
 
             // Keep only horizontal scrollbar inside iframe content.
+            const isTextPlain = 'text/plain' === layer.infoformat;
             if (_doc.documentElement) {
-              _doc.documentElement.style.overflowX = 'auto';
-              _doc.documentElement.style.overflowY = 'hidden'
+              _doc.documentElement.style.overflowX = isTextPlain ? 'hidden' : 'auto';
+              _doc.documentElement.style.overflowY = 'hidden';
             }
             if (_doc.body) {
-            _doc.body.style.overflowX = 'auto';
-            _doc.body.style.overflowY = 'hidden';
+              _doc.body.style.overflowX = isTextPlain ? 'hidden' : 'auto';
+              _doc.body.style.overflowY = 'hidden';
             }
 
-            const height = Math.max(...[
-              _doc.scrollingElement,
-              _doc.documentElement,
-              _doc.body,
-            ].filter(Boolean).map(el => Math.max(
-              el.scrollHeight || 0,
-              el.offsetHeight || 0,
-              el.clientHeight || 0,
-            )));
+            const bodyRect = _doc.body?.getBoundingClientRect?.();
+            const contentBottom = !_doc.body || !bodyRect
+              ? 0
+              : Array.from(_doc.body.children || []).reduce((max, child) => {
+                const rect = child.getBoundingClientRect?.();
+                return Math.max(max, rect ? (rect.bottom - bodyRect.top) : 0);
+              }, 0);
+
+            const height = Math.ceil(Math.max(
+              getElementHeight(_doc.scrollingElement),
+              getElementHeight(_doc.documentElement),
+              getElementHeight(_doc.body),
+              contentBottom,
+            ));
 
             iframe.style.height = `${Math.max(height, 120)}px`;
+          };
+
+          const scheduleMeasure = () => {
+            requestAnimationFrame(measure);
+            setTimeout(measure, 50);
+            setTimeout(measure, 200);
+            setTimeout(measure, 500);
+          };
+
+          const setupAutoMeasure = () => {
+            const _doc = iframe.contentDocument;
+            if (!_doc || 'undefined' === typeof ResizeObserver) {
+              return;
+            }
+
+            iframe.__g3wResizeObserver?.disconnect?.();
+            iframe.__g3wResizeObserverCleanup?.();
+            iframe.__g3wResizeObserverCleanup = null;
+
+            const ro = new ResizeObserver(() => {
+              measure();
+            });
+
+            if (_doc.documentElement) {
+              ro.observe(_doc.documentElement);
+            }
+            if (_doc.body) {
+              ro.observe(_doc.body);
+            }
+
+            iframe.__g3wResizeObserver = ro;
+
+            const onUnload = () => {
+              if (iframe.__g3wResizeObserver === ro) {
+                iframe.__g3wResizeObserver?.disconnect?.();
+                iframe.__g3wResizeObserver = null;
+              }
+            };
+
+            _doc.defaultView?.addEventListener('unload', onUnload, { once: true });
+            iframe.__g3wResizeObserverCleanup = () => {
+              _doc.defaultView?.removeEventListener('unload', onUnload);
+            };
           };
 
           // First load: write iframe content and measure after DOM is rebuilt.
@@ -708,13 +769,18 @@
             doc.write(data);
             doc.close();
 
-            requestAnimationFrame(measure);
-            setTimeout(measure, 50);
-            setTimeout(measure, 200);
+            Array.from(doc.images || []).forEach(img => {
+              img.addEventListener('load', measure, { once: true });
+              img.addEventListener('error', measure, { once: true });
+            });
+
+            setupAutoMeasure();
+            scheduleMeasure();
             return;
           }
 
-          measure();
+          setupAutoMeasure();
+          scheduleMeasure();
         } catch(e) {
           console.warn(e);
         }

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -1069,7 +1069,7 @@
        * @since 4.1.0 
        */
       async changeInfoFormat(layer, contenttype) {
-        layer.loading = true;
+        layer.loading     = true;
         try {
           const catalog_layer = getCatalogLayerById(layer.id);
 
@@ -1087,12 +1087,12 @@
           catalog_layer.setInfoFormat(layer.infoformat);
 
           const [data] = Layer._parse(contenttype, { layers: [catalog_layer], response });
-
           // parse as raw data
           if (!data.features) {
             layer.features.splice(0);
             await this.$nextTick();
-            layer.rawdata = data.rawdata;
+            layer.rawdata     = data.rawdata;
+            layer.hasgeometry = false;
           }
 
           // parse data

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -29,7 +29,6 @@
           <div class = "box box-primary">
             <div
               class           = "box-header with-border"
-              :class          = "{'mobile': isMobile()}"
               @mouseover.stop = "!isMobile() && highlightLayer(layer, { zoom: false, highlight: true, duration: Infinity })"
               @mouseout.stop  = "!isMobile() && highlightLayer(layer, { zoom: false, highlight: false })"
               @click.stop     = "collapseSidebar"
@@ -196,7 +195,6 @@
               v-if   = "state.layeractiontool[layer.id].component"
               class  = "g3w-layer-action-tools with-border"
               style  = "padding: 5px"
-              :class = "{'mobile': isMobile()}"
             >
               <component
                 :is     = "state.layeractiontool[layer.id].component"
@@ -308,7 +306,7 @@
               </ul>
             </div>
 
-            <div class = "box-body" :class = "{'mobile': isMobile()}">
+            <div class = "box-body">
 
               <!-- LAYER WITH RAW DATA -->
               <iframe
@@ -322,7 +320,7 @@
                 @load     = "setRawdataIframeContent($event, layer)"
               ></iframe>
 
-              <table v-else class = "table" :class = "{'mobile': isMobile()}">
+              <table v-else class = "table">
                 <tbody v-for = "(feature, index) in layer.features.filter(f => showFeature(layer, f))" :key = "feature.id">
 
                   <!-- ORIGINAL SOURCE: src/components/QueryResultsHeaderFeatureActionsBody.vue@v4.0.0 -->

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -916,9 +916,11 @@
       },
 
       /**
-       * @since 4.1.1 
-       * @param layer 
-       * @return { boolean } whether can open attribute table for layer
+       * @param layer
+       * 
+       * @returns { boolean } whether can open attribute table for layer
+       * 
+       * @since 4.1.1
        */
       canOpenAttibuteTable(layer) {
         return !layer.external && !getCatalogLayerById(layer.id)?.state?.not_show_attributes_table;
@@ -1248,5 +1250,4 @@
   cursor: not-allowed;
   opacity: 0.5;
 }
-
 </style>

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -311,8 +311,6 @@
               <!-- LAYER WITH RAW DATA -->
               <iframe
                 v-if   = "layer.rawdata"
-                class  = "queryresults-text-html"
-                :class    = "{ text: layer.infoformat === 'text/plain' }"
                 :key      = "`${layer.id}_${layer.infoformat}_${(layer.rawdata || '').length}_${(layer.rawdata || '').charCodeAt(0) || 0}`"
                 style     = "width: 100%; border: none;"
                 sandbox   = "allow-same-origin allow-popups allow-scripts"

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -311,21 +311,16 @@
             <div class = "box-body" :class = "{'mobile': isMobile()}">
 
               <!-- LAYER WITH RAW DATA -->
-              <div
+              <iframe
                 v-if   = "layer.rawdata"
                 class  = "queryresults-text-html"
                 :class = "{ text: layer.infoformat === 'text/plain' }"
-              >
-                <iframe
-                  v-if         = "layer.infoformat === 'text/html'"
-                  :key         = "`${layer.id}_${layer.infoformat}`"
-                  style        = "width: 100%; border: none;"
-                  :srcdoc      = "layer.rawdata"
-                  sandbox      = "allow-same-origin"
-                  @load        = "setRawdataIframeHeight"
-                ></iframe>
-                <div v-else v-html="layer.rawdata"></div>
-              </div>
+                :key         = "`${layer.id}_${layer.infoformat}`"
+                style        = "width: 100%; border: none;"
+                sandbox      = "allow-same-origin"
+                scrolling    = "no"
+                @load        = "setRawdataIframeContent($event, layer.rawdata, layer.infoformat)"
+              ></iframe>
 
               <table v-else class = "table" :class = "{'mobile': isMobile()}">
                 <tbody v-for = "(feature, index) in layer.features.filter(f => showFeature(layer, f))" :key = "feature.id">
@@ -659,26 +654,70 @@
     methods: {
 
       /**
-       * @since 4.1.1
-       * Auto-resize iframe to show full proxy HTML response without internal scrollbars.
+       * @since 4.1.1 - Inject layer data raw data within and <iframe>
        */
-      setRawdataIframeHeight(event) {
+      setRawdataIframeContent(event, rawdata, infoformat) {
         try {
           const iframe = event?.target;
           const doc    = iframe?.contentDocument;
           if (!iframe || !doc) {
             return;
           }
-          const body   = doc.body;
-          const html   = doc.documentElement;
-          const height = Math.max(
-            body?.scrollHeight || 0,
-            body?.offsetHeight || 0,
-            html?.clientHeight || 0,
-            html?.scrollHeight || 0,
-            html?.offsetHeight || 0,
-          );
-          iframe.style.height = `${Math.max(height, 120)}px`;
+
+          const toIframeMarkup = (data, format) => {
+            if ('text/plain' === format) {
+              let text = String(data || '');
+
+              const escaped = text
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;');
+              return `<pre style="margin:0;white-space:pre-wrap;word-break:break-word;font-family:monospace;">${escaped}</pre>`;
+            }
+            return data || '';
+          };
+
+          const markup = toIframeMarkup(rawdata, infoformat);
+
+          const measure = () => {
+            const _doc = iframe.contentDocument;
+            if (!_doc) {
+              return;
+            }
+
+            const elements = [
+              _doc.scrollingElement,
+              _doc.documentElement,
+              _doc.body,
+            ].filter(Boolean);
+
+            if (0 === elements.length) {
+              return;
+            }
+
+            const height = Math.max(...elements.map(el => Math.max(
+              el.scrollHeight || 0,
+              el.offsetHeight || 0,
+              el.clientHeight || 0,
+            )));
+
+            iframe.style.height = `${Math.max(height, 120)}px`;
+          };
+
+          // First load: write iframe content and measure after DOM is rebuilt.
+          if (iframe.__g3wRawdata !== markup) {
+            iframe.__g3wRawdata = markup;
+            doc.open();
+            doc.write(markup);
+            doc.close();
+
+            requestAnimationFrame(measure);
+            setTimeout(measure, 50);
+            setTimeout(measure, 200);
+            return;
+          }
+
+          measure();
         } catch(e) {
           console.warn(e);
         }

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -670,19 +670,8 @@
               .replace(/>/g, '&gt;')}</pre>`
             : (layer.rawdata || '');
 
-          const getElementHeight = el => {
-            if (!el) {
-              return 0;
-            }
-            return Math.max(
-              el.scrollHeight || 0,
-              el.offsetHeight || 0,
-              el.clientHeight || 0,
-              el.getBoundingClientRect?.().height || 0,
-            );
-          };
-
-          const measure = () => {
+          const getHeight = el => Math.max(el?.scrollHeight || 0, el?.offsetHeight || 0, el?.clientHeight || 0, el?.getBoundingClientRect?.().height || 0);
+          const measure   = () => {
             // Keep only horizontal scrollbar inside iframe content.
             if (doc.documentElement) {
               doc.documentElement.style.overflowX = 'text/plain' === layer.infoformat ? 'hidden' : 'auto';
@@ -701,14 +690,7 @@
                 return Math.max(max, rect ? (rect.bottom - bodyRect.top) : 0);
               }, 0);
 
-            const height = Math.ceil(Math.max(
-              getElementHeight(doc.scrollingElement),
-              getElementHeight(doc.documentElement),
-              getElementHeight(doc.body),
-              contentBottom,
-            ));
-
-            iframe.style.height = `${Math.max(height, 120)}px`;
+            iframe.style.height = `${Math.max(120, Math.ceil(Math.max(getHeight(doc.scrollingElement), getHeight(doc.documentElement), getHeight(doc.body), contentBottom )))}px`;
           };
 
           doc.open();

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -48,7 +48,7 @@
               >
                 <!-- OPEN ATTRIBUTE TABLE -->
                 <button
-                  v-if           = "!layer.external"
+                  v-if           = "canOpenAttibuteTable(layer)"
                   type           = "button"
                   @click.stop    = "openAttributeTable(layer)"
                   class          = "action-button"
@@ -878,6 +878,15 @@
        */
        isJSON(field) {
         return !this.isVue(field) && this.isSimple(field) && 'Object' === toRawType(field.value);
+      },
+
+      /**
+       * @since 4.1.1 
+       * @param layer 
+       * @return { boolean } whether can open attribute table for layer
+       */
+      canOpenAttibuteTable(layer) {
+        return !layer.external && !getCatalogLayerById(layer.id)?.state?.not_show_attributes_table;
       },
 
       /**

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -658,12 +658,9 @@
           const doc    = iframe?.contentDocument;
 
           // skip when iframe is not ready
-          if (!iframe || !doc) {
+          if (!doc) {
             return;
           }
-
-          // reset observer
-          iframe.__g3wObserver?.disconnect();
 
           // inject html or text contect (within ifram)
           doc.body.innerHTML = 'text/plain' === layer.infoformat
@@ -676,10 +673,9 @@
           </style>`;
 
           // watch for layout changes (within iframe)
-          iframe.__g3wObserver = new ResizeObserver(([entry]) => {
+          (new ResizeObserver(([entry]) => {
             iframe.style.height = `${Math.max(120, Math.ceil(entry.borderBoxSize?.[0]?.blockSize || entry.contentRect.height))}px`;
-          });
-          iframe.__g3wObserver.observe(doc.documentElement);
+          })).observe(doc.documentElement);
 
         } catch(e) {
           console.warn(e);

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -313,7 +313,7 @@
                 v-if   = "layer.rawdata"
                 :key      = "`${layer.id}_${layer.infoformat}_${(layer.rawdata || '').length}_${(layer.rawdata || '').charCodeAt(0) || 0}`"
                 style     = "width: 100%; border: none;"
-                sandbox   = "allow-same-origin allow-popups allow-scripts"
+                sandbox   = "allow-same-origin"
                 scrolling = "no"
                 @load     = "setRawdataIframeContent($event, layer)"
               ></iframe>
@@ -657,18 +657,23 @@
           const iframe = event?.target;
           const doc    = iframe?.contentDocument;
 
+          // skip when iframe content is not ready
           if (!iframe || !doc) {
             return;
           }
 
+          // plain text or html content
           const data = 'text/plain' === layer.infoformat
-            ? `<pre style="margin:0; white-space:pre-wrap; overflow-wrap:anywhere; word-break:break-word; overflow-x:hidden; overflow-y:hidden;">${String(layer.rawdata || '')
+            ? /* html */`<pre style="margin:0; white-space:pre-wrap; overflow-wrap:anywhere; word-break:break-word; overflow-x:hidden; overflow-y:hidden;">${String(layer.rawdata || '')
               .replace(/&/g, '&amp;')
               .replace(/</g, '&lt;')
               .replace(/>/g, '&gt;')}</pre>`
-            : (layer.rawdata || '');
+            : /* html */`<div style="box-sizing:border-box;width:100%;background:#fff3cd;color:#856404;border:1px solid #ffc107;border-radius:3px;padding:4px 8px;font-size:0.85em;font-family:sans-serif;margin-bottom:6px;">&#9888; ${this.$t('(CSP) scripts and links are disabled in this frame')}</div>` + (layer.rawdata || '');
 
+          // helper function to extract maximum height of an element
           const getHeight = el => Math.max(el?.scrollHeight || 0, el?.offsetHeight || 0, el?.clientHeight || 0, el?.getBoundingClientRect?.().height || 0);
+
+          // recalculate content height and update the iframe dimensions (to avoid vertical scrollbars within iframe)
           const measure   = () => {
             // Keep only horizontal scrollbar inside iframe content.
             if (doc.documentElement) {
@@ -680,6 +685,7 @@
               doc.body.style.overflowY = 'hidden';
             }
 
+            // Calculate absolute bottom position of the lowest child element in <body>
             const bodyRect = doc.body?.getBoundingClientRect?.();
             const contentBottom = !doc.body || !bodyRect
               ? 0
@@ -688,21 +694,26 @@
                 return Math.max(max, rect ? (rect.bottom - bodyRect.top) : 0);
               }, 0);
 
+            // Set iframe height matching the largest measured element (min: 120px)
             iframe.style.height = `${Math.max(120, Math.ceil(Math.max(getHeight(doc.scrollingElement), getHeight(doc.documentElement), getHeight(doc.body), contentBottom )))}px`;
           };
 
+          // inject HTML data within iframe 
           doc.open();
           doc.write(data);
           doc.close();
 
+          // adjust iframe size when images are loaded.
           Array.from(doc.images || []).forEach(img => {
             img.addEventListener('load', measure, { once: true });
             img.addEventListener('error', measure, { once: true });
           });
 
+          // prevent memory leaks by cleaning up any pre-existing observer
           iframe.__g3wResizeObserver?.disconnect?.();
           iframe.__g3wResizeObserverCleanup?.();
 
+          // watch for dynamic layout changes inside the iframe
           const observer = new ResizeObserver(measure);
 
           if (doc.documentElement) {
@@ -712,8 +723,10 @@
             observer.observe(doc.body);
           }
 
+          // store the observer instance on the iframe element for future cleanup access
           iframe.__g3wResizeObserver = observer;
 
+          // disconnect observer when the iframe document unloads to free up system memory
           const onUnload = () => {
             iframe.__g3wResizeObserver?.disconnect?.();
             iframe.__g3wResizeObserver = null;
@@ -722,10 +735,8 @@
           doc.defaultView?.addEventListener('unload', onUnload, { once: true });
           iframe.__g3wResizeObserverCleanup = () => { doc.defaultView?.removeEventListener('unload', onUnload); };
 
-          requestAnimationFrame(measure);
-          setTimeout(measure, 50);
-          setTimeout(measure, 200);
-          setTimeout(measure, 500);
+          // execute an immediate initial height measurement on the next Vue lifecycle tick
+          this.$nextTick().then(measure) ;
         } catch(e) {
           console.warn(e);
         }

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -127,7 +127,7 @@
 
                 <!-- TOGGLE LAYER FEATURES -->
                 <button
-                  v-if           = "layer.external || (!layer.filter.active && layer.source && 'wms' !== layer.source.type && !(state.query && state.query.pagination))"
+                  v-if           = "layer.external || (!layer.filter.active && layer.source && !['wms', 'arcgismapserver'].includes(layer.source.type) && !(state.query && state.query.pagination))"
                   type           = "button"
                   @click.stop    = "addLayerFeaturesToResults(layer)"
                   class          = "action-button"

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -314,12 +314,12 @@
               <iframe
                 v-if   = "layer.rawdata"
                 class  = "queryresults-text-html"
-                :class = "{ text: layer.infoformat === 'text/plain' }"
-                :key         = "`${layer.id}_${layer.infoformat}`"
+                :class    = "{ text: layer.infoformat === 'text/plain' }"
+                :key         = "`${layer.id}_${layer.infoformat}_${(layer.rawdata || '').length}_${(layer.rawdata || '').charCodeAt(0) || 0}`"
                 style        = "width: 100%; border: none;"
-                sandbox      = "allow-same-origin"
-                scrolling    = "no"
-                @load        = "setRawdataIframeContent($event, layer.rawdata, layer.infoformat)"
+                sandbox   = "allow-same-origin"
+                scrolling = "no"
+                @load     = "setRawdataIframeContent($event, layer)"
               ></iframe>
 
               <table v-else class = "table" :class = "{'mobile': isMobile()}">
@@ -656,28 +656,21 @@
       /**
        * @since 4.1.1 - Inject layer data raw data within and <iframe>
        */
-      setRawdataIframeContent(event, rawdata, infoformat) {
+      setRawdataIframeContent(event, layer) {
         try {
           const iframe = event?.target;
           const doc    = iframe?.contentDocument;
+
           if (!iframe || !doc) {
             return;
           }
 
-          const toIframeMarkup = (data, format) => {
-            if ('text/plain' === format) {
-              let text = String(data || '');
-
-              const escaped = text
-                .replace(/&/g, '&amp;')
-                .replace(/</g, '&lt;')
-                .replace(/>/g, '&gt;');
-              return `<pre style="margin:0;white-space:pre-wrap;word-break:break-word;font-family:monospace;">${escaped}</pre>`;
-            }
-            return data || '';
-          };
-
-          const markup = toIframeMarkup(rawdata, infoformat);
+          const data = 'text/plain' === layer.infoformat
+            ? `<pre style="margin:0; white-space:pre; overflow-x:auto; overflow-y:hidden;">${String(layer.rawdata || '')
+              .replace(/&/g, '&amp;')
+              .replace(/</g, '&lt;')
+              .replace(/>/g, '&gt;')}</pre>`
+            : (layer.rawdata || '');
 
           const measure = () => {
             const _doc = iframe.contentDocument;
@@ -685,17 +678,21 @@
               return;
             }
 
-            const elements = [
+            // Keep only horizontal scrollbar inside iframe content.
+            if (_doc.documentElement) {
+              _doc.documentElement.style.overflowX = 'auto';
+              _doc.documentElement.style.overflowY = 'hidden'
+            }
+            if (_doc.body) {
+            _doc.body.style.overflowX = 'auto';
+            _doc.body.style.overflowY = 'hidden';
+            }
+
+            const height = Math.max(...[
               _doc.scrollingElement,
               _doc.documentElement,
               _doc.body,
-            ].filter(Boolean);
-
-            if (0 === elements.length) {
-              return;
-            }
-
-            const height = Math.max(...elements.map(el => Math.max(
+            ].filter(Boolean).map(el => Math.max(
               el.scrollHeight || 0,
               el.offsetHeight || 0,
               el.clientHeight || 0,
@@ -705,10 +702,10 @@
           };
 
           // First load: write iframe content and measure after DOM is rebuilt.
-          if (iframe.__g3wRawdata !== markup) {
-            iframe.__g3wRawdata = markup;
+          if (iframe.__g3wRawdata !== data) {
+            iframe.__g3wRawdata = data;
             doc.open();
-            doc.write(markup);
+            doc.write(data);
             doc.close();
 
             requestAnimationFrame(measure);

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -1145,7 +1145,7 @@
               if (0 === layer.attributes.length) {
                 layer.hasgeometry = !!feature.geometry;
                 GUI.setActionsForLayers([layer]);
-                getAlphanumericProps(feature.attributes).forEach(name => layer.attributes.push({ name, label: name, show: true }));
+                getAlphanumericProps(feature.attributes).forEach(name => layer.attributes.push({ name, label: name, show: true, type: 'varchar' }));
               }
               layer.features.push(feature);
             });

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -683,102 +683,69 @@
           };
 
           const measure = () => {
-            const _doc = iframe.contentDocument;
-            if (!_doc) {
-              return;
-            }
-
             // Keep only horizontal scrollbar inside iframe content.
-            const isTextPlain = 'text/plain' === layer.infoformat;
-            if (_doc.documentElement) {
-              _doc.documentElement.style.overflowX = isTextPlain ? 'hidden' : 'auto';
-              _doc.documentElement.style.overflowY = 'hidden';
+            if (doc.documentElement) {
+              doc.documentElement.style.overflowX = 'text/plain' === layer.infoformat ? 'hidden' : 'auto';
+              doc.documentElement.style.overflowY = 'hidden';
             }
-            if (_doc.body) {
-              _doc.body.style.overflowX = isTextPlain ? 'hidden' : 'auto';
-              _doc.body.style.overflowY = 'hidden';
+            if (doc.body) {
+              doc.body.style.overflowX = 'text/plain' === layer.infoformat ? 'hidden' : 'auto';
+              doc.body.style.overflowY = 'hidden';
             }
 
-            const bodyRect = _doc.body?.getBoundingClientRect?.();
-            const contentBottom = !_doc.body || !bodyRect
+            const bodyRect = doc.body?.getBoundingClientRect?.();
+            const contentBottom = !doc.body || !bodyRect
               ? 0
-              : Array.from(_doc.body.children || []).reduce((max, child) => {
+              : Array.from(doc.body.children || []).reduce((max, child) => {
                 const rect = child.getBoundingClientRect?.();
                 return Math.max(max, rect ? (rect.bottom - bodyRect.top) : 0);
               }, 0);
 
             const height = Math.ceil(Math.max(
-              getElementHeight(_doc.scrollingElement),
-              getElementHeight(_doc.documentElement),
-              getElementHeight(_doc.body),
+              getElementHeight(doc.scrollingElement),
+              getElementHeight(doc.documentElement),
+              getElementHeight(doc.body),
               contentBottom,
             ));
 
             iframe.style.height = `${Math.max(height, 120)}px`;
           };
 
-          const scheduleMeasure = () => {
-            requestAnimationFrame(measure);
-            setTimeout(measure, 50);
-            setTimeout(measure, 200);
-            setTimeout(measure, 500);
-          };
+          doc.open();
+          doc.write(data);
+          doc.close();
 
-          const setupAutoMeasure = () => {
-            const _doc = iframe.contentDocument;
-            if (!_doc || 'undefined' === typeof ResizeObserver) {
-              return;
-            }
+          Array.from(doc.images || []).forEach(img => {
+            img.addEventListener('load', measure, { once: true });
+            img.addEventListener('error', measure, { once: true });
+          });
 
-            iframe.__g3wResizeObserver?.disconnect?.();
-            iframe.__g3wResizeObserverCleanup?.();
-            iframe.__g3wResizeObserverCleanup = null;
+          iframe.__g3wResizeObserver?.disconnect?.();
+          iframe.__g3wResizeObserverCleanup?.();
 
-            const ro = new ResizeObserver(() => {
-              measure();
-            });
+          const observer = new ResizeObserver(measure);
 
-            if (_doc.documentElement) {
-              ro.observe(_doc.documentElement);
-            }
-            if (_doc.body) {
-              ro.observe(_doc.body);
-            }
-
-            iframe.__g3wResizeObserver = ro;
-
-            const onUnload = () => {
-              if (iframe.__g3wResizeObserver === ro) {
-                iframe.__g3wResizeObserver?.disconnect?.();
-                iframe.__g3wResizeObserver = null;
-              }
-            };
-
-            _doc.defaultView?.addEventListener('unload', onUnload, { once: true });
-            iframe.__g3wResizeObserverCleanup = () => {
-              _doc.defaultView?.removeEventListener('unload', onUnload);
-            };
-          };
-
-          // First load: write iframe content and measure after DOM is rebuilt.
-          if (iframe.__g3wRawdata !== data) {
-            iframe.__g3wRawdata = data;
-            doc.open();
-            doc.write(data);
-            doc.close();
-
-            Array.from(doc.images || []).forEach(img => {
-              img.addEventListener('load', measure, { once: true });
-              img.addEventListener('error', measure, { once: true });
-            });
-
-            setupAutoMeasure();
-            scheduleMeasure();
-            return;
+          if (doc.documentElement) {
+            observer.observe(doc.documentElement);
+          }
+          if (doc.body) {
+            observer.observe(doc.body);
           }
 
-          setupAutoMeasure();
-          scheduleMeasure();
+          iframe.__g3wResizeObserver = observer;
+
+          const onUnload = () => {
+            iframe.__g3wResizeObserver?.disconnect?.();
+            iframe.__g3wResizeObserver = null;
+          };
+
+          doc.defaultView?.addEventListener('unload', onUnload, { once: true });
+          iframe.__g3wResizeObserverCleanup = () => { doc.defaultView?.removeEventListener('unload', onUnload); };
+
+          requestAnimationFrame(measure);
+          setTimeout(measure, 50);
+          setTimeout(measure, 200);
+          setTimeout(measure, 500);
         } catch(e) {
           console.warn(e);
         }

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -662,10 +662,23 @@
             return;
           }
 
-          // inject html or text contect (within ifram)
+          // inject html or text contect (within iframe)
           doc.body.innerHTML = 'text/plain' === layer.infoformat
             ? /* html */`<pre style="margin:0; white-space:pre-wrap; overflow-wrap:anywhere; word-break:break-word; overflow:hidden hidden;">${String(layer.rawdata || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre>`
-            : /* html */`<div style="box-sizing:border-box;width:100%;background:#fff3cd;color:#856404;border:1px solid #ffc107;border-radius:3px;padding:4px 8px;font-size:0.85em;font-family:sans-serif;margin-bottom:6px;">⚠ ${this.$t('(CSP) scripts and links are disabled in this frame')}</div>` + (layer.rawdata || '');
+            : (layer.rawdata || '');
+
+          // intercept click on links (within iframe)
+          doc.body.addEventListener('click', async e => {
+            const anchor = e.target.closest('a');
+            if (anchor) {
+              e.preventDefault();
+              const url = anchor.getAttribute('href');
+              const ok = await GUI.confirm(`<h4>🚨 ${this.$t('Open external link?')}</h4><p>${url}</p>`);
+              if (ok) {
+                window.open(url, '_blank', 'noopener,noreferrer');
+              }
+            }
+          });
 
           // html content → keep horizontal scrollbar
           doc.head.innerHTML = /* html */`<style>

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -657,77 +657,30 @@
           const iframe = event?.target;
           const doc    = iframe?.contentDocument;
 
-          // skip when iframe content is not ready
+          // skip when iframe is not ready
           if (!iframe || !doc) {
             return;
           }
 
-          // plain text or html content
-          const data = 'text/plain' === layer.infoformat
-            ? /* html */`<pre style="margin:0; white-space:pre-wrap; overflow-wrap:anywhere; word-break:break-word; overflow-x:hidden; overflow-y:hidden;">${String(layer.rawdata || '')
-              .replace(/&/g, '&amp;')
-              .replace(/</g, '&lt;')
-              .replace(/>/g, '&gt;')}</pre>`
-            : /* html */`<div style="box-sizing:border-box;width:100%;background:#fff3cd;color:#856404;border:1px solid #ffc107;border-radius:3px;padding:4px 8px;font-size:0.85em;font-family:sans-serif;margin-bottom:6px;">&#9888; ${this.$t('(CSP) scripts and links are disabled in this frame')}</div>` + (layer.rawdata || '');
+          // reset observer
+          iframe.__g3wObserver?.disconnect();
 
-          // helper function to extract maximum height of an element
-          const getHeight = el => Math.max(el?.scrollHeight || 0, el?.offsetHeight || 0, el?.clientHeight || 0, el?.getBoundingClientRect?.().height || 0);
+          // inject html or text contect (within ifram)
+          doc.body.innerHTML = 'text/plain' === layer.infoformat
+            ? /* html */`<pre style="margin:0; white-space:pre-wrap; overflow-wrap:anywhere; word-break:break-word; overflow:hidden hidden;">${String(layer.rawdata || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre>`
+            : /* html */`<div style="box-sizing:border-box;width:100%;background:#fff3cd;color:#856404;border:1px solid #ffc107;border-radius:3px;padding:4px 8px;font-size:0.85em;font-family:sans-serif;margin-bottom:6px;">⚠ ${this.$t('(CSP) scripts and links are disabled in this frame')}</div>` + (layer.rawdata || '');
 
-          // recalculate content height and update the iframe dimensions (to avoid vertical scrollbars within iframe)
-          const measure   = () => {
-            // Keep only horizontal scrollbar inside iframe content.
-            doc.documentElement.style.overflowX = 'text/plain' === layer.infoformat ? 'hidden' : 'auto';
-            doc.body.style.overflowX            = 'text/plain' === layer.infoformat ? 'hidden' : 'auto';
-            doc.documentElement.style.overflowY = 'hidden';
-            doc.body.style.overflowY            = 'hidden';
+          // html content → keep horizontal scrollbar
+          doc.head.innerHTML = /* html */`<style>
+            html, body { overflow: ${'text/plain' === layer.infoformat ? 'hidden' : 'auto'} hidden; margin: 0; }
+          </style>`;
 
-            // Calculate absolute bottom position of the lowest child element in <body>
-            const bodyRect = doc.body?.getBoundingClientRect?.();
-            const contentBottom = !doc.body || !bodyRect
-              ? 0
-              : Array.from(doc.body.children || []).reduce((max, child) => {
-                const rect = child.getBoundingClientRect?.();
-                return Math.max(max, rect ? (rect.bottom - bodyRect.top) : 0);
-              }, 0);
-
-            // Set iframe height matching the largest measured element (min: 120px)
-            iframe.style.height = `${Math.max(120, Math.ceil(Math.max(getHeight(doc.scrollingElement), getHeight(doc.documentElement), getHeight(doc.body), contentBottom )))}px`;
-          };
-
-          // inject HTML data within iframe 
-          doc.open();
-          doc.write(data);
-          doc.close();
-
-          // adjust iframe size when images are loaded.
-          Array.from(doc.images || []).forEach(img => {
-            img.addEventListener('load', measure, { once: true });
-            img.addEventListener('error', measure, { once: true });
+          // watch for layout changes (within iframe)
+          iframe.__g3wObserver = new ResizeObserver(([entry]) => {
+            iframe.style.height = `${Math.max(120, Math.ceil(entry.borderBoxSize?.[0]?.blockSize || entry.contentRect.height))}px`;
           });
+          iframe.__g3wObserver.observe(doc.documentElement);
 
-          // prevent memory leaks by cleaning up any pre-existing observer
-          iframe.__g3wResizeObserver?.disconnect?.();
-          iframe.__g3wResizeObserverCleanup?.();
-
-          // watch for dynamic layout changes inside the iframe
-          const observer = new ResizeObserver(measure);
-          observer.observe(doc.documentElement);
-          observer.observe(doc.body);
-
-          // store the observer instance on the iframe element for future cleanup access
-          iframe.__g3wResizeObserver = observer;
-
-          // disconnect observer when the iframe document unloads to free up system memory
-          const onUnload = () => {
-            iframe.__g3wResizeObserver?.disconnect?.();
-            iframe.__g3wResizeObserver = null;
-          };
-
-          doc.defaultView?.addEventListener('unload', onUnload, { once: true });
-          iframe.__g3wResizeObserverCleanup = () => { doc.defaultView?.removeEventListener('unload', onUnload); };
-
-          // execute an immediate initial height measurement on the next Vue lifecycle tick
-          this.$nextTick().then(measure) ;
         } catch(e) {
           console.warn(e);
         }

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -314,8 +314,17 @@
                 v-if   = "layer.rawdata"
                 class  = "queryresults-text-html"
                 :class = "{ text: layer.infoformat === 'text/plain' }"
-                v-html = "layer.rawdata"
-              ></div>
+              >
+                <iframe
+                  v-if         = "layer.infoformat === 'text/html'"
+                  :key         = "`${layer.id}_${layer.infoformat}`"
+                  style        = "width: 100%; border: none;"
+                  :srcdoc      = "layer.rawdata"
+                  sandbox      = "allow-same-origin"
+                  @load        = "setRawdataIframeHeight"
+                ></iframe>
+                <div v-else v-html="layer.rawdata"></div>
+              </div>
 
               <table v-else class = "table" :class = "{'mobile': isMobile()}">
                 <tbody v-for = "(feature, index) in layer.features.filter(f => showFeature(layer, f))" :key = "feature.id">
@@ -647,6 +656,32 @@
     },
 
     methods: {
+
+      /**
+       * @since 4.1.1
+       * Auto-resize iframe to show full proxy HTML response without internal scrollbars.
+       */
+      setRawdataIframeHeight(event) {
+        try {
+          const iframe = event?.target;
+          const doc    = iframe?.contentDocument;
+          if (!iframe || !doc) {
+            return;
+          }
+          const body   = doc.body;
+          const html   = doc.documentElement;
+          const height = Math.max(
+            body?.scrollHeight || 0,
+            body?.offsetHeight || 0,
+            html?.clientHeight || 0,
+            html?.scrollHeight || 0,
+            html?.offsetHeight || 0,
+          );
+          iframe.style.height = `${Math.max(height, 120)}px`;
+        } catch(e) {
+          console.warn(e);
+        }
+      },
 
       /**
        * @returns { boolean } whether can paginate layer results
@@ -1213,4 +1248,5 @@
   cursor: not-allowed;
   opacity: 0.5;
 }
+
 </style>

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -2226,8 +2226,8 @@ export default new (class GUI extends Emitter {
           } : undefined,
           relationsattributes:       (is_layer || is_vector || is_string)                       ? []                     : undefined,
           hasdownloadablerelations:  !external && layer.hasDowloadableRelations(), //@since 3.11.7
-          filter:                    (is_layer && !['wms', 'wcs', 'wmst'].includes(sourceType)) ? layer.state.filter     : {},
-          selection:                 (is_layer && !['wms', 'wcs', 'wmst'].includes(sourceType) && layer.state.selection) || (is_vector && layer.selection) || { active: undefined },
+          filter:                    (is_layer && !['wms', 'wcs', 'wmst', 'arcgismapserver'].includes(sourceType)) ? layer.state.filter     : {},
+          selection:                 (is_layer && !['wms', 'wcs', 'wmst', 'arcgismapserver'].includes(sourceType) && layer.state.selection) || (is_vector && layer.selection) || { active: undefined },
           title:                     (is_layer && layer.getTitle()) || (is_vector && layer.get('name')) || (is_string && name && (name.length > 4 ? name.slice(0, name.length - 4).join(' ') : layer)) || undefined,
           atlas:                     this.#atlas.filter(a => a.atlas.qgs_layer_id === id),
           rawdata:                   rawdata  || null,
@@ -2541,7 +2541,7 @@ export default new (class GUI extends Emitter {
         },
 
         // remove feature
-        ('__g3w_marker' === layer.id || (!layer.external && 'wms' !== (layer.source || {}).type)) && {
+        ('__g3w_marker' === layer.id || (!layer.external && !['wms', 'arcgismapserver'].includes((layer.source || {}).type))) && {
           id:        'removefeaturefromresult',
           mouseover: true,
           class:     "fas fa-minus-square",
@@ -2591,7 +2591,7 @@ export default new (class GUI extends Emitter {
         },
 
         // permalink (click to copy)
-        (layer.hasgeometry && !layer.external && 'wms' !== (layer.source || {}).type) && {
+        (layer.hasgeometry && !layer.external && !['wms', 'arcgismapserver'].includes((layer.source || {}).type)) && {
           id:          'link_zoom_to_fid',
           class:       "fa fa-share-alt",
           hint:        'Share via link',

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -9,7 +9,11 @@
  * @since 4.1.0
  */
 
-import { G3W_FID, QUERY_POINT_TOLERANCE }       from 'g3w-constants';
+import { 
+  G3W_FID,
+  QUERY_POINT_TOLERANCE,
+  GEOMETRY_FIELDS 
+}                                               from 'g3w-constants';
 import Emitter                                  from 'g3w-emitter';
 import Component                                from 'g3w-component';
 import Panel                                    from 'g3w-panel';
@@ -2132,7 +2136,12 @@ export default new (class GUI extends Emitter {
     
         // Sanitize OWS Layer attributes
         if (!attributes && layer instanceof g3w.Layer) {
-          layerAttrs = layer.getAttributes().map(attr => 'ows' === this.state.type ? ({ ...attr, name: attr.name.replace(/ /g, '_') }) : attr);
+          layerAttrs = (
+            layer.getAttributes().length 
+              ? layer.getAttributes()
+              : Object.entries(features?.[0].getProperties() ?? {}) //No fields set by server on layer https://github.com/g3w-suite/g3w-client/issues/936
+                  .map(([key, value]) => ({ name: key, value, label: key, show: !GEOMETRY_FIELDS.concat(G3W_FID).includes(key) }))
+          ).map(attr => 'ows' === this.state.type ? ({ ...attr, name: attr.name.replace(/ /g, '_') }) : attr);
         }
     
         if (!attributes && layer instanceof ol.layer.Vector) {
@@ -2219,9 +2228,11 @@ export default new (class GUI extends Emitter {
           downloads:              is_layer   ? layer.getDownloadFormats()                          : [],
           formStructure:          structure  ? {
             structure,
-            // get field show
-            fields: layer.getFields().filter(f => f.show).concat(
-              (Array.isArray(features) && !rawdata && features.length > 0 && attributes || []).filter(attr => layer.getFields().some(f => f.name === attr.name))
+            // get field show. 
+            fields: (
+              layer.getFields().length //set fields from server
+                ? layer.getFields().filter(f => f.show).concat((Array.isArray(features) && !rawdata && features.length > 0 && attributes || []).filter(attr => layer.getFields().some(f => f.name === attr.name))
+              ) : (Array.isArray(features) && !rawdata && features.length > 0 && attributes || []) //no fields set by server https://github.com/g3w-suite/g3w-client/issues/936
             ),
           } : undefined,
           relationsattributes:       (is_layer || is_vector || is_string)                       ? []                     : undefined,
@@ -2255,6 +2266,7 @@ export default new (class GUI extends Emitter {
 
     this.setActionsForLayers(layers, { add: options.add, update: options.update });
     this.state.changed = true;
+
 
     // used by the following plugins: "bforest"
     this.emit('onafter:setLayersData', layers, options);

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -4808,6 +4808,7 @@ export default new (class GUI extends Emitter {
           } else if (undefined !== this.#layers.index[`qtimeseries_${id}`]) {
             id = `${id}_${this.#layers.index[`qtimeseries_${id}`] + 1}`;
           }
+          // if layer has the same "multilayerid" means that is part of a multilayer, so need to be grouped in a single map layer
           const mapLayer = this.#layers.index[id] || new g3w.Layer(l);
           mapLayer.addLayer(l, 'start');
           // listen change filter token

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -9,11 +9,7 @@
  * @since 4.1.0
  */
 
-import { 
-  G3W_FID,
-  QUERY_POINT_TOLERANCE,
-  GEOMETRY_FIELDS 
-}                                               from 'g3w-constants';
+import { G3W_FID, QUERY_POINT_TOLERANCE }       from 'g3w-constants';
 import Emitter                                  from 'g3w-emitter';
 import Component                                from 'g3w-component';
 import Panel                                    from 'g3w-panel';
@@ -2136,12 +2132,7 @@ export default new (class GUI extends Emitter {
     
         // Sanitize OWS Layer attributes
         if (!attributes && layer instanceof g3w.Layer) {
-          layerAttrs = (
-            layer.getFields()?.length 
-              ? layer.getFields()
-              : Object.entries(features?.[0].getProperties() ?? {}) //No fields set by server on layer https://github.com/g3w-suite/g3w-client/issues/936
-                  .map(([key, value]) => ({ name: key, value, label: key, show: !GEOMETRY_FIELDS.concat(G3W_FID).includes(key) }))
-          ).map(attr => 'ows' === this.state.type ? ({ ...attr, name: attr.name.replace(/ /g, '_') }) : attr);
+          layerAttrs = layer.getAttributes().map(attr => 'ows' === this.state.type ? ({ ...attr, name: attr.name.replace(/ /g, '_') }) : attr);
         }
     
         if (!attributes && layer instanceof ol.layer.Vector) {
@@ -2230,7 +2221,7 @@ export default new (class GUI extends Emitter {
             structure,
             // get field show. 
             fields: (
-              layer.getFields()?.length //set fields from server
+              layer.getFields().length //set fields from server
                 ? layer.getFields().filter(f => f.show).concat((Array.isArray(features) && !rawdata && features.length > 0 && attributes || []).filter(attr => layer.getFields().some(f => f.name === attr.name))
               ) : (Array.isArray(features) && !rawdata && features.length > 0 && attributes || []) //no fields set by server https://github.com/g3w-suite/g3w-client/issues/936
             ),
@@ -2266,7 +2257,6 @@ export default new (class GUI extends Emitter {
 
     this.setActionsForLayers(layers, { add: options.add, update: options.update });
     this.state.changed = true;
-
 
     // used by the following plugins: "bforest"
     this.emit('onafter:setLayersData', layers, options);

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -2178,7 +2178,7 @@ export default new (class GUI extends Emitter {
             : attrs.map(featureAttr => ({
               name:  featureAttr,
               label: featureAttr,
-              show:  G3W_FID !== featureAttr && [undefined, 'gdal', 'wms', 'wcs', 'wmst', 'postgresraster'].includes(sourceType),
+              show:  G3W_FID !== featureAttr && [undefined, 'gdal', 'wms', 'wcs', 'wmst', 'postgresraster', 'arcgismapserver'].includes(sourceType),
               type:  'varchar'
             }));
         }
@@ -2219,11 +2219,9 @@ export default new (class GUI extends Emitter {
           downloads:              is_layer   ? layer.getDownloadFormats()                          : [],
           formStructure:          structure  ? {
             structure,
-            // get field show. 
-            fields: (
-              layer.getFields().length //set fields from server
-                ? layer.getFields().filter(f => f.show).concat((Array.isArray(features) && !rawdata && features.length > 0 && attributes || []).filter(attr => layer.getFields().some(f => f.name === attr.name))
-              ) : (Array.isArray(features) && !rawdata && features.length > 0 && attributes || []) //no fields set by server https://github.com/g3w-suite/g3w-client/issues/936
+            // get field show
+            fields: layer.getFields().filter(f => f.show).concat(
+              (Array.isArray(features) && !rawdata && features.length > 0 && attributes || []).filter(attr => layer.getFields().some(f => f.name === attr.name))
             ),
           } : undefined,
           relationsattributes:       (is_layer || is_vector || is_string)                       ? []                     : undefined,

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -2821,7 +2821,7 @@ export default new (class GUI extends Emitter {
 
     layer.addfeaturesresults.active = !layer.addfeaturesresults.active;
 
-    //@since 4.1.1 disable context menu on map when interaction to add feature is active
+    // disable map context menu when add feature interaction is active
     this.getMap().set('can_show_context_menu', !layer.addfeaturesresults.active);
 
     if (false === layer.addfeaturesresults.active) {
@@ -4807,7 +4807,6 @@ export default new (class GUI extends Emitter {
           } else if (undefined !== this.#layers.index[`qtimeseries_${id}`]) {
             id = `${id}_${this.#layers.index[`qtimeseries_${id}`] + 1}`;
           }
-          // if layer has the same "multilayerid" means that is part of a multilayer, so need to be grouped in a single map layer
           const mapLayer = this.#layers.index[id] || new g3w.Layer(l);
           mapLayer.addLayer(l, 'start');
           // listen change filter token

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -2822,6 +2822,9 @@ export default new (class GUI extends Emitter {
 
     layer.addfeaturesresults.active = !layer.addfeaturesresults.active;
 
+    //@since 4.1.1 disable context menu on map when interaction to add feature is active
+    this.getMap().set('can_show_context_menu', !layer.addfeaturesresults.active);
+
     if (false === layer.addfeaturesresults.active) {
       this.removeAddFeaturesLayerResultInteraction(true);
     } else {

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -859,8 +859,7 @@ export default new (class GUI extends Emitter {
       }
 
       // check if data can be shown on query result content
-      if (last && show) {
-        this.#clearState();
+      if (last && show && !output.add) {
         this.setContent({
           content:    new Component({
             id:                 'queryresults',
@@ -872,6 +871,9 @@ export default new (class GUI extends Emitter {
           post_title: output.title || '',
           perc:       isMobile.any ? 100 : undefined,
         });
+      }
+
+      if (last && show) {
         this.setQueryResponse(data, { add: !!output.add });
       }
 

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -2137,7 +2137,7 @@ export default new (class GUI extends Emitter {
         // Sanitize OWS Layer attributes
         if (!attributes && layer instanceof g3w.Layer) {
           layerAttrs = (
-            layer.getAttributes().length 
+            layer.getAttributes()?.length 
               ? layer.getAttributes()
               : Object.entries(features?.[0].getProperties() ?? {}) //No fields set by server on layer https://github.com/g3w-suite/g3w-client/issues/936
                   .map(([key, value]) => ({ name: key, value, label: key, show: !GEOMETRY_FIELDS.concat(G3W_FID).includes(key) }))
@@ -2230,7 +2230,7 @@ export default new (class GUI extends Emitter {
             structure,
             // get field show. 
             fields: (
-              layer.getFields().length //set fields from server
+              layer.getFields()?.length //set fields from server
                 ? layer.getFields().filter(f => f.show).concat((Array.isArray(features) && !rawdata && features.length > 0 && attributes || []).filter(attr => layer.getFields().some(f => f.name === attr.name))
               ) : (Array.isArray(features) && !rawdata && features.length > 0 && attributes || []) //no fields set by server https://github.com/g3w-suite/g3w-client/issues/936
             ),

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -2137,8 +2137,8 @@ export default new (class GUI extends Emitter {
         // Sanitize OWS Layer attributes
         if (!attributes && layer instanceof g3w.Layer) {
           layerAttrs = (
-            layer.getAttributes()?.length 
-              ? layer.getAttributes()
+            layer.getFields()?.length 
+              ? layer.getFields()
               : Object.entries(features?.[0].getProperties() ?? {}) //No fields set by server on layer https://github.com/g3w-suite/g3w-client/issues/936
                   .map(([key, value]) => ({ name: key, value, label: key, show: !GEOMETRY_FIELDS.concat(G3W_FID).includes(key) }))
           ).map(attr => 'ows' === this.state.type ? ({ ...attr, name: attr.name.replace(/ /g, '_') }) : attr);

--- a/src/g3w-layer.js
+++ b/src/g3w-layer.js
@@ -3752,47 +3752,41 @@ Layer._parse = function(type, params, opts) {
      * 
      * @since 4.1.1
      */
-    'esri/json'({ response = { results: [], error: undefined }, projections, layers } = {}) {
-      const layersFeatures = layers.map(layer => ({ layer, features: [] }));
-      const layersId       = layers.map(l => l.getWMSLayerName());
+    'esri/json'({ response = {}, projections, layers } = {}) {
+      const layersId = layers.map(l => l.getWMSLayerName());
       // handle server errors
       if (response.error) {
         GUI.showUserMessage({
           type:        'warning',
           textMessage: true,
           message:     `${layersId.join(',')}: ${response.error.message}`
-        })
+        });
       }
-      //handle features
-      (
-        response?.results
-          ? response.results.map((r) => (new ol.format.EsriJSON({
-              geometryName:          'geometry',
-              defaultDataProjection: projections.layer || projections.map,
-            })).readFeature(r)) 
-          : []
-      ).filter(feature => {
-        const featureId = feature.getId();
-        const g3w_fid   = sanitizeFidFeature(featureId);
-        // in the case of wms getfeature without a filter return string contain layerName or layerid
-        const index = featureId == g3w_fid ? 0 : layersId.indexOf(featureId);
-        // skip when ..
-        if (-1 === index) {
-          return false;
-        }
-        const props = feature.getProperties();
-        feature.set(G3W_FID, g3w_fid);
-        // fields
-        layersFeatures[index]
-          .layer
-          .getFields()
-          .filter(f => f.show && undefined === props[f.name] && undefined !== props[f.label])
-          .forEach(f => feature.set(f.name, props[f.label]));
-        // features
-        layersFeatures[index].features.push(feature);
+      // JSON parser
+      const esriFormat = new ol.format.EsriJSON({
+        geometryName: 'geometry',
+        defaultDataProjection: projections.layer || projections.map
       });
-      return layersFeatures;
-
+      // features by layer
+      return (response.results || [])
+        .map(r => esriFormat.readFeature(r))
+        .reduce((acc, feature) => {
+          const g3w_fid = sanitizeFidFeature(feature.getId());
+          const index = feature.getId() === g3w_fid ? 0 : layersId.indexOf(feature.getId());
+          // layer exists
+          if (index !== -1) {
+            feature.set(G3W_FID, g3w_fid);
+            const props = feature.getProperties();
+            // set fields
+            layers[index]
+              .getFields()
+              .filter(f => f.show && props[f.name] === undefined && props[f.label] !== undefined)
+              .forEach(f => feature.set(f.name, props[f.label]));
+            // insert feature into appropriate layer array
+            acc[index].features.push(feature);
+          }
+          return acc;
+        }, layers.map(layer => ({ layer, features: [] })));
     }
   });
 

--- a/src/g3w-layer.js
+++ b/src/g3w-layer.js
@@ -3774,7 +3774,7 @@ Layer._parse = function(type, params, opts) {
           const g3w_fid = sanitizeFidFeature(feature.getId());
           const index = feature.getId() === g3w_fid ? 0 : layersId.indexOf(feature.getId());
           // layer exists
-          if (index !== -1) {
+          if (-1 !== index) {
             feature.set(G3W_FID, g3w_fid);
             const props = feature.getProperties();
             // set fields

--- a/src/g3w-layer.js
+++ b/src/g3w-layer.js
@@ -2037,7 +2037,7 @@ export class Layer extends Emitter {
    */
   async #queryArcGIS(opts = {}) {
      const {
-      layer         = this,
+      layers         = [this],
       size          = [101, 101],
       coordinates   = [],
       resolution,
@@ -2054,21 +2054,21 @@ export class Layer extends Emitter {
     let response;
 
     try {
-      response = await layer.fetchProxyData('arcgismapserver', {
+      response = await layers[0].fetchProxyData('arcgismapserver', {
         // ref: https://developers.arcgis.com/rest/services-reference/enterprise/identify-map-service/
-        url: `${layer.getQueryUrl()}/identify`,
+        url: `${layers[0].getQueryUrl()}/identify`,
         params: {
           f:            "json",
           geometryType: "esriGeometryPoint",
           geometry:     `{x: ${x}, y: ${y}}`,
-          layers:       `all:${(layer.getWMSInfoLayerName() ?? []).join(',')}`,
+          layers:       `all:${(layers.map(l => l.getWMSInfoLayerName()) ?? []).join(',')}`,
           imageDisplay: `${GUI.getMap().getSize().join(',')},${DOTS_PER_INCH}`,
           mapExtent:    ('ne' === projection.getAxisOrientation().substr(0, 2) ? [bbox[1], bbox[0], bbox[3], bbox[2]] : bbox).join(','),
           tolerance:    'map' === tolerance.unit ? undefined : tolerance.value
         },
-        method: layer.getOwsMethod(),
+        method: layers[0].getOwsMethod(),
         headers: {
-          'Content-Type': layer.getInfoFormat()
+          'Content-Type': layers[0].getInfoFormat()
         }
       });
     } catch(e) {
@@ -2076,9 +2076,9 @@ export class Layer extends Emitter {
     }
 
     return {
-      data: Layer._parse(layer.getInfoFormat(), {
+      data: Layer._parse(layers[0].getInfoFormat(), {
         response,
-        layers:      [layer],
+        layers,
         wms:         true,
         projections: { map: ApplicationState.project.getProjection(), layer: this.getProjection() },
       }),

--- a/src/g3w-layer.js
+++ b/src/g3w-layer.js
@@ -2181,7 +2181,7 @@ export class Layer extends Emitter {
     if (this.#providers[type]) {
       return this.#providers[type]; 
     }
-    const providerType = `${type} ${this.state.servertype} ${this.state?.source?.type}${this.isArcgisMapserver() ? ' proxy' : ''}`;
+    const providerType = `${type} ${this.state.servertype} ${this.state?.source?.type}}`;
     const provider = {
       getLayer:    () => this,
       query:       () => [],
@@ -2246,7 +2246,6 @@ export class Layer extends Emitter {
       'query QGIS postgresraster',
       'query QGIS vector-tile',
       'query QGIS vectortile',
-      'query QGIS arcgismapserver',
       /** @since 4.0.0 */
       'query QGIS arcgisfeatureserver',
       'query QGIS mdal',
@@ -2257,9 +2256,15 @@ export class Layer extends Emitter {
 
     if ([
       /** @since 4.1.1 */
-      'query QGIS arcgismapserver proxy',
+      'query QGIS arcgismapserver',
     ].includes(providerType)) {
-      provider.query = this.#queryArcgisMapserver.bind(this);
+      //In case of external arcgis mapserver use specific query since arcgis server only return json format for getfeatureinfo request, otherwise use wms query
+      if (this.state?.source?.external) {
+        provider.query = this.#queryArcgisMapserver.bind(this);
+      } else {
+        provider.query = this.#queryWMS.bind(this);
+      }
+      
     }
 
     return (this.#providers[type] = provider);

--- a/src/g3w-layer.js
+++ b/src/g3w-layer.js
@@ -1874,7 +1874,7 @@ export class Layer extends Emitter {
    * @returns {*}
    */
   getAttributeLabel(name) {
-    return (this.getAttributes().find(a => name === a.name) || {}).label;
+    return (this.getAttributes().find(a => name === a.name) || {})?.label;
   }
 
   /**

--- a/src/g3w-layer.js
+++ b/src/g3w-layer.js
@@ -2055,7 +2055,7 @@ export class Layer extends Emitter {
       f:            "json",
       geometryType: "esriGeometryPoint",
       geometry:     `{x: ${x}, y: ${y}}`,
-      layers:       `${(layer.getWMSInfoLayerName() ?? []).join(',')}`,
+      layers:       `all:${(layer.getWMSInfoLayerName() ?? []).join(',')}`,
       imageDisplay: `${GUI.getMap().getSize().join(',')},${DOTS_PER_INCH}`,
       mapExtent:    ('ne' === projection.getAxisOrientation().substr(0, 2) ? [bbox[1], bbox[0], bbox[3], bbox[2]] : bbox).join(','),
       tolerance:    'map' === tolerance.unit ? undefined : tolerance.value

--- a/src/g3w-layer.js
+++ b/src/g3w-layer.js
@@ -152,8 +152,10 @@ export class Layer extends Emitter {
             cache_grid_extent: layer.state.cache_grid_extent,
           }
         ),
-        servertype: layer.state.servertype, //@since 4.1.1
-        source:     layer.state.source,     //@since 4.1.1 
+        /** @since 4.1.1 */
+        servertype: layer.state.servertype,
+        /** @since 4.1.1 */
+        source:     layer.state.source,
       };
     }
 
@@ -1826,14 +1828,13 @@ export class Layer extends Emitter {
     if (this.isMulti() && !this.isXYZ()) {
       return 'application/vnd.ogc.gml';
     }
-    //@since 4.1.1 In case of external arcgismapserver, set infoformat to esri/json since arcgis server only return json format for getfeatureinfo request
+    // external arcgismapserver
     if (this.state.infoformat && '' !== this.state.infoformat && this.isArcgisMapserver()) {
       return 'esri/json';
     }
     if (this.state.infoformat && '' !== this.state.infoformat && 'wfs' !== ogcService) {
       return this.state.infoformat;
     }
-
     return 'application/vnd.ogc.gml';
   }
 
@@ -2030,10 +2031,11 @@ export class Layer extends Emitter {
   }
 
   /**
+   * Retrieve external features (remote ARCGIS Server)
+   *
    * @since 4.1.1
-   * Get features from arcgismapserver when external
    */
-  async #queryArcgisMapserver(opts = {}) {
+  async #queryArcGIS(opts = {}) {
      const {
       layer         = this,
       size          = [101, 101],
@@ -2041,8 +2043,6 @@ export class Layer extends Emitter {
       resolution,
     } = opts;
 
-     const url    = `${layer.getQueryUrl()}/identify`;
-     const method = layer.getOwsMethod();
      // get extent for view size
      const dx         = resolution * size[0] / 2;
      const dy         = resolution * size[1] / 2;
@@ -2051,21 +2051,26 @@ export class Layer extends Emitter {
      const [x, y]     = ('ne' === projection.getAxisOrientation().substr(0, 2) ? [coordinates[1], coordinates[0]] : coordinates);
      const tolerance  = opts.query_point_tolerance ?? QUERY_POINT_TOLERANCE;
 
-     //https://developers.arcgis.com/rest/services-reference/enterprise/identify-map-service/
-     const params = {
-      f:            "json",
-      geometryType: "esriGeometryPoint",
-      geometry:     `{x: ${x}, y: ${y}}`,
-      layers:       `all:${(layer.getWMSInfoLayerName() ?? []).join(',')}`,
-      imageDisplay: `${GUI.getMap().getSize().join(',')},${DOTS_PER_INCH}`,
-      mapExtent:    ('ne' === projection.getAxisOrientation().substr(0, 2) ? [bbox[1], bbox[0], bbox[3], bbox[2]] : bbox).join(','),
-      tolerance:    'map' === tolerance.unit ? undefined : tolerance.value
-    }
-
     let response;
 
     try {
-      response = await layer.fetchProxyData('arcgismapserver', { url, params, method, headers: { 'Content-Type': layer.getInfoFormat() } });
+      response = await layer.fetchProxyData('arcgismapserver', {
+        // ref: https://developers.arcgis.com/rest/services-reference/enterprise/identify-map-service/
+        url: `${layer.getQueryUrl()}/identify`,
+        params: {
+          f:            "json",
+          geometryType: "esriGeometryPoint",
+          geometry:     `{x: ${x}, y: ${y}}`,
+          layers:       `all:${(layer.getWMSInfoLayerName() ?? []).join(',')}`,
+          imageDisplay: `${GUI.getMap().getSize().join(',')},${DOTS_PER_INCH}`,
+          mapExtent:    ('ne' === projection.getAxisOrientation().substr(0, 2) ? [bbox[1], bbox[0], bbox[3], bbox[2]] : bbox).join(','),
+          tolerance:    'map' === tolerance.unit ? undefined : tolerance.value
+        },
+        method: layer.getOwsMethod(),
+        headers: {
+          'Content-Type': layer.getInfoFormat()
+        }
+      });
     } catch(e) {
       console.warn(e);
     }
@@ -2073,7 +2078,7 @@ export class Layer extends Emitter {
     return {
       data: Layer._parse(layer.getInfoFormat(), {
         response,
-        layers: [layer],
+        layers:      [layer],
         wms:         true,
         projections: { map: ApplicationState.project.getProjection(), layer: this.getProjection() },
       }),
@@ -2261,17 +2266,14 @@ export class Layer extends Emitter {
       provider.query = this.#queryWMS.bind(this);
     }
 
-    if ([
-      /** @since 4.1.1 */
-      'query QGIS arcgismapserver',
-    ].includes(providerType)) {
-      //In case of external arcgis mapserver use specific query since arcgis server only return json format for getfeatureinfo request, otherwise use wms query
-      if (this.state?.source?.external) {
-        provider.query = this.#queryArcgisMapserver.bind(this);
-      } else {
-        provider.query = this.#queryWMS.bind(this);
-      }
-      
+    // external arcgis mapserver
+    if ('query QGIS arcgismapserver' === providerType && this.state?.source?.external) {
+      provider.query = this.#queryArcGIS.bind(this);
+    }
+
+    // internal arcgis mapserver
+    if ('query QGIS arcgismapserver' === providerType && !this.state?.source?.external) {
+      provider.query = this.#queryWMS.bind(this);
     }
 
     return (this.#providers[type] = provider);
@@ -2893,10 +2895,8 @@ export class Layer extends Emitter {
     if (!this.isRaster()) {
       return;
     }
-
     if (this.useProxy()) {
-      //@since 4.1.1 for external ArcgisMapserver surce that hasn't layers attribute but only layer attribute
-      return this.getSource().layers ?? [this.getSource().layer];
+      return this.getSource().layers ?? [this.getSource().layer]; // FALLBACK: for external ArcGIS server (source)
     }
     if (this.state.wms_use_layer_ids) {
       return this.getId();
@@ -3745,42 +3745,12 @@ Layer._parse = function(type, params, opts) {
       return parsed;
     },
 
-    //@since 4.1.1 handle "esri/json" format for ArcGIS MapServer layers
     /**
-     * https://developers.arcgis.com/rest/services-reference/enterprise/identify-map-service/#json-response-syntax
-     * {
-        "results": [
-          {
-            "layerId": <layerId1>,
-            "layerName": "<layerName1>",
-            "value": "<value1>",
-            "displayFieldName": "<displayFieldName1>",
-            "attributes": {
-              "<fieldName11>": <fieldValue11>,
-              "<fieldName12>": <fieldValue12>
-            },
-            "geometryType": "<geometryType1>",
-            "hasZ": <true|false>, //added in 10.1
-            "hasM": <true|false>, //added in 10.1
-            "geometry": {<geometry1>}
-          },
-          {
-            "layerId": <layerId2>,
-            "layerName": "<layerName2>",
-            "value": "<value2>",
-            "displayFieldName": "<displayFieldName1>",
-            "attributes": {
-              "<fieldName21>": <fieldValue21>,
-              "<fieldName22>": <fieldValue22>
-            },
-            "geometryType": "<geometryType2>",
-            "hasZ": <true|false>, //added in 10.1
-            "hasM": <true|false>, //added in 10.1
-            "geometry" : {<geometry2>}
-          }
-        ]
-      }
+     * Handle "esri/json" response for ArcGIS layers
      * 
+     * @see https://developers.arcgis.com/rest/services-reference/enterprise/identify-map-service/#json-response-syntax
+     * 
+     * @since 4.1.1
      */
     'esri/json'({ response = { results: [], error: undefined }, projections, layers } = {}) {
       const layersFeatures = layers.map(layer => ({ layer, features: [] }));

--- a/src/g3w-layer.js
+++ b/src/g3w-layer.js
@@ -2051,6 +2051,7 @@ export class Layer extends Emitter {
      const [x, y]     = ('ne' === projection.getAxisOrientation().substr(0, 2) ? [coordinates[1], coordinates[0]] : coordinates);
      const tolerance  = opts.query_point_tolerance ?? QUERY_POINT_TOLERANCE;
 
+     //https://developers.arcgis.com/rest/services-reference/enterprise/identify-map-service/
      const params = {
       f:            "json",
       geometryType: "esriGeometryPoint",

--- a/src/g3w-layer.js
+++ b/src/g3w-layer.js
@@ -377,8 +377,8 @@ export class Layer extends Emitter {
       /** @type {number} opacity range = [0, 100] (since 3.8) */
       opacity: config.opacity || 100,
 
-      /** cached proxy params (eg. external wms server) */
-      proxyData: { wms: null },
+      /** cached proxy params (eg. external wms/arcgismapserver server) */
+      proxyData: { wms: null, arcgismapserver: null }, 
 
       /** @since 4.0.0 @type {number } number of preview fields on result */
       max_preview_fields: config.max_preview_fields,
@@ -2062,10 +2062,10 @@ export class Layer extends Emitter {
       tolerance:    'map' === tolerance.unit ? undefined : tolerance.value
     }
 
-    let response = [];
+    let response;
 
     try {
-      response = (await layer.fetchProxyData('arcgismapserver', { url, params, method, headers: { 'Content-Type': layer.getInfoFormat() } }))?.results ?? [];
+      response = await layer.fetchProxyData('arcgismapserver', { url, params, method, headers: { 'Content-Type': layer.getInfoFormat() } });
     } catch(e) {
       console.warn(e);
     }
@@ -3746,14 +3746,57 @@ Layer._parse = function(type, params, opts) {
     },
 
     //@since 4.1.1 handle "esri/json" format for ArcGIS MapServer layers
-    'esri/json'({ response, projections, layers } = {}) {
+    /**
+     * https://developers.arcgis.com/rest/services-reference/enterprise/identify-map-service/#json-response-syntax
+     * {
+        "results": [
+          {
+            "layerId": <layerId1>,
+            "layerName": "<layerName1>",
+            "value": "<value1>",
+            "displayFieldName": "<displayFieldName1>",
+            "attributes": {
+              "<fieldName11>": <fieldValue11>,
+              "<fieldName12>": <fieldValue12>
+            },
+            "geometryType": "<geometryType1>",
+            "hasZ": <true|false>, //added in 10.1
+            "hasM": <true|false>, //added in 10.1
+            "geometry": {<geometry1>}
+          },
+          {
+            "layerId": <layerId2>,
+            "layerName": "<layerName2>",
+            "value": "<value2>",
+            "displayFieldName": "<displayFieldName1>",
+            "attributes": {
+              "<fieldName21>": <fieldValue21>,
+              "<fieldName22>": <fieldValue22>
+            },
+            "geometryType": "<geometryType2>",
+            "hasZ": <true|false>, //added in 10.1
+            "hasM": <true|false>, //added in 10.1
+            "geometry" : {<geometry2>}
+          }
+        ]
+      }
+     * 
+     */
+    'esri/json'({ response = { results: [], error: undefined }, projections, layers } = {}) {
       const layersFeatures = layers.map(layer => ({ layer, features: [] }));
       const layersId       = layers.map(l => l.getWMSLayerName());
-
-      // features
+      // handle server errors
+      if (response.error) {
+        GUI.showUserMessage({
+          type:        'warning',
+          textMessage: true,
+          message:     `${layersId.join(',')}: ${response.error.message}`
+        })
+      }
+      //handle features
       (
-        response
-          ? (Array.isArray(response) ? response : [response]).map((r) => (new ol.format.EsriJSON({
+        response?.results
+          ? response.results.map((r) => (new ol.format.EsriJSON({
               geometryName:          'geometry',
               defaultDataProjection: projections.layer || projections.map,
             })).readFeature(r)) 

--- a/src/g3w-layer.js
+++ b/src/g3w-layer.js
@@ -2062,7 +2062,6 @@ export class Layer extends Emitter {
       tolerance:    'map' === tolerance.unit ? undefined : tolerance.value
     }
 
-
      const { results: response } = await layer.fetchProxyData('arcgismapserver', { url, params, method, headers: { 'Content-Type': layer.getInfoFormat() } });
      return {
       data: Layer._parse(layer.getInfoFormat(), {

--- a/src/g3w-layer.js
+++ b/src/g3w-layer.js
@@ -2062,8 +2062,15 @@ export class Layer extends Emitter {
       tolerance:    'map' === tolerance.unit ? undefined : tolerance.value
     }
 
-     const { results: response } = await layer.fetchProxyData('arcgismapserver', { url, params, method, headers: { 'Content-Type': layer.getInfoFormat() } });
-     return {
+    let response = [];
+
+    try {
+      response = (await layer.fetchProxyData('arcgismapserver', { url, params, method, headers: { 'Content-Type': layer.getInfoFormat() } }))?.results ?? [];
+    } catch(e) {
+      console.warn(e);
+    }
+
+    return {
       data: Layer._parse(layer.getInfoFormat(), {
         response,
         layers: [layer],
@@ -2181,7 +2188,7 @@ export class Layer extends Emitter {
     if (this.#providers[type]) {
       return this.#providers[type]; 
     }
-    const providerType = `${type} ${this.state.servertype} ${this.state?.source?.type}}`;
+    const providerType = `${type} ${this.state.servertype} ${this.state?.source?.type}`;
     const provider = {
       getLayer:    () => this,
       query:       () => [],

--- a/src/g3w-layer.js
+++ b/src/g3w-layer.js
@@ -151,7 +151,9 @@ export class Layer extends Emitter {
             cache_grid:        layer.state.cache_grid,
             cache_grid_extent: layer.state.cache_grid_extent,
           }
-        )
+        ),
+        servertype: layer.state.servertype, //@since 4.1.1
+        source:     layer.state.source,     //@since 4.1.1 
       };
     }
 
@@ -1824,9 +1826,14 @@ export class Layer extends Emitter {
     if (this.isMulti() && !this.isXYZ()) {
       return 'application/vnd.ogc.gml';
     }
-    if (this.state.infoformat && '' !== this.state.infoformat  && 'wfs' !== ogcService) {
+    //@since 4.1.1 In case of external arcgismapserver, set infoformat to esri/json since arcgis server only return json format for getfeatureinfo request
+    if (this.state.infoformat && '' !== this.state.infoformat && this.isArcgisMapserver()) {
+      return 'esri/json';
+    }
+    if (this.state.infoformat && '' !== this.state.infoformat && 'wfs' !== ogcService) {
       return this.state.infoformat;
     }
+
     return 'application/vnd.ogc.gml';
   }
 
@@ -2022,6 +2029,52 @@ export class Layer extends Emitter {
     return { count, data, params }
   }
 
+  /**
+   * @since 4.1.1
+   * Get features from arcgismapserver when external
+   */
+  async #queryArcgisMapserver(opts = {}) {
+     const {
+      layer         = this,
+      size          = [101, 101],
+      coordinates   = [],
+      resolution,
+    } = opts;
+
+     const url    = `${layer.getQueryUrl()}/identify`;
+     const method = layer.getOwsMethod();
+     // get extent for view size
+     const dx         = resolution * size[0] / 2;
+     const dy         = resolution * size[1] / 2;
+     const bbox       = [coordinates[0] - dx, coordinates[1] - dy, coordinates[0] + dx, coordinates[1] + dy];
+     const projection = ApplicationState.project.getProjection() || this.getProjection();
+     const [x, y]     = ('ne' === projection.getAxisOrientation().substr(0, 2) ? [coordinates[1], coordinates[0]] : coordinates);
+     const tolerance  = opts.query_point_tolerance ?? QUERY_POINT_TOLERANCE;
+
+     const params = {
+      f:            "json",
+      geometryType: "esriGeometryPoint",
+      geometry:     `{x: ${x}, y: ${y}}`,
+      layers:       `${(layer.getWMSInfoLayerName() ?? []).join(',')}`,
+      imageDisplay: `${GUI.getMap().getSize().join(',')},${DOTS_PER_INCH}`,
+      mapExtent:    ('ne' === projection.getAxisOrientation().substr(0, 2) ? [bbox[1], bbox[0], bbox[3], bbox[2]] : bbox).join(','),
+      tolerance:    'map' === tolerance.unit ? undefined : tolerance.value
+    }
+
+
+     const { results: response } = await layer.fetchProxyData('arcgismapserver', { url, params, method, headers: { 'Content-Type': layer.getInfoFormat() } });
+     return {
+      data: Layer._parse(layer.getInfoFormat(), {
+        response,
+        layers: [layer],
+        wms:         true,
+        projections: { map: ApplicationState.project.getProjection(), layer: this.getProjection() },
+      }),
+      query: { coordinates, resolution }
+    };
+  }
+
+
   #queryWMS(opts = {}) {
     const {
       layers        = [this],
@@ -2035,7 +2088,7 @@ export class Layer extends Emitter {
     const dy   = resolution * size[1] / 2;
     const bbox = [coordinates[0] - dx, coordinates[1] - dy, coordinates[0] + dx, coordinates[1] + dy];
 
-    const projection = ApplicationState.project.getProjection() || this.getLayer().getProjection();
+    const projection = ApplicationState.project.getProjection() || this.getProjection();
     const tolerance  = opts.query_point_tolerance ?? QUERY_POINT_TOLERANCE;
 
     const url    = layers[0].getQueryUrl();
@@ -2128,7 +2181,7 @@ export class Layer extends Emitter {
     if (this.#providers[type]) {
       return this.#providers[type]; 
     }
-    const providerType = `${type} ${this.state.servertype} ${this.state?.source?.type}`;
+    const providerType = `${type} ${this.state.servertype} ${this.state?.source?.type}${this.isArcgisMapserver() ? ' proxy' : ''}`;
     const provider = {
       getLayer:    () => this,
       query:       () => [],
@@ -2200,6 +2253,13 @@ export class Layer extends Emitter {
       'query OGC wms',
     ].includes(providerType)) {
       provider.query = this.#queryWMS.bind(this);
+    }
+
+    if ([
+      /** @since 4.1.1 */
+      'query QGIS arcgismapserver proxy',
+    ].includes(providerType)) {
+      provider.query = this.#queryArcgisMapserver.bind(this);
     }
 
     return (this.#providers[type] = provider);
@@ -2660,7 +2720,7 @@ export class Layer extends Emitter {
    */
   getWMSLayerName({ type = 'map' } = {}) {
     if (this.isRaster()) {
-      const source_layer = this.state?.source?.layers || this.state?.source?.layer;
+      const source_layer = this.state?.source?.layers ?? this.state?.source?.layer;
 
       /** @FIXME add description */
       if (source_layer && this.#hasExternalWMSOrLegend(type)) {
@@ -2821,8 +2881,10 @@ export class Layer extends Emitter {
     if (!this.isRaster()) {
       return;
     }
+
     if (this.useProxy()) {
-      return this.getSource().layers;
+      //@since 4.1.1 for external ArcgisMapserver surce that hasn't layers attribute but only layer attribute
+      return this.getSource().layers ?? [this.getSource().layer];
     }
     if (this.state.wms_use_layer_ids) {
       return this.getId();
@@ -3093,7 +3155,7 @@ export class Layer extends Emitter {
     }
 
     // ARCGIS LAYER
-    if ('ARCGISMAPSERVER' === this.config.servertype && ('image' === this.getType() || this.isMulti())) {
+    if (('ARCGISMAPSERVER' === this.config.servertype || this.isArcgisMapserver()) && ('image' === this.getType() || this.isMulti())) {
       olLayer = new ol.layer.Tile({
         extent:  this.state.extent,
         visible: this.state.visible ?? true,
@@ -3670,6 +3732,43 @@ Layer._parse = function(type, params, opts) {
 
       return parsed;
     },
+
+    //@since 4.1.1 handle "esri/json" format for ArcGIS MapServer layers
+    'esri/json'({ response, projections, layers } = {}) {
+      const layersFeatures = layers.map(layer => ({ layer, features: [] }));
+      const layersId       = layers.map(l => l.getWMSLayerName());
+
+      // features
+      (
+        response
+          ? (Array.isArray(response) ? response : [response]).map((r) => (new ol.format.EsriJSON({
+              geometryName:          'geometry',
+              defaultDataProjection: projections.layer || projections.map,
+            })).readFeature(r)) 
+          : []
+      ).filter(feature => {
+        const featureId = feature.getId();
+        const g3w_fid   = sanitizeFidFeature(featureId);
+        // in the case of wms getfeature without a filter return string contain layerName or layerid
+        const index = featureId == g3w_fid ? 0 : layersId.indexOf(featureId);
+        // skip when ..
+        if (-1 === index) {
+          return false;
+        }
+        const props = feature.getProperties();
+        feature.set(G3W_FID, g3w_fid);
+        // fields
+        layersFeatures[index]
+          .layer
+          .getFields()
+          .filter(f => f.show && undefined === props[f.name] && undefined !== props[f.label])
+          .forEach(f => feature.set(f.name, props[f.label]));
+        // features
+        layersFeatures[index].features.push(feature);
+      });
+      return layersFeatures;
+
+    }
   });
 
   Parsers['g3w-vector/geojson'] = Parsers['g3w-vector/json']; 

--- a/src/static/app.css
+++ b/src/static/app.css
@@ -84,6 +84,7 @@ label                                       { display: inline-block; max-width: 
 input[disabled], fieldset[disabled] input   { cursor: not-allowed; }
 input[type="file"]                          { display: block; }
 input[type="range"]                         { display: block; width: 100%; }
+input:is([type="file"], [type="radio"], [type="checkbox"]):focus   { outline: 5px auto -webkit-focus-ring-color; outline-offset: -2px; }
 button, input :is([type="button"], [type="reset"], [type="submit"]) { cursor: pointer; }
 select:is([multiple], [size])               { height: auto; }
 textarea                                    { overflow: auto; }
@@ -1208,17 +1209,14 @@ dialog:is(.usermessage-alert, .usermessage-info, .usermessage-warning, .usermess
 .tree-legend                                        { padding: 0 0 0 43px; width:100%; background-color: var(--bgcolor); margin-top: -1ch; }
 .tree-root + .tree-root                             { border-top: 2px solid var(--skin-color); padding-top: 12px; }
 
-.tree-item button.toggle-context-menu               { opacity: 0; padding: 0; border: 1px solid; border-radius: 3px; }
-.tree-item button.toggle-context-menu > i           { padding: 4px 8px; }
+.tree-item button.toggle-context-menu             { opacity: 0; padding: 0; border: 1px solid; border-radius: 3px; }
+.tree-item button.toggle-context-menu > i         { padding: 4px 8px; }
 .tree-item:not(.group):hover > button.toggle-context-menu,
 .tree-item:not(.group) > button.toggle-context-menu:focus-visible { opacity: 1; }
 .tree-item button                                   { border: unset; background-color: unset; box-shadow: rgba(0,0,0,0.3) 0 2px 5px; padding: 0; border-radius: 3px; margin: 0 3px; font-weight: bold; color: #fff !important; }
 .tree-item button > i                               { padding: 5px; }
-
 .tree-item button.active                            { box-shadow: none; background-color: #384247; }
-.tree-item input[type="checkbox"]                   { accent-color: currentColor; width: unset; margin: unset; margin-top: 5px; -webkit-appearance: none; appearance: none; width: 1em; height: 1em; margin: 5px 0 0 0; border: 1px solid #d9d9d9; border-radius: 2px; background-color: #fff; display: inline-grid; place-content: center; }
-.tree-item input[type="checkbox"]::before           { content: ""; width: 0.65em; height: 0.65em; transform: scale(0); transform-origin: center; clip-path: polygon(14% 44%, 0 59%, 41% 100%, 100% 20%, 84% 6%, 39% 62%); background-color: #000; }
-.tree-item input[type="checkbox"]:checked::before   { transform: scale(1); }
+.tree-item input[type="checkbox"]                   { accent-color: currentColor; width: unset; margin: unset; margin-top: 5px; }
 
 #g3w-themes                            { display: none; padding: 0; }
 #g3w-themes.menu-open                  { display: block; }

--- a/src/static/app.css
+++ b/src/static/app.css
@@ -84,7 +84,6 @@ label                                       { display: inline-block; max-width: 
 input[disabled], fieldset[disabled] input   { cursor: not-allowed; }
 input[type="file"]                          { display: block; }
 input[type="range"]                         { display: block; width: 100%; }
-input:is([type="file"], [type="radio"], [type="checkbox"]):focus   { outline: 5px auto -webkit-focus-ring-color; outline-offset: -2px; }
 button, input :is([type="button"], [type="reset"], [type="submit"]) { cursor: pointer; }
 select:is([multiple], [size])               { height: auto; }
 textarea                                    { overflow: auto; }
@@ -1209,14 +1208,17 @@ dialog:is(.usermessage-alert, .usermessage-info, .usermessage-warning, .usermess
 .tree-legend                                        { padding: 0 0 0 43px; width:100%; background-color: var(--bgcolor); margin-top: -1ch; }
 .tree-root + .tree-root                             { border-top: 2px solid var(--skin-color); padding-top: 12px; }
 
-.tree-item button.toggle-context-menu             { opacity: 0; padding: 0; border: 1px solid; border-radius: 3px; }
-.tree-item button.toggle-context-menu > i         { padding: 4px 8px; }
+.tree-item button.toggle-context-menu               { opacity: 0; padding: 0; border: 1px solid; border-radius: 3px; }
+.tree-item button.toggle-context-menu > i           { padding: 4px 8px; }
 .tree-item:not(.group):hover > button.toggle-context-menu,
 .tree-item:not(.group) > button.toggle-context-menu:focus-visible { opacity: 1; }
 .tree-item button                                   { border: unset; background-color: unset; box-shadow: rgba(0,0,0,0.3) 0 2px 5px; padding: 0; border-radius: 3px; margin: 0 3px; font-weight: bold; color: #fff !important; }
 .tree-item button > i                               { padding: 5px; }
+
 .tree-item button.active                            { box-shadow: none; background-color: #384247; }
-.tree-item input[type="checkbox"]                   { accent-color: currentColor; width: unset; margin: unset; margin-top: 5px; }
+.tree-item input[type="checkbox"]                   { accent-color: currentColor; width: unset; margin: unset; margin-top: 5px; -webkit-appearance: none; appearance: none; width: 1em; height: 1em; margin: 5px 0 0 0; border: 1px solid #d9d9d9; border-radius: 2px; background-color: #fff; display: inline-grid; place-content: center; }
+.tree-item input[type="checkbox"]::before           { content: ""; width: 0.65em; height: 0.65em; transform: scale(0); transform-origin: center; clip-path: polygon(14% 44%, 0 59%, 41% 100%, 100% 20%, 84% 6%, 39% 62%); background-color: #000; }
+.tree-item input[type="checkbox"]:checked::before   { transform: scale(1); }
 
 #g3w-themes                            { display: none; padding: 0; }
 #g3w-themes.menu-open                  { display: block; }

--- a/src/static/app.css
+++ b/src/static/app.css
@@ -267,7 +267,6 @@ button.close                { padding: 0; cursor: pointer; background: transpare
 .btn-box-tool:hover                                { color: #606c84; }
 .btn-box-tool.btn:active                           { box-shadow: none; }
 .box-body                                          { border-radius: 0 0 3px 3px; padding: 10px; }
-.box-body.mobile                                   { padding: 5px; }
 .box-body > .table                                 { margin-bottom: 0; }
 .box-footer                                        { border-radius: 0 0 3px 3px; border-top: 1px solid #f4f4f4; padding: 10px; background-color: #fff; }
 .chart-legend                                      { list-style: none; margin: 0; padding: 0; margin: 10px 0; }
@@ -832,8 +831,7 @@ ul.g3w-tools .tool:hover              { background-color: #374850; }
 .queryresults-container ul                                                                    { list-style-type: none; overflow: auto; padding: 0; }
 .queryresults-container ul > li .queryresults-multi                                           { margin-top: 25px; }
 .queryresults-container ul > li span.key                                                      { font-weight: bold; font-size: 1.2em; margin-bottom: 10px; display: block; }
-.queryresults-container ul > li .box-header                                                   { padding: 0; display: flex; flex-wrap: nowrap; align-items: center; font-weight: bold !important; font-size: 1.2em !important; justify-content: space-between; }
-.queryresults-container ul > li .box-header.mobile                                            { padding: 5px; }
+.queryresults-container ul > li .box-header                                                   { padding: 0; display: flex; flex-wrap: nowrap; align-items: center; font-weight: bold !important; font-size: 1.2em !important; min-height: 3.2em; justify-content: space-between; }
 .queryresults-container ul > li .box-header .box-title                                        { margin: auto; margin-left: 0; font-weight: bold !important; font-size: 1.2em !important; }
 .queryresults-container ul > li .box-header .box-title.query-layer-title                      { padding: 5px 5px 5px 0; overflow: hidden; white-space: normal; text-overflow: ellipsis; user-select: none; }
 .queryresults-container .divider                                                              { display: block; position: relative; padding: 0; margin: 8px auto; height: 0; width: 100%; max-height: 0; font-size: 1px; line-height: 0; clear: both; border: none; border-bottom: 1px solid rgba(65, 86, 96, 0.3); }
@@ -1106,8 +1104,6 @@ input[type="range"]                                                       { acce
 
 .c3-title                                                                 { font-weight: bold; top: 5px; font-size: 2em; }
 .select2-dropdown                                                         { color: #444 !important; }
-.table.mobile thead tr th,
-.table.mobile tbody tr td                                                 { padding: 3px; }
 .form-control.search                                                      { height: 25px !important; margin-left: 1px !important; max-width: 160px; }
 .select2-container--default .select2-results__option[aria-selected=true]  { color: #fff; font-weight: bold; }
 .select2-selection--single, .select2-selection__choice                    { overflow: hidden; white-space: normal; overflow-wrap: break-word; }

--- a/src/static/app.css
+++ b/src/static/app.css
@@ -813,7 +813,6 @@ ul.g3w-tools .tool:hover              { background-color: #374850; }
 .query_relation_field i                                                                       { padding: 6px; }
 .query_relation_field_message                                                                 { font-weight: bold; margin-left: 5px; }
 .queryresults-wrapper                                                                         { height: 100%; caret-color: transparent;}
-.queryresults-wrapper .queryresults-text-html.text                                            { white-space: break-spaces; }
 .queryresults-container                                                                       { height: 100%; overflow-y: auto; position: relative; }
 .queryresults-container .query-results-not-found                                              { height: 100%; display: flex; flex-direction: column; align-items: center; justify-content: center; background-color: #fff; border-radius: 3px; }
 .queryresults-container .sub-group .group > .row                                              { margin-left: -2px; margin-right: -2px; }

--- a/src/static/locales/it.js
+++ b/src/static/locales/it.js
@@ -391,5 +391,5 @@ export default {
   'Layers settings': 'Configura livelli',
   'layers selected': 'livelli selezionati',
   'Type to search layers': 'Inizia a digitare per cercare i livelli',
-  '(CSP) scripts and links are disabled in this frame': '(CSP) script e link sono disabilitati in questo riquadro',
+  'Open external link?': 'Vuoi aprire questo link esterno?',
 };

--- a/src/static/locales/it.js
+++ b/src/static/locales/it.js
@@ -391,4 +391,5 @@ export default {
   'Layers settings': 'Configura livelli',
   'layers selected': 'livelli selezionati',
   'Type to search layers': 'Inizia a digitare per cercare i livelli',
+  '(CSP) scripts and links are disabled in this frame': '(CSP) script e link sono disabilitati in questo frame',
 };

--- a/src/static/locales/it.js
+++ b/src/static/locales/it.js
@@ -391,5 +391,5 @@ export default {
   'Layers settings': 'Configura livelli',
   'layers selected': 'livelli selezionati',
   'Type to search layers': 'Inizia a digitare per cercare i livelli',
-  '(CSP) scripts and links are disabled in this frame': '(CSP) script e link sono disabilitati in questo frame',
+  '(CSP) scripts and links are disabled in this frame': '(CSP) script e link sono disabilitati in questo riquadro',
 };

--- a/src/static/map-controls/queryby.js
+++ b/src/static/map-controls/queryby.js
@@ -767,7 +767,7 @@ function _getAvailableLayers(type) {
 
     // QUERYABLE
     ...Object.values(ApplicationState.layers)
-        .flatMap(s => s.isQueryable() ? s.getLayers({ GEOLAYER: true, QUERYABLE: true, SELECTED_OR_ALL: true }) : []),
+        .flatMap(s => s.isQueryable() ? s.getLayers({ GEOLAYER: true, QUERYABLE: true, SELECTED_OR_ALL: true }).filter(l => l.state?.geometrytype) : []),
 
     // POLYGONS
     ...GUI.getExternalLayers('vector')
@@ -775,6 +775,6 @@ function _getAvailableLayers(type) {
 
     // SELECTED POLYGONS
     ...Object.values(ApplicationState.layers)
-        .flatMap(s => 'querybypolygon' === type && s.isQueryable() ? s.getLayers({ GEOLAYER: true, QUERYABLE: true, SELECTED_OR_ALL: true }, {}) : []),
+        .flatMap(s => 'querybypolygon' === type && s.isQueryable() ? s.getLayers({ GEOLAYER: true, QUERYABLE: true, SELECTED_OR_ALL: true }, {}).filter(l => l.state?.geometrytype) : []),
   ])];
 }


### PR DESCRIPTION
Closes: #936 

Demo project: https://dev.g3wsuite.it/en/map/epsg-25832/qdjango/282/

This pull request improves the handling of layer attributes and fields when server-provided fields are missing, addressing cases where the server does not return attribute definitions. The main changes ensure that attribute and field information can be derived from feature properties as a fallback, increasing robustness and compatibility.

**Layer attribute and field handling improvements:**

* In the absence of server-defined attributes, the code now derives attribute definitions from the properties of the first feature, excluding geometry fields and feature IDs using the `GEOMETRY_FIELDS` and `G3W_FID` constants. [[1]](diffhunk://#diff-9c1be9677cc8c221ff8b1fb9fd38e4fb449ad601122a548e4cb804376497eefaL12-R16) [[2]](diffhunk://#diff-9c1be9677cc8c221ff8b1fb9fd38e4fb449ad601122a548e4cb804376497eefaL2135-R2144)
* The logic for constructing the `fields` array in the form structure was updated to handle cases where no fields are set by the server, falling back to feature-derived attributes.

**Code quality and maintainability:**

* Minor formatting and whitespace improvements for clarity.

These changes address issues such as https://github.com/g3w-suite/g3w-client/issues/936, making the application more resilient to incomplete server responses.

### Before

<img width="1161" height="936" alt="Screenshot_20260528_155248" src="https://github.com/user-attachments/assets/76ceb664-b525-41a6-8b20-bc89edef23e3" />


### After

<img width="1161" height="936" alt="Screenshot_20260528_154647" src="https://github.com/user-attachments/assets/4f955039-e226-4d79-b2c4-bf835d4117b9" />
