### PR TITLE
Add Git hook workflow to enforce Conventional Commits

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# Read the commit message from the temporary file provided by Git
+commit_msg=$(cat "$1")
+
+# Standard Regex for Conventional Commits
+# Accepts formats like: feat: add login, fix(api): fix bug, feat!: breaking change
+REGEXP="^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-z0-9_-]+\))?!?: .+"
+
+if ! echo "$commit_msg" | grep -Eq "$REGEXP"; then
+    echo "❌ ERROR: Commit message does not follow Conventional Commits standard!"
+    echo "Expected format: type(scope): description"
+    echo "Examples: feat(auth): add login, fix: resolve crash"
+    echo "More info: https://conventionalcommits.org"
+    exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "preinstall": "",
+    "prepare": "git config core.hooksPath .githooks",
     "build": "node build.js build",
     "build:ci": "node build.js build:ci",
     "dev": "node build.js dev",


### PR DESCRIPTION
### Summary
Added a lightweight, native [Git Hook](https://git-scm.com/docs/githooks) to automatically enforce the [**Conventional Commits**](https://www.conventionalcommits.org) standard across the team without heavy npm dependencies.

### How it works
1. When you run `npm install`, the `prepare` script automatically configures your local Git to look at the `.githooks` folder.
2. Every time you run `git commit`, the script will validate your message format using regex.
3. If the message is invalid, the commit will be blocked with a clear error message and a link to the official docs.
