### PR TITLE
Disable layer on scale visibility constraint

### DIFF
--- a/src/components/CatalogTree.vue
+++ b/src/components/CatalogTree.vue
@@ -15,7 +15,7 @@
     role                      = "button"
     :class                    = "{
       selected:             layerstree.selected,
-      disabled:             isDisabled,
+      disabled:             isDisabled || has_scale_visibility_toolip,
       group:                isGroup,
       table:                isTable,
       external:             layerstree.external,


### PR DESCRIPTION
QGIS project

<img width="1920" height="203" alt="Screenshot_20260608_151441" src="https://github.com/user-attachments/assets/c173ef3f-621d-4a0e-82b8-c36d9c2ab876" />

Grey color of road in case out of scale visibility

<img width="1897" height="783" alt="Screenshot_20260608_151522" src="https://github.com/user-attachments/assets/783302c7-35f2-4c27-a2dd-a096ae188d39" />

You can check it also in

Road Scale visibility between 5000 - 2500  

https://dev.g3wsuite.it/en/map/g3w-suite-demo/qdjango/97/

with Anonymous user 

### Before

<img width="918" height="469" alt="Screenshot_20260608_151629" src="https://github.com/user-attachments/assets/77381e8b-f220-4e91-9815-edfab567e53b" />


### After

<img width="918" height="469" alt="Screenshot_20260608_151702" src="https://github.com/user-attachments/assets/0b53ad9c-ceee-4363-a643-01aa713a2742" />


