### PR TITLE
Add search `id` parameter to identify nested searches (ref: `g3w-search.js`)

### DIFF
--- a/src/components/g3w-search.js
+++ b/src/components/g3w-search.js
@@ -216,7 +216,8 @@ async function doSearch({
         feature_count,
         raw:        'search' === state.return,                                        // whether get a raw response
         autofilter: Number(show && state.autofilter.value),                           // 0/1 = autofilter (by server)
-        ...(state.paginate && !search_1n ? { page: 1, page_sizes: PAGELENGTHS } : {}) // @since 3.11.0 pagination configuration
+        ...(state.paginate && !search_1n ? { page: 1, page_sizes: PAGELENGTHS } : {}), // @since 3.11.0 pagination configuration
+        config: state, //since 4.2.0 pass search configuration
       },
       outputs: show && { title: state.title }
     });

--- a/src/components/g3w-search.js
+++ b/src/components/g3w-search.js
@@ -230,8 +230,9 @@ async function doSearch({
     }
     // no search response (values) → show an empty result
     if (!has_values && 'search' === state.return) {
-      GUI.showData({ data: [] });
+      await GUI.closeContent();
       data = [];
+      GUI.showData({ data });
     }
     /********************************************************************************/
 

--- a/src/components/g3w-search.js
+++ b/src/components/g3w-search.js
@@ -26,6 +26,8 @@ import vueSearchComp                  from 'components/SearchPanel.vue';
  */
 export function SearchPanel(opts = {}, show = false) {
   const state = {
+    id:                   opts.id, //since 4.2.0
+    name:                 opts.name, //since 4.2.0
     loading:              {}, // store loading state of each input and each dependency
     searching:            false, //Boolean. If true, search request from server is starts. False no search
     title:                opts.name,
@@ -194,7 +196,6 @@ async function doSearch({
   feature_count = 10000,
   state
 } = {}) {
-
   queryUrl = undefined === queryUrl ? state.queryurl : queryUrl;
   show     = undefined === show     ? 'search' === state.type && 'data' === state.return : show;
 

--- a/src/components/g3w-search.js
+++ b/src/components/g3w-search.js
@@ -207,6 +207,7 @@ async function doSearch({
   try {
     data = await GUI.getData('search:features', {
       inputs: {
+        id:        state.id, //since 4.2.0
         layer:     state.search_layers,
         filter:    filter || createFilterFormInputs({
           layer:   state.search_layers,
@@ -218,7 +219,6 @@ async function doSearch({
         raw:        'search' === state.return,                                        // whether get a raw response
         autofilter: Number(show && state.autofilter.value),                           // 0/1 = autofilter (by server)
         ...(state.paginate && !search_1n ? { page: 1, page_sizes: PAGELENGTHS } : {}), // @since 3.11.0 pagination configuration
-        config: state, //since 4.2.0 pass search configuration
       },
       outputs: show && { title: state.title }
     });

--- a/src/components/g3w-search.js
+++ b/src/components/g3w-search.js
@@ -233,8 +233,8 @@ async function doSearch({
     // no search response (values) → show an empty result
     if (!has_values && 'search' === state.return) {
       await GUI.closeContent();
-      data = [];
-      GUI.showData({ data });
+      data = { data: [] };
+      GUI.showData(data);
     }
     /********************************************************************************/
 

--- a/src/components/g3w-search.js
+++ b/src/components/g3w-search.js
@@ -27,7 +27,6 @@ import vueSearchComp                  from 'components/SearchPanel.vue';
 export function SearchPanel(opts = {}, show = false) {
   const state = {
     id:                   opts.id, //since 4.2.0
-    name:                 opts.name, //since 4.2.0
     loading:              {}, // store loading state of each input and each dependency
     searching:            false, //Boolean. If true, search request from server is starts. False no search
     title:                opts.name,

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -5646,7 +5646,7 @@ export default new (class GUI extends Emitter {
    * @param options.page               - since 3.11.0
    * @param options.page_sizes         - since 3.11.0
    * @param { boolean } options.raw    - whether it should return raw data
-   * @param { string } options.id      - since 4.2.0
+   * @param { string } options.id      - since 4.2.0 - search request identifier
    * 
    * @private invoked by `getData('search:features')`
    */

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -5689,8 +5689,18 @@ export default new (class GUI extends Emitter {
         ([].concat(layer).sort((a, b) => (layersId.indexOf(a.state.id) > layersId.indexOf(b.state.id) ? 1 : -1)))
           .map((l, i) => l.getFilterData({ ...params, field: params.filter[i] }))
       ))
-        .filter(d => 'fulfilled' === d.status && (params.raw || d.value?.data?.at?.(0)?.features))
+        .filter(d => 'fulfilled' === d.status)
         .map(({ value } = {}) => {
+          // raw data, return as is (eg. for `getData('search:features')` with `raw: true`)
+          if (params.raw) {
+            return { data: value };
+          }
+          
+          //in case no features return from response, return an empty array 
+          if (!value?.data?.at?.(0)?.features) {
+            return [];
+          }
+
           const layerId = value.data?.at?.(0)?.layer?.state?.id;
           // autofilter → automatically set filtertoken
           if (1 === params.autofilter) {
@@ -5719,10 +5729,7 @@ export default new (class GUI extends Emitter {
             };
             pagination.getData.params[layerId] = { ...params, filter: params.filter[0] };
           }
-          // raw data
-          if (params.raw) {
-            return { data: value };
-          }
+          
           if (Array.isArray(value.data) && value.data.length > 0) {
             return value.data?.at?.(0);
           }

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -5691,17 +5691,18 @@ export default new (class GUI extends Emitter {
       ))
         .filter(d => 'fulfilled' === d.status)
         .map(({ value } = {}) => {
-          // raw data, return as is (eg. for `getData('search:features')` with `raw: true`)
+          // raw data → return as is
           if (params.raw) {
             return { data: value };
           }
-          
-          //in case no features return from response, return an empty array 
+
+          // no features → return an empty array
           if (!value?.data?.at?.(0)?.features) {
             return [];
           }
 
           const layerId = value.data?.at?.(0)?.layer?.state?.id;
+
           // autofilter → automatically set filtertoken
           if (1 === params.autofilter) {
             (value.data || []).forEach(({ layer, filtertoken }) => {
@@ -5710,6 +5711,7 @@ export default new (class GUI extends Emitter {
                   layer.setToken(filtertoken); }
               })
           }
+
           // pagination (total elements > page size)
           if (params.page_sizes)  {
             const page_size     = Math.max(...(Array.isArray(params.page_sizes) ? params.page_sizes : [params.page_sizes])); // page size = max elements per page
@@ -5729,7 +5731,7 @@ export default new (class GUI extends Emitter {
             };
             pagination.getData.params[layerId] = { ...params, filter: params.filter[0] };
           }
-          
+
           if (Array.isArray(value.data) && value.data.length > 0) {
             return value.data?.at?.(0);
           }

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -5646,6 +5646,7 @@ export default new (class GUI extends Emitter {
    * @param options.page               - since 3.11.0
    * @param options.page_sizes         - since 3.11.0
    * @param { boolean } options.raw    - whether it should return raw data
+   * @param { object } options.config  - since 4.2.0
    * 
    * @private invoked by `getData('search:features')`
    */
@@ -5660,6 +5661,7 @@ export default new (class GUI extends Emitter {
     autofilter: 0,
     page,
     page_sizes,
+    config: {},
   }) {
     const { layer, ...params } = options;
 
@@ -5732,7 +5734,8 @@ export default new (class GUI extends Emitter {
         /** whether it was an autofilter request */
         autofilter: !!params.autofilter,
         /** @since 3.11.0 - pagination info (in case of paginated request) */
-        pagination: params.page_size && pagination
+        pagination: params.page_size && pagination,
+        config: params.config ?? {},
       },
       type: 'api',
     };

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -5687,7 +5687,7 @@ export default new (class GUI extends Emitter {
         ([].concat(layer).sort((a, b) => (layersId.indexOf(a.state.id) > layersId.indexOf(b.state.id) ? 1 : -1)))
           .map((l, i) => l.getFilterData({ ...params, field: params.filter[i] }))
       ))
-        .filter(d => 'fulfilled' === d.status && d.value?.data?.at?.(0)?.features)
+        .filter(d => 'fulfilled' === d.status && (params.raw || d.value?.data?.at?.(0)?.features))
         .map(({ value } = {}) => {
           const layerId = value.data?.at?.(0)?.layer?.state?.id;
           // autofilter → automatically set filtertoken

--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -5646,7 +5646,7 @@ export default new (class GUI extends Emitter {
    * @param options.page               - since 3.11.0
    * @param options.page_sizes         - since 3.11.0
    * @param { boolean } options.raw    - whether it should return raw data
-   * @param { object } options.config  - since 4.2.0
+   * @param { string } options.id      - since 4.2.0
    * 
    * @private invoked by `getData('search:features')`
    */
@@ -5661,7 +5661,7 @@ export default new (class GUI extends Emitter {
     autofilter: 0,
     page,
     page_sizes,
-    config: {},
+    id,
   }) {
     const { layer, ...params } = options;
 
@@ -5735,7 +5735,7 @@ export default new (class GUI extends Emitter {
         autofilter: !!params.autofilter,
         /** @since 3.11.0 - pagination info (in case of paginated request) */
         pagination: params.page_size && pagination,
-        config: params.config ?? {},
+        id:         params.id,
       },
       type: 'api',
     };


### PR DESCRIPTION
Related to: https://github.com/g3w-suite/g3w-admin-cadastre

When a search need to return another search (options attribute vale return: search) config and no results features

Example:

```json
{
    "id": "catasto_data_by_name_surname",
    "name": "Ricerca particelle catastali per NOME e COGNOME sul layer catasto",
    "type": "search",
    "options": {
        "querylayerid": "catasto_9be09475_9d4e_49a0_b982_16b10de73a61",
        "queryurl": "/en/cadastre/searchbycf/204/catasto_9be09475_9d4e_49a0_b982_16b10de73a61",
        "title": "Nome e Cognome",
        "layerid": "catasto_9be09475_9d4e_49a0_b982_16b10de73a61",
        "return": "search",
        "filter": [
            {
                "attribute": "name",
                "label": "Nome",
                "input": {
                    "type": "textfield",
                    "options": {
                        "blanktext": ""
                    }
                },
                "op": "eq",
                "logicop": "AND"
            },
            {
                "attribute": "surname",
                "label": "Cognome",
                "input": {
                    "type": "textfield",
                    "options": {
                        "blanktext": ""
                    }
                },
                "op": "eq",
                "logicop": "AND"
            }
        ],
        "dozoomtoextent": true
    }
}
```

### Before

<img width="388" height="505" alt="Screenshot_20260903_124927" src="https://github.com/user-attachments/assets/d16a78c3-118f-4d8a-80b0-18219f20ee73" />

Click on search. Show me no results instead to show me new search

<img width="1066" height="965" alt="Screenshot_20260903_125655" src="https://github.com/user-attachments/assets/3ab2e475-846b-47d6-ab09-ee7606010456" />

### After

<img width="388" height="505" alt="Screenshot_20260903_124927" src="https://github.com/user-attachments/assets/a2afdcd8-a4cb-4122-b69e-b13f2d9028aa" />
 
Click on search button. Get new search fill with values from previous search

<img width="388" height="390" alt="Screenshot_20260903_125429" src="https://github.com/user-attachments/assets/a55d2675-0e9d-47d1-b588-9895f705b29e" />



