### PR TITLE
Conditionally show WMST URL only if supported by at least one layer (ref: ModalMetadata.vue)

### DIFF
--- a/src/components/ModalMetadata.vue
+++ b/src/components/ModalMetadata.vue
@@ -570,8 +570,8 @@
         project.metadata.wms_url = `${project.WMSUrl}?service=WMS&version=1.3.0&request=GetCapabilities`;
       } 
 
-      // @since 4.1.0 set WMTS URL if not set by QGIS project and some layer has WMTS capability
-      if (!project.metadata.wmts_url && layers.find(l => l?.state?.ows?.includes?.('WMTS'))) {
+      // @since 4.1.0 set WMTS URL if not set by QGIS project (and some layer has WMTS capability)
+      if (!project.metadata.wmts_url && layers.some(l => l?.state?.ows?.includes?.('WMTS'))) {
         project.metadata.wmts_url = `${project.WMSUrl}?service=WMTS&version=1.3.0&request=GetCapabilities`;
       } 
 

--- a/src/components/ModalMetadata.vue
+++ b/src/components/ModalMetadata.vue
@@ -570,8 +570,8 @@
         project.metadata.wms_url = `${project.WMSUrl}?service=WMS&version=1.3.0&request=GetCapabilities`;
       } 
 
-      // @since 4.1.0 set WMTS URL if not set by QGIS project
-      if (!project.metadata.wmts_url) {
+      // @since 4.1.0 set WMTS URL if not set by QGIS project and some layer has WMTS capability
+      if (!project.metadata.wmts_url && layers.find(l => l?.state?.ows?.includes?.('WMTS'))) {
         project.metadata.wmts_url = `${project.WMSUrl}?service=WMTS&version=1.3.0&request=GetCapabilities`;
       } 
 


### PR DESCRIPTION
Closes: #944 

In case of no layers has WMTS capabilities

### Before

<img width="841" height="335" alt="Screenshot_20260610_090003" src="https://github.com/user-attachments/assets/67991c3d-fbba-4856-ae7d-1659ecfd3209" />

### After

<img width="841" height="335" alt="Screenshot_20260610_090052" src="https://github.com/user-attachments/assets/22724ee5-95c7-416c-b661-2eb9d88b6186" />
