### PR TITLE
Unable to open Datetimepicker (dialog)

### DIFF
--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -678,7 +678,6 @@ export default new (class GUI extends Emitter {
     resize_observer.observe(document.querySelector('.content-wrapper'));
     resize_observer.observe(document.querySelector('.navbar'));
     document.querySelector('.main-sidebar').addEventListener('transitionend', () => this._layout());
-    document.querySelector('.content-wrapper').addEventListener('transitionend', () => this._layout());
 
     this._layout();
 


### PR DESCRIPTION
Project: https://dev.g3wsuite.it/en/map/g3w-suite-demo/qdjango/97/

If i try to click on calendar icon, datetimepicker widget it appear and hide immediately

### Before

<img width="981" height="494" alt="Screenshot_20260605_092524" src="https://github.com/user-attachments/assets/a450011a-3bd8-4f29-9992-15c6cdfc648f" />


### After

<img width="981" height="494" alt="Screenshot_20260605_092806" src="https://github.com/user-attachments/assets/34e211b3-b38b-4c19-a520-df073f24839e" />
