### PR TITLE
Set default value for RULELABEL to 'auto' in legend

### DIFF
--- a/src/g3w-layer.js
+++ b/src/g3w-layer.js
@@ -2955,7 +2955,7 @@ export class Layer extends Emitter {
         __('LAYERFONTSIZE=',    layerfontsize),    //@since 3.11.3
         __('SHOWFEATURECOUNT=', showfeaturecount), //@since 3.11.3
         __('ITEMFONTITALIC=',   itemfontitalic),
-        __('RULELABEL=',        rulelabel),
+        __('RULELABEL=',        rulelabel ?? 'auto'),
         __('LEGEND_ON=',        ctx_legend && ctx_legend.LEGEND_ON),
         __('LEGEND_OFF=',       ctx_legend && ctx_legend.LEGEND_OFF),
         __('STYLES=',           (opts.categories && 'application/json' === opts.format ? encodeURIComponent(this.getCurrentStyle().name) : undefined)),


### PR DESCRIPTION
Avoid layer name duplication in a single category

### Before

<img width="424" height="182" alt="Screenshot_20260603_121848" src="https://github.com/user-attachments/assets/be160c09-9493-4e51-8eb6-65f439affaee" />

### After

<img width="424" height="182" alt="Screenshot_20260603_121756" src="https://github.com/user-attachments/assets/49f303f3-f380-4172-87e3-60cc2a271ee6" />
