### PR TITLE
Enable clickmap functionality in QueryBy control

### DIFF
--- a/src/static/map-controls/queryby.js
+++ b/src/static/map-controls/queryby.js
@@ -67,6 +67,7 @@ export class QueryBy extends MapControl {
       ...opts,
       name:        'queryby',
       tipLabel:    'Query area',
+      clickmap:    true, //@since 4.2.0
       enabled:     true,
       cursorClass: null, //store cursorClass of a current sub control enabled (querybbox, etc..)
     });


### PR DESCRIPTION
Updates the `QueryBy` map control to be treated as a “map-interacting” control by the application, so it can be disabled when `GUI.disableClickMapControls(true)` (eg. while editing) is used to prevent conflicting map interactions.

### Before

Query by map control is enabled:

<img width="87" height="556" alt="Screenshot_20260804_105335" src="https://github.com/user-attachments/assets/90e86e13-49de-4b86-a765-175e49a9a56e" />


### After

Query by map control is disabled:

<img width="87" height="556" alt="Screenshot_20260804_105246" src="https://github.com/user-attachments/assets/42dd58cf-c4a3-413f-833a-72665ca9a501" />
