### PR TITLE
🐛Avoid preview image in case of only file name field

### DIFF
--- a/src/components/g3w-fields.js
+++ b/src/components/g3w-fields.js
@@ -52,7 +52,7 @@ export const FieldsService = {
         } else {
           type = 'simple'
         }
-      } else if (value.toString().toLowerCase().match(/[^\s]+.(png|jpg|jpeg|gif)$/g)) {
+      } else if (value.toString().toLowerCase().match(/^(https?:\/\/[^\s]+)\.(png|jpg|jpeg|gif)$/g)) {
         type = 'photo';
       } else if (value.toString().match(/^(https?:\/\/[^\s]+)/g)) {
         type = 'link';


### PR DESCRIPTION
Project https://dev.g3wsuite.it/en/map/g3w-suite-demo/qdjango/97/

In case of a filed that contain only filename and not a url of image, avoid to show preview on result

Case:

**field**: name | **value**: Casa Rosada.png
### Before


<img width="1916" height="716" alt="Screenshot_20260618_144550" src="https://github.com/user-attachments/assets/cc57fbe0-698b-4491-8204-cd5865c76726" />

### After


<img width="1916" height="716" alt="Screenshot_20260618_144708" src="https://github.com/user-attachments/assets/ef93dbcc-fe33-48f4-b760-6fcecc80f2c0" />
