### PR TITLE
Fix cyclic object value on permalink creation

### DIFF
--- a/src/index.prod.js
+++ b/src/index.prod.js
@@ -726,7 +726,6 @@ $.ajaxSetup({
         }
       });
     };
-    console.log(project.state.layerstree)
     // compare all layer ids from server config with all layer nodes on layerstree server property
     _traverse(
       project.state.layerstree,

--- a/src/index.prod.js
+++ b/src/index.prod.js
@@ -641,23 +641,23 @@ $.ajaxSetup({
   const traverse = nodes => {
     for (let i = 0; i < nodes.length; i++) {
       let node = nodes[i];
-      //check if layer (node) of folder
+      // check if layer (node) of folder
       if (undefined !== node.id) {
         project.state.layers
           .forEach(l => {
-            //In case of layer
+            // in case of layer
             if (node.id === l.id) {
               node.name = l.name;
               l.wmsUrl  = project.state.WMSUrl;
               l.project = project;
-              node      = Object.assign(l, node); //replace node with layer configuration from server config
+              node      = Object.assign(l, node); // replace node with layer configuration (from server config)
               return false
             }
           });
       }
-      //iN case of group
+      // in case of group
       if (Array.isArray(node.nodes)) {
-        //add title to tree
+        // add title to tree
         node.title = node.name;
         traverse(node.nodes);
       }

--- a/src/index.prod.js
+++ b/src/index.prod.js
@@ -640,20 +640,22 @@ $.ajaxSetup({
   // Process layerstree and baselayers of the project (useful info for catalog)
   const traverse = nodes => {
     for (let i = 0; i < nodes.length; i++) {
-      const node = nodes[i];
+      let node = nodes[i];
       //check if layer (node) of folder
       if (undefined !== node.id) {
         project.state.layers
           .forEach(l => {
+            //In case of layer
             if (node.id === l.id) {
               node.name = l.name;
               l.wmsUrl  = project.state.WMSUrl;
               l.project = project;
-              node[i]   = Object.assign(l, node);
+              node      = Object.assign(l, node); //replace node with layer configuration from server config
               return false
             }
           });
       }
+      //iN case of group
       if (Array.isArray(node.nodes)) {
         //add title to tree
         node.title = node.name;
@@ -724,6 +726,7 @@ $.ajaxSetup({
         }
       });
     };
+    console.log(project.state.layerstree)
     // compare all layer ids from server config with all layer nodes on layerstree server property
     _traverse(
       project.state.layerstree,


### PR DESCRIPTION
## Motivation

Wrong layersstree node assignement

It set a wrong property without add node layer property

- `node[i] = Object.assign(l, node)` **l** and **node** are objects --> KO
- `node = Object.assing(l, node)` --> OK

### Project: https://sit.comune.roverbella.g3wsuite.it/it/map/piano-delle-regole/qdjango/4/

### Before

<img width="1335" height="1071" alt="Screenshot_20260610_162910" src="https://github.com/user-attachments/assets/e9765fa0-09df-4fca-aa51-a234b4ff8de7" />

### After

<img width="1209" height="1071" alt="Screenshot_20260610_164124" src="https://github.com/user-attachments/assets/f992bbed-18b5-4071-b40a-c67cac65d3d8" />


