### PR TITLE
Allow to proxy local plugins while developing against a remote server (ref: `npm run dev`)

### DIFF
--- a/build.js
+++ b/build.js
@@ -105,7 +105,7 @@ const task = args[0];
 
       // update versions
       await Promise.all([''].concat(dev_plugins).map(pluginName => new Promise(done => {
-        const src     = pluginName ? `${g3w.pluginsFolder}/${pluginName}` : '.';
+        const src     = pluginName ? `${g3w.pluginsFolder}/g3w-admin-${pluginName}` : '.';
         const version = get_version(pluginName);
         fs.readFile(`${src}/README.md`, 'utf8', function (_, data) {
           data = (data || '').toString().split("\n");
@@ -160,7 +160,8 @@ async function build_app() {
    * - [submodule "src/plugins/sidebar"]     --> src/plugins/sidebar/plugin.js
    */
   if (!production) {
-    dev_plugins.forEach(p => build_plugin(p)); // build all plugins (async)
+    console.log()
+    //dev_plugins.forEach(p => build_plugin(p)); // build all plugins (async)
   } else if('build:ci' !== task) {
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
     await new Promise(done => {
@@ -357,7 +358,7 @@ async function build_plugin(pluginName) {
 }
 
 function get_version(pluginName) {
-  const src = (pluginName ? `${g3w.pluginsFolder}/${pluginName}` : '.');
+  const src = (pluginName ? `${g3w.pluginsFolder}/g3w-admin-${pluginName}` : '.');
   // delete cache of require otherwise no package.json version rests the old (cache) one
   try {
     delete require.cache[require.resolve(`${src}/package.json`)];
@@ -377,7 +378,7 @@ function get_version(pluginName) {
  * @since 3.10.0
  */
 function get_hash(pluginName) {
-  const src = (pluginName ? `${g3w.pluginsFolder}/${pluginName}` : '.');
+  const src = (pluginName ? `${g3w.pluginsFolder}/g3w-admin-${pluginName}` : '.');
   try {
     let branch = execSync(`git -C  ${src} rev-parse --abbrev-ref HEAD`, { encoding: 'utf8' }).trim();
     if (branch && 'HEAD' !== branch.trim()) {
@@ -394,7 +395,7 @@ function get_hash(pluginName) {
  * @since 3.10.0
  */
 function get_branch(pluginName) {
-  const src = (pluginName ? `${g3w.pluginsFolder}/${pluginName}` : '.');
+  const src = (pluginName ? `${g3w.pluginsFolder}/g3w-admin-${pluginName}` : '.');
   try {
     return execSync(`git -C  ${src} rev-parse --abbrev-ref HEAD`, { encoding: 'utf8' }).trim();
   } catch(err) {
@@ -449,7 +450,7 @@ async function start_proxy_server() {
     const SERVER_URL = new URL(g3w.proxy);
 
     const proxy      = httpProxy.createProxyServer({
-      secure: false,
+      secure:       false,
       changeOrigin: true,
     });
 
@@ -457,11 +458,16 @@ async function start_proxy_server() {
       const url = new URL(req.url, `http://${req.headers.host}`);
       let localPath;
       // proxy core and static plugins
-      for (const pluginName of ['client', 'editing', 'openrouteservice', 'qplotly', 'qtimeseries']) {
+      for (const pluginName of ['client', 'editing', 'openrouteservice', 'qplotly', 'qtimeseries', ...dev_plugins]) {
         if ('client' === pluginName) {
           localPath = path.join(g3w.admin_overrides_folder, url.pathname)
         } else {
-          localPath = path.join(`${g3w.pluginsFolder}/g3w-admin-${pluginName}`, url.pathname);
+          //In case of dev plugins (lea) we need to change the path because in g3w-admin-plugins the lea plugin is named qlea, but in src/plugins is lea, so we need to replace /lea with /qlea
+          if (dev_plugins.includes(pluginName)) {
+            localPath = path.join(`${g3w.pluginsFolder}/g3w-admin-${pluginName}`, `${'lea' === pluginName? 'qlea' : pluginName}${url.pathname}`.replace('/lea', '/qlea'));
+          } else {
+            localPath = path.join(`${g3w.pluginsFolder}/g3w-admin-${pluginName}`, url.pathname);
+          }
         }
         if (url.pathname.startsWith(`/static/${pluginName}`) && fs.existsSync(localPath)) {
           console.log(true, '→', localPath);

--- a/build.js
+++ b/build.js
@@ -86,7 +86,7 @@ const task = args[0];
       if (g3w.docker_plugins_folder) {
         fs.readdirSync(g3w.docker_plugins_folder).forEach(pluginName => {
           if (!fs.existsSync(`${g3w.pluginsFolder}/${pluginName}`)) {
-            fs.symlinkSync(path.resolve(`${g3w.docker_plugins_folder}/${pluginName}`), path.resolve(`${g3w.pluginsFolder}/${pluginName}`), 'junction');
+            fs.symlinkSync(path.resolve(`${g3w.docker_plugins_folder}/${pluginName}`), path.resolve(`${g3w.pluginsFolder}/${pluginName = 'g3w-admin-lea' === pluginName ? 'g3w-admin-qlea' : pluginName}`), 'junction');
           }
         })
       }
@@ -464,7 +464,7 @@ async function start_proxy_server() {
         } else {
           //In case of dev plugins (lea) we need to change the path because in g3w-admin-plugins the lea plugin is named qlea, but in src/plugins is lea, so we need to replace /lea with /qlea
           if (dev_plugins.includes(pluginName)) {
-            localPath = path.join(`${g3w.pluginsFolder}/g3w-admin-${pluginName}`, `${'lea' === pluginName? 'qlea' : pluginName}${url.pathname}`.replace('/lea', '/qlea'));
+            localPath = path.join(`${g3w.pluginsFolder}/g3w-admin-${pluginName}`, `${pluginName}${url.pathname}`);
           } else {
             localPath = path.join(`${g3w.pluginsFolder}/g3w-admin-${pluginName}`, url.pathname);
           }

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -821,7 +821,6 @@
               @click         = "closeContent"
               title          = "close"
               data-placement = "bottom"
-              :class         = "{'mobile': isMobile()}"
               class          = "action-button action-button-close skin-color-dark fas fa-times"
             ></button>
           </div>

--- a/src/components/CatalogTree.vue
+++ b/src/components/CatalogTree.vue
@@ -15,7 +15,7 @@
     role                      = "button"
     :class                    = "{
       selected:             layerstree.selected,
-      disabled:             isDisabled,
+      disabled:             isDisabled || has_scale_visibility_toolip,
       group:                isGroup,
       table:                isTable,
       external:             layerstree.external,

--- a/src/components/ModalMetadata.vue
+++ b/src/components/ModalMetadata.vue
@@ -570,8 +570,8 @@
         project.metadata.wms_url = `${project.WMSUrl}?service=WMS&version=1.3.0&request=GetCapabilities`;
       } 
 
-      // @since 4.1.0 set WMTS URL if not set by QGIS project
-      if (!project.metadata.wmts_url) {
+      // @since 4.1.0 set WMTS URL if not set by QGIS project (and some layer has WMTS capability)
+      if (!project.metadata.wmts_url && layers.some(l => l?.state?.ows?.includes?.('WMTS'))) {
         project.metadata.wmts_url = `${project.WMSUrl}?service=WMTS&version=1.3.0&request=GetCapabilities`;
       } 
 

--- a/src/components/QueryResults.vue
+++ b/src/components/QueryResults.vue
@@ -29,7 +29,6 @@
           <div class = "box box-primary">
             <div
               class           = "box-header with-border"
-              :class          = "{'mobile': isMobile()}"
               @mouseover.stop = "!isMobile() && highlightLayer(layer, { zoom: false, highlight: true, duration: Infinity })"
               @mouseout.stop  = "!isMobile() && highlightLayer(layer, { zoom: false, highlight: false })"
               @click.stop     = "collapseSidebar"
@@ -48,7 +47,7 @@
               >
                 <!-- OPEN ATTRIBUTE TABLE -->
                 <button
-                  v-if           = "!layer.external"
+                  v-if           = "canOpenAttibuteTable(layer)"
                   type           = "button"
                   @click.stop    = "openAttributeTable(layer)"
                   class          = "action-button"
@@ -71,10 +70,11 @@
               <div class="query-layer-actions" style = "display: flex; gap: 2.5px; padding-right: 10px;">
                 <!-- INFO FORMATS -->
                 <select
-                  v-if      = "(layer.infoformats || []).length"
-                  class     = "form-control"
-                  @change   = "changeInfoFormat(layer, $event.target.value)"
-                  :disabled = "layer.loading"
+                  v-if        = "(layer.infoformats || []).length"
+                  class       = "form-control"
+                  @change     = "changeInfoFormat(layer, $event.target.value)"
+                  @click.stop = ""
+                  :disabled   = "layer.loading"
                 >
                   <option
                     v-for     = "format in layer.infoformats"
@@ -127,7 +127,7 @@
 
                 <!-- TOGGLE LAYER FEATURES -->
                 <button
-                  v-if           = "layer.external || (!layer.filter.active && layer.source && 'wms' !== layer.source.type && !(state.query && state.query.pagination))"
+                  v-if           = "layer.external || (!layer.filter.active && layer.source && !['wms', 'arcgismapserver'].includes(layer.source.type) && !(state.query && state.query.pagination))"
                   type           = "button"
                   @click.stop    = "addLayerFeaturesToResults(layer)"
                   class          = "action-button"
@@ -195,7 +195,6 @@
               v-if   = "state.layeractiontool[layer.id].component"
               class  = "g3w-layer-action-tools with-border"
               style  = "padding: 5px"
-              :class = "{'mobile': isMobile()}"
             >
               <component
                 :is     = "state.layeractiontool[layer.id].component"
@@ -307,17 +306,19 @@
               </ul>
             </div>
 
-            <div class = "box-body" :class = "{'mobile': isMobile()}">
+            <div class = "box-body">
 
               <!-- LAYER WITH RAW DATA -->
-              <div
+              <iframe
                 v-if   = "layer.rawdata"
-                class  = "queryresults-text-html"
-                :class = "{ text: layer.infoformat === 'text/plain' }"
-                v-html = "layer.rawdata"
-              ></div>
+                :key      = "`${layer.id}_${layer.infoformat}_${(layer.rawdata || '').length}_${(layer.rawdata || '').charCodeAt(0) || 0}`"
+                style     = "width: 100%; border: none;"
+                sandbox   = "allow-same-origin"
+                scrolling = "no"
+                @load     = "setRawdataIframeContent($event, layer)"
+              ></iframe>
 
-              <table v-else class = "table" :class = "{'mobile': isMobile()}">
+              <table v-else class = "table">
                 <tbody v-for = "(feature, index) in layer.features.filter(f => showFeature(layer, f))" :key = "feature.id">
 
                   <!-- ORIGINAL SOURCE: src/components/QueryResultsHeaderFeatureActionsBody.vue@v4.0.0 -->
@@ -649,6 +650,52 @@
     methods: {
 
       /**
+       * @since 4.1.1 - Inject layer data raw data within and <iframe>
+       */
+      setRawdataIframeContent(event, layer) {
+        try {
+          const iframe = event?.target;
+          const doc    = iframe?.contentDocument;
+
+          // skip when iframe is not ready
+          if (!doc) {
+            return;
+          }
+
+          // inject html or text contect (within iframe)
+          doc.body.innerHTML = 'text/plain' === layer.infoformat
+            ? /* html */`<pre style="margin:0; white-space:pre-wrap; overflow-wrap:anywhere; word-break:break-word; overflow:hidden hidden;">${String(layer.rawdata || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')}</pre>`
+            : (layer.rawdata || '');
+
+          // intercept click on links (within iframe)
+          doc.body.addEventListener('click', async e => {
+            const anchor = e.target.closest('a');
+            if (anchor) {
+              e.preventDefault();
+              const url = anchor.getAttribute('href');
+              const ok = await GUI.confirm(`<h4>🚨 ${this.$t('Open external link?')}</h4><p>${url}</p>`);
+              if (ok) {
+                window.open(url, '_blank', 'noopener,noreferrer');
+              }
+            }
+          });
+
+          // html content → keep horizontal scrollbar
+          doc.head.innerHTML = /* html */`<style>
+            html, body { overflow: ${'text/plain' === layer.infoformat ? 'hidden' : 'auto'} hidden; margin: 0; }
+          </style>`;
+
+          // watch for layout changes (within iframe)
+          (new ResizeObserver(([entry]) => {
+            iframe.style.height = `${Math.max(120, Math.ceil(entry.borderBoxSize?.[0]?.blockSize || entry.contentRect.height))}px`;
+          })).observe(doc.documentElement);
+
+        } catch(e) {
+          console.warn(e);
+        }
+      },
+
+      /**
        * @returns { boolean } whether can paginate layer results
        */
       canPaginate(layer) {
@@ -881,6 +928,17 @@
       },
 
       /**
+       * @param layer
+       * 
+       * @returns { boolean } whether can open attribute table for layer
+       * 
+       * @since 4.1.1
+       */
+      canOpenAttibuteTable(layer) {
+        return !layer.external && !getCatalogLayerById(layer.id)?.state?.not_show_attributes_table;
+      },
+
+      /**
        * @since 3.10.0
        */
       openAttributeTable(layer) {
@@ -1022,7 +1080,7 @@
        * @since 4.1.0 
        */
       async changeInfoFormat(layer, contenttype) {
-        layer.loading = true;
+        layer.loading     = true;
         try {
           const catalog_layer = getCatalogLayerById(layer.id);
 
@@ -1040,12 +1098,12 @@
           catalog_layer.setInfoFormat(layer.infoformat);
 
           const [data] = Layer._parse(contenttype, { layers: [catalog_layer], response });
-
           // parse as raw data
           if (!data.features) {
             layer.features.splice(0);
             await this.$nextTick();
-            layer.rawdata = data.rawdata;
+            layer.rawdata     = data.rawdata;
+            layer.hasgeometry = false;
           }
 
           // parse data
@@ -1062,7 +1120,7 @@
               if (0 === layer.attributes.length) {
                 layer.hasgeometry = !!feature.geometry;
                 GUI.setActionsForLayers([layer]);
-                getAlphanumericProps(feature.attributes).forEach(name => layer.attributes.push({ name, label: name, show: true }));
+                getAlphanumericProps(feature.attributes).forEach(name => layer.attributes.push({ name, label: name, show: true, type: 'varchar' }));
               }
               layer.features.push(feature);
             });

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -678,7 +678,6 @@ export default new (class GUI extends Emitter {
     resize_observer.observe(document.querySelector('.content-wrapper'));
     resize_observer.observe(document.querySelector('.navbar'));
     document.querySelector('.main-sidebar').addEventListener('transitionend', () => this._layout());
-    document.querySelector('.content-wrapper').addEventListener('transitionend', () => this._layout());
 
     this._layout();
 

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -858,8 +858,7 @@ export default new (class GUI extends Emitter {
       }
 
       // check if data can be shown on query result content
-      if (last && show) {
-        this.#clearState();
+      if (last && show && !output.add) {
         this.setContent({
           content:    new Component({
             id:                 'queryresults',
@@ -871,6 +870,9 @@ export default new (class GUI extends Emitter {
           post_title: output.title || '',
           perc:       isMobile.any ? 100 : undefined,
         });
+      }
+
+      if (last && show) {
         this.setQueryResponse(data, { add: !!output.add });
       }
 
@@ -2177,7 +2179,7 @@ export default new (class GUI extends Emitter {
             : attrs.map(featureAttr => ({
               name:  featureAttr,
               label: featureAttr,
-              show:  G3W_FID !== featureAttr && [undefined, 'gdal', 'wms', 'wcs', 'wmst', 'postgresraster'].includes(sourceType),
+              show:  G3W_FID !== featureAttr && [undefined, 'gdal', 'wms', 'wcs', 'wmst', 'postgresraster', 'arcgismapserver'].includes(sourceType),
               type:  'varchar'
             }));
         }
@@ -2225,8 +2227,8 @@ export default new (class GUI extends Emitter {
           } : undefined,
           relationsattributes:       (is_layer || is_vector || is_string)                       ? []                     : undefined,
           hasdownloadablerelations:  !external && layer.hasDowloadableRelations(), //@since 3.11.7
-          filter:                    (is_layer && !['wms', 'wcs', 'wmst'].includes(sourceType)) ? layer.state.filter     : {},
-          selection:                 (is_layer && !['wms', 'wcs', 'wmst'].includes(sourceType) && layer.state.selection) || (is_vector && layer.selection) || { active: undefined },
+          filter:                    (is_layer && !['wms', 'wcs', 'wmst', 'arcgismapserver'].includes(sourceType)) ? layer.state.filter     : {},
+          selection:                 (is_layer && !['wms', 'wcs', 'wmst', 'arcgismapserver'].includes(sourceType) && layer.state.selection) || (is_vector && layer.selection) || { active: undefined },
           title:                     (is_layer && layer.getTitle()) || (is_vector && layer.get('name')) || (is_string && name && (name.length > 4 ? name.slice(0, name.length - 4).join(' ') : layer)) || undefined,
           atlas:                     this.#atlas.filter(a => a.atlas.qgs_layer_id === id),
           rawdata:                   rawdata  || null,
@@ -2540,7 +2542,7 @@ export default new (class GUI extends Emitter {
         },
 
         // remove feature
-        ('__g3w_marker' === layer.id || (!layer.external && 'wms' !== (layer.source || {}).type)) && {
+        ('__g3w_marker' === layer.id || (!layer.external && !['wms', 'arcgismapserver'].includes((layer.source || {}).type))) && {
           id:        'removefeaturefromresult',
           mouseover: true,
           class:     "fas fa-minus-square",
@@ -2590,7 +2592,7 @@ export default new (class GUI extends Emitter {
         },
 
         // permalink (click to copy)
-        (layer.hasgeometry && !layer.external && 'wms' !== (layer.source || {}).type) && {
+        (layer.hasgeometry && !layer.external && !['wms', 'arcgismapserver'].includes((layer.source || {}).type)) && {
           id:          'link_zoom_to_fid',
           class:       "fa fa-share-alt",
           hint:        'Share via link',
@@ -2818,6 +2820,9 @@ export default new (class GUI extends Emitter {
     this.#interaction.id = layer.id;
 
     layer.addfeaturesresults.active = !layer.addfeaturesresults.active;
+
+    // disable map context menu when add feature interaction is active
+    this.getMap().set('can_show_context_menu', !layer.addfeaturesresults.active);
 
     if (false === layer.addfeaturesresults.active) {
       this.removeAddFeaturesLayerResultInteraction(true);

--- a/src/g3w-layer.js
+++ b/src/g3w-layer.js
@@ -2955,7 +2955,7 @@ export class Layer extends Emitter {
         __('LAYERFONTSIZE=',    layerfontsize),    //@since 3.11.3
         __('SHOWFEATURECOUNT=', showfeaturecount), //@since 3.11.3
         __('ITEMFONTITALIC=',   itemfontitalic),
-        __('RULELABEL=',        rulelabel),
+        __('RULELABEL=',        rulelabel ?? 'auto'),
         __('LEGEND_ON=',        ctx_legend && ctx_legend.LEGEND_ON),
         __('LEGEND_OFF=',       ctx_legend && ctx_legend.LEGEND_OFF),
         __('STYLES=',           (opts.categories && 'application/json' === opts.format ? encodeURIComponent(this.getCurrentStyle().name) : undefined)),

--- a/src/g3w-layer.js
+++ b/src/g3w-layer.js
@@ -151,7 +151,11 @@ export class Layer extends Emitter {
             cache_grid:        layer.state.cache_grid,
             cache_grid_extent: layer.state.cache_grid_extent,
           }
-        )
+        ),
+        /** @since 4.1.1 */
+        servertype: layer.state.servertype,
+        /** @since 4.1.1 */
+        source:     layer.state.source,
       };
     }
 
@@ -375,8 +379,8 @@ export class Layer extends Emitter {
       /** @type {number} opacity range = [0, 100] (since 3.8) */
       opacity: config.opacity || 100,
 
-      /** cached proxy params (eg. external wms server) */
-      proxyData: { wms: null },
+      /** cached proxy params (eg. external wms/arcgismapserver server) */
+      proxyData: { wms: null, arcgismapserver: null }, 
 
       /** @since 4.0.0 @type {number } number of preview fields on result */
       max_preview_fields: config.max_preview_fields,
@@ -1824,7 +1828,11 @@ export class Layer extends Emitter {
     if (this.isMulti() && !this.isXYZ()) {
       return 'application/vnd.ogc.gml';
     }
-    if (this.state.infoformat && '' !== this.state.infoformat  && 'wfs' !== ogcService) {
+    // external arcgismapserver
+    if (this.state.infoformat && '' !== this.state.infoformat && this.isArcgisMapserver()) {
+      return 'esri/json';
+    }
+    if (this.state.infoformat && '' !== this.state.infoformat && 'wfs' !== ogcService) {
       return this.state.infoformat;
     }
     return 'application/vnd.ogc.gml';
@@ -1874,7 +1882,7 @@ export class Layer extends Emitter {
    * @returns {*}
    */
   getAttributeLabel(name) {
-    return (this.getAttributes().find(a => name === a.name) || {}).label;
+    return (this.getAttributes().find(a => name === a.name) || {})?.label;
   }
 
   /**
@@ -2022,6 +2030,63 @@ export class Layer extends Emitter {
     return { count, data, params }
   }
 
+  /**
+   * Retrieve external features (remote ARCGIS Server)
+   *
+   * @since 4.1.1
+   */
+  async #queryArcGIS(opts = {}) {
+     const {
+      layers         = [this],
+      size          = [101, 101],
+      coordinates   = [],
+      resolution,
+    } = opts;
+
+     // get extent for view size
+     const dx         = resolution * size[0] / 2;
+     const dy         = resolution * size[1] / 2;
+     const bbox       = [coordinates[0] - dx, coordinates[1] - dy, coordinates[0] + dx, coordinates[1] + dy];
+     const projection = ApplicationState.project.getProjection() || this.getProjection();
+     const [x, y]     = ('ne' === projection.getAxisOrientation().substr(0, 2) ? [coordinates[1], coordinates[0]] : coordinates);
+     const tolerance  = opts.query_point_tolerance ?? QUERY_POINT_TOLERANCE;
+
+    let response;
+
+    try {
+      response = await layers[0].fetchProxyData('arcgismapserver', {
+        // ref: https://developers.arcgis.com/rest/services-reference/enterprise/identify-map-service/
+        url: `${layers[0].getQueryUrl()}/identify`,
+        params: {
+          f:            "json",
+          geometryType: "esriGeometryPoint",
+          geometry:     `{x: ${x}, y: ${y}}`,
+          layers:       `all:${(layers.map(l => l.getWMSInfoLayerName()) ?? []).join(',')}`,
+          imageDisplay: `${GUI.getMap().getSize().join(',')},${DOTS_PER_INCH}`,
+          mapExtent:    ('ne' === projection.getAxisOrientation().substr(0, 2) ? [bbox[1], bbox[0], bbox[3], bbox[2]] : bbox).join(','),
+          tolerance:    'map' === tolerance.unit ? undefined : tolerance.value
+        },
+        method: layers[0].getOwsMethod(),
+        headers: {
+          'Content-Type': layers[0].getInfoFormat()
+        }
+      });
+    } catch(e) {
+      console.warn(e);
+    }
+
+    return {
+      data: Layer._parse(layers[0].getInfoFormat(), {
+        response,
+        layers,
+        wms:         true,
+        projections: { map: ApplicationState.project.getProjection(), layer: this.getProjection() },
+      }),
+      query: { coordinates, resolution }
+    };
+  }
+
+
   #queryWMS(opts = {}) {
     const {
       layers        = [this],
@@ -2035,7 +2100,7 @@ export class Layer extends Emitter {
     const dy   = resolution * size[1] / 2;
     const bbox = [coordinates[0] - dx, coordinates[1] - dy, coordinates[0] + dx, coordinates[1] + dy];
 
-    const projection = ApplicationState.project.getProjection() || this.getLayer().getProjection();
+    const projection = ApplicationState.project.getProjection() || this.getProjection();
     const tolerance  = opts.query_point_tolerance ?? QUERY_POINT_TOLERANCE;
 
     const url    = layers[0].getQueryUrl();
@@ -2193,12 +2258,21 @@ export class Layer extends Emitter {
       'query QGIS postgresraster',
       'query QGIS vector-tile',
       'query QGIS vectortile',
-      'query QGIS arcgismapserver',
       /** @since 4.0.0 */
       'query QGIS arcgisfeatureserver',
       'query QGIS mdal',
       'query OGC wms',
     ].includes(providerType)) {
+      provider.query = this.#queryWMS.bind(this);
+    }
+
+    // external arcgis mapserver
+    if ('query QGIS arcgismapserver' === providerType && this.state?.source?.external) {
+      provider.query = this.#queryArcGIS.bind(this);
+    }
+
+    // internal arcgis mapserver
+    if ('query QGIS arcgismapserver' === providerType && !this.state?.source?.external) {
       provider.query = this.#queryWMS.bind(this);
     }
 
@@ -2660,7 +2734,7 @@ export class Layer extends Emitter {
    */
   getWMSLayerName({ type = 'map' } = {}) {
     if (this.isRaster()) {
-      const source_layer = this.state?.source?.layers || this.state?.source?.layer;
+      const source_layer = this.state?.source?.layers ?? this.state?.source?.layer;
 
       /** @FIXME add description */
       if (source_layer && this.#hasExternalWMSOrLegend(type)) {
@@ -2822,7 +2896,7 @@ export class Layer extends Emitter {
       return;
     }
     if (this.useProxy()) {
-      return this.getSource().layers;
+      return this.getSource().layers ?? [this.getSource().layer]; // FALLBACK: for external ArcGIS server (source)
     }
     if (this.state.wms_use_layer_ids) {
       return this.getId();
@@ -3093,7 +3167,7 @@ export class Layer extends Emitter {
     }
 
     // ARCGIS LAYER
-    if ('ARCGISMAPSERVER' === this.config.servertype && ('image' === this.getType() || this.isMulti())) {
+    if (('ARCGISMAPSERVER' === this.config.servertype || this.isArcgisMapserver()) && ('image' === this.getType() || this.isMulti())) {
       olLayer = new ol.layer.Tile({
         extent:  this.state.extent,
         visible: this.state.visible ?? true,
@@ -3670,6 +3744,50 @@ Layer._parse = function(type, params, opts) {
 
       return parsed;
     },
+
+    /**
+     * Handle "esri/json" response for ArcGIS layers
+     * 
+     * @see https://developers.arcgis.com/rest/services-reference/enterprise/identify-map-service/#json-response-syntax
+     * 
+     * @since 4.1.1
+     */
+    'esri/json'({ response = {}, projections, layers } = {}) {
+      const layersId = layers.map(l => l.getWMSLayerName());
+      // handle server errors
+      if (response.error) {
+        GUI.showUserMessage({
+          type:        'warning',
+          textMessage: true,
+          message:     `${layersId.join(',')}: ${response.error.message}`
+        });
+      }
+      // JSON parser
+      const esriFormat = new ol.format.EsriJSON({
+        geometryName: 'geometry',
+        defaultDataProjection: projections.layer || projections.map
+      });
+      // features by layer
+      return (response.results || [])
+        .map(r => esriFormat.readFeature(r))
+        .reduce((acc, feature) => {
+          const g3w_fid = sanitizeFidFeature(feature.getId());
+          const index = feature.getId() === g3w_fid ? 0 : layersId.indexOf(feature.getId());
+          // layer exists
+          if (-1 !== index) {
+            feature.set(G3W_FID, g3w_fid);
+            const props = feature.getProperties();
+            // set fields
+            layers[index]
+              .getFields()
+              .filter(f => f.show && props[f.name] === undefined && props[f.label] !== undefined)
+              .forEach(f => feature.set(f.name, props[f.label]));
+            // insert feature into appropriate layer array
+            acc[index].features.push(feature);
+          }
+          return acc;
+        }, layers.map(layer => ({ layer, features: [] })));
+    }
   });
 
   Parsers['g3w-vector/geojson'] = Parsers['g3w-vector/json']; 

--- a/src/index.prod.js
+++ b/src/index.prod.js
@@ -640,22 +640,24 @@ $.ajaxSetup({
   // Process layerstree and baselayers of the project (useful info for catalog)
   const traverse = nodes => {
     for (let i = 0; i < nodes.length; i++) {
-      const node = nodes[i];
-      //check if layer (node) of folder
+      let node = nodes[i];
+      // check if layer (node) of folder
       if (undefined !== node.id) {
         project.state.layers
           .forEach(l => {
+            // in case of layer
             if (node.id === l.id) {
               node.name = l.name;
               l.wmsUrl  = project.state.WMSUrl;
               l.project = project;
-              node[i]   = Object.assign(l, node);
+              node      = Object.assign(l, node); // replace node with layer configuration (from server config)
               return false
             }
           });
       }
+      // in case of group
       if (Array.isArray(node.nodes)) {
-        //add title to tree
+        // add title to tree
         node.title = node.name;
         traverse(node.nodes);
       }

--- a/src/static/app.css
+++ b/src/static/app.css
@@ -267,7 +267,6 @@ button.close                { padding: 0; cursor: pointer; background: transpare
 .btn-box-tool:hover                                { color: #606c84; }
 .btn-box-tool.btn:active                           { box-shadow: none; }
 .box-body                                          { border-radius: 0 0 3px 3px; padding: 10px; }
-.box-body.mobile                                   { padding: 5px; }
 .box-body > .table                                 { margin-bottom: 0; }
 .box-footer                                        { border-radius: 0 0 3px 3px; border-top: 1px solid #f4f4f4; padding: 10px; background-color: #fff; }
 .chart-legend                                      { list-style: none; margin: 0; padding: 0; margin: 10px 0; }
@@ -814,7 +813,6 @@ ul.g3w-tools .tool:hover              { background-color: #374850; }
 .query_relation_field i                                                                       { padding: 6px; }
 .query_relation_field_message                                                                 { font-weight: bold; margin-left: 5px; }
 .queryresults-wrapper                                                                         { height: 100%; caret-color: transparent;}
-.queryresults-wrapper .queryresults-text-html.text                                            { white-space: break-spaces; }
 .queryresults-container                                                                       { height: 100%; overflow-y: auto; position: relative; }
 .queryresults-container .query-results-not-found                                              { height: 100%; display: flex; flex-direction: column; align-items: center; justify-content: center; background-color: #fff; border-radius: 3px; }
 .queryresults-container .sub-group .group > .row                                              { margin-left: -2px; margin-right: -2px; }
@@ -832,8 +830,7 @@ ul.g3w-tools .tool:hover              { background-color: #374850; }
 .queryresults-container ul                                                                    { list-style-type: none; overflow: auto; padding: 0; }
 .queryresults-container ul > li .queryresults-multi                                           { margin-top: 25px; }
 .queryresults-container ul > li span.key                                                      { font-weight: bold; font-size: 1.2em; margin-bottom: 10px; display: block; }
-.queryresults-container ul > li .box-header                                                   { padding: 0; display: flex; flex-wrap: nowrap; align-items: center; font-weight: bold !important; font-size: 1.2em !important; justify-content: space-between; }
-.queryresults-container ul > li .box-header.mobile                                            { padding: 5px; }
+.queryresults-container ul > li .box-header                                                   { padding: 0; display: flex; flex-wrap: nowrap; align-items: center; font-weight: bold !important; font-size: 1.2em !important; min-height: 3.2em; justify-content: space-between; }
 .queryresults-container ul > li .box-header .box-title                                        { margin: auto; margin-left: 0; font-weight: bold !important; font-size: 1.2em !important; }
 .queryresults-container ul > li .box-header .box-title.query-layer-title                      { padding: 5px 5px 5px 0; overflow: hidden; white-space: normal; text-overflow: ellipsis; user-select: none; }
 .queryresults-container .divider                                                              { display: block; position: relative; padding: 0; margin: 8px auto; height: 0; width: 100%; max-height: 0; font-size: 1px; line-height: 0; clear: both; border: none; border-bottom: 1px solid rgba(65, 86, 96, 0.3); }
@@ -1106,8 +1103,6 @@ input[type="range"]                                                       { acce
 
 .c3-title                                                                 { font-weight: bold; top: 5px; font-size: 2em; }
 .select2-dropdown                                                         { color: #444 !important; }
-.table.mobile thead tr th,
-.table.mobile tbody tr td                                                 { padding: 3px; }
 .form-control.search                                                      { height: 25px !important; margin-left: 1px !important; max-width: 160px; }
 .select2-container--default .select2-results__option[aria-selected=true]  { color: #fff; font-weight: bold; }
 .select2-selection--single, .select2-selection__choice                    { overflow: hidden; white-space: normal; overflow-wrap: break-word; }

--- a/src/static/app.css
+++ b/src/static/app.css
@@ -84,7 +84,6 @@ label                                       { display: inline-block; max-width: 
 input[disabled], fieldset[disabled] input   { cursor: not-allowed; }
 input[type="file"]                          { display: block; }
 input[type="range"]                         { display: block; width: 100%; }
-input:is([type="file"], [type="radio"], [type="checkbox"]):focus   { outline: 5px auto -webkit-focus-ring-color; outline-offset: -2px; }
 button, input :is([type="button"], [type="reset"], [type="submit"]) { cursor: pointer; }
 select:is([multiple], [size])               { height: auto; }
 textarea                                    { overflow: auto; }
@@ -1209,14 +1208,19 @@ dialog:is(.usermessage-alert, .usermessage-info, .usermessage-warning, .usermess
 .tree-legend                                        { padding: 0 0 0 43px; width:100%; background-color: var(--bgcolor); margin-top: -1ch; }
 .tree-root + .tree-root                             { border-top: 2px solid var(--skin-color); padding-top: 12px; }
 
-.tree-item button.toggle-context-menu             { opacity: 0; padding: 0; border: 1px solid; border-radius: 3px; }
-.tree-item button.toggle-context-menu > i         { padding: 4px 8px; }
+.tree-item button.toggle-context-menu               { opacity: 0; padding: 0; border: 1px solid; border-radius: 3px; }
+.tree-item button.toggle-context-menu > i           { padding: 4px 8px; }
 .tree-item:not(.group):hover > button.toggle-context-menu,
 .tree-item:not(.group) > button.toggle-context-menu:focus-visible { opacity: 1; }
 .tree-item button                                   { border: unset; background-color: unset; box-shadow: rgba(0,0,0,0.3) 0 2px 5px; padding: 0; border-radius: 3px; margin: 0 3px; font-weight: bold; color: #fff !important; }
 .tree-item button > i                               { padding: 5px; }
+
 .tree-item button.active                            { box-shadow: none; background-color: #384247; }
+
 .tree-item input[type="checkbox"]                   { accent-color: currentColor; width: unset; margin: unset; margin-top: 5px; }
+
+/** Hotfix for mobile, ref: PR #939 */
+body.is-mobile .tree-item input[type="checkbox"]    { accent-color: var(--skin-color); }
 
 #g3w-themes                            { display: none; padding: 0; }
 #g3w-themes.menu-open                  { display: block; }

--- a/src/static/locales/it.js
+++ b/src/static/locales/it.js
@@ -391,4 +391,5 @@ export default {
   'Layers settings': 'Configura livelli',
   'layers selected': 'livelli selezionati',
   'Type to search layers': 'Inizia a digitare per cercare i livelli',
+  'Open external link?': 'Vuoi aprire questo link esterno?',
 };

--- a/src/static/map-controls/queryby.js
+++ b/src/static/map-controls/queryby.js
@@ -767,7 +767,7 @@ function _getAvailableLayers(type) {
 
     // QUERYABLE
     ...Object.values(ApplicationState.layers)
-        .flatMap(s => s.isQueryable() ? s.getLayers({ GEOLAYER: true, QUERYABLE: true, SELECTED_OR_ALL: true }) : []),
+        .flatMap(s => s.isQueryable() ? s.getLayers({ GEOLAYER: true, QUERYABLE: true, SELECTED_OR_ALL: true }).filter(l => l.state?.geometrytype) : []),
 
     // POLYGONS
     ...GUI.getExternalLayers('vector')
@@ -775,6 +775,6 @@ function _getAvailableLayers(type) {
 
     // SELECTED POLYGONS
     ...Object.values(ApplicationState.layers)
-        .flatMap(s => 'querybypolygon' === type && s.isQueryable() ? s.getLayers({ GEOLAYER: true, QUERYABLE: true, SELECTED_OR_ALL: true }, {}) : []),
+        .flatMap(s => 'querybypolygon' === type && s.isQueryable() ? s.getLayers({ GEOLAYER: true, QUERYABLE: true, SELECTED_OR_ALL: true }, {}).filter(l => l.state?.geometrytype) : []),
   ])];
 }


### PR DESCRIPTION
This pull request updates the plugin handling logic in `build.js` to standardize plugin folder naming conventions and improve proxy server support for development plugins. The main changes ensure that all plugin references use the `g3w-admin-<pluginName>` format and add special handling for the `lea` plugin due to its unique naming in different locations.

**Plugin path standardization and handling:**

* Updated all code referencing plugin source directories to use the `g3w-admin-<pluginName>` naming convention, ensuring consistency when reading versions, hashes, and branches for plugins. [[1]](diffhunk://#diff-7d111b05fe05c50beb729d1e99a36010fbda8c89b57a1a26ac3e7b0778a0ed53L108-R108) [[2]](diffhunk://#diff-7d111b05fe05c50beb729d1e99a36010fbda8c89b57a1a26ac3e7b0778a0ed53L360-R361) [[3]](diffhunk://#diff-7d111b05fe05c50beb729d1e99a36010fbda8c89b57a1a26ac3e7b0778a0ed53L380-R381) [[4]](diffhunk://#diff-7d111b05fe05c50beb729d1e99a36010fbda8c89b57a1a26ac3e7b0778a0ed53L397-R398)

**Development workflow adjustments:**

* Commented out the automatic build of all development plugins in non-production mode, likely to prevent unnecessary builds during development.

**Proxy server improvements:**

* Enhanced the proxy server logic to support both core and dynamically specified development plugins, including special path adjustments for the `lea` plugin (which is named `qlea` in the admin plugins folder). This ensures correct file resolution during development.
