### PR TITLE
Fix css contents first-child selector + iframe vertical sizings

### DIFF
--- a/src/g3w-app.js
+++ b/src/g3w-app.js
@@ -1502,10 +1502,6 @@ export default new (class GUI extends Emitter {
       ApplicationState.contentsdata.push({ content, options: opts });
     }
 
-    Array
-      .from(contents.internalComponent.$el.children)  // hide other elements but not the last one
-      .forEach((el, i, a) => el.style.display = (i === a.length - 1) ? 'block' : 'none');
-
     contents.setOpen(true);
 
     await this.toggleContent(true);
@@ -1584,10 +1580,6 @@ export default new (class GUI extends Emitter {
     }
 
     ApplicationState.contentsdata.pop();
-
-    Array
-      .from(this.getComponent('contents').internalComponent.$el.children)       // hide other elements but not the last one
-      .forEach((el, i, a) => el.style.display = (i === a.length - 1) ? 'block' : 'none');
 
     this.resize();
 

--- a/src/static/app.css
+++ b/src/static/app.css
@@ -1050,10 +1050,10 @@ textarea.form-control                     { height: auto; }
 /**************************************************************************************
  * 10. Contents
  **************************************************************************************/
-.contents                            { padding: 0 10px; height: auto; display: flex; flex-direction: column; flex-grow: 1; min-height: 0; }
-.contents > :first-child             { flex-grow: 1; height: auto !important; display: flex !important; flex-direction: column; min-height: 0; }
-.contents > div                      { height: 100%; }
-.contents table                      { empty-cells: show; width: 100%; background-color: #fff !important; }
+.contents                                                          { padding: 0 10px; height: auto; display: flex; flex-direction: column; flex-grow: 1; min-height: 0; }
+.contents > :first-child:not([style*="display: none"])             { flex-grow: 1; height: auto !important; display: flex !important; flex-direction: column; min-height: 0; }
+.contents > div                                                    { height: 100%; }
+.contents table                                                    { empty-cells: show; width: 100%; background-color: #fff !important; }
 .contents .node-row > div + div,
 .contents .tabs-wrapper + .tabs-wrapper,
 .contents .node-row .field + .tabs-wrapper                          { border-left: 1px solid rgba(0,0,0,.1);  }

--- a/src/static/app.css
+++ b/src/static/app.css
@@ -1050,10 +1050,10 @@ textarea.form-control                     { height: auto; }
 /**************************************************************************************
  * 10. Contents
  **************************************************************************************/
-.contents                                                          { padding: 0 10px; height: auto; display: flex; flex-direction: column; flex-grow: 1; min-height: 0; }
-.contents > :first-child:not([style*="display: none"])             { flex-grow: 1; height: auto !important; display: flex !important; flex-direction: column; min-height: 0; }
-.contents > div                                                    { height: 100%; }
-.contents table                                                    { empty-cells: show; width: 100%; background-color: #fff !important; }
+.contents                                                           { padding: 0 10px; height: auto; display: flex; flex-direction: column; flex-grow: 1; min-height: 0; }
+.contents > :first-child:not([style*="display"][style*="none"])     { flex-grow: 1; height: auto !important; display: flex !important; flex-direction: column; min-height: 0; }
+.contents > div                                                     { height: 100%; }
+.contents table                                                     { empty-cells: show; width: 100%; background-color: #fff !important; }
 .contents .node-row > div + div,
 .contents .tabs-wrapper + .tabs-wrapper,
 .contents .node-row .field + .tabs-wrapper                          { border-left: 1px solid rgba(0,0,0,.1);  }

--- a/src/static/app.css
+++ b/src/static/app.css
@@ -49,7 +49,7 @@
 
 .content-wrapper            { height: calc(100% - 50px); position: fixed; inset: 0; pointer-events: none; }
 .content-wrapper > *        { pointer-events: all; }
-.is-iframe .content-wrapper { height: calc(100% - 0px); padding-top: 0;  }
+.is-iframe .content-wrapper { height: 100%; padding-top: 0;  }
 /*!
 * Based on Bootstrap v3.4.1 (https://getbootstrap.com/)
 * Copyright 2011-2019 Twitter, Inc.
@@ -543,7 +543,7 @@ fieldset[disabled] .btn-warning:is(:hover, :focus, .focus)           { backgroun
 .treeview-menu > li.active > a,
 .treeview-menu > li > a:hover                                      { color: #fff; }
 
-.is-iframe .main-sidebar                                           { margin-top: 0; }
+.is-iframe .main-sidebar                                           { margin-top: 0; height: 100%; }
 .is-iframe .main-sidebar a.sidebar-aside-toggle                    { top: 0! important; }
 .sidebar-panel                                                     { position: relative; color: #FFF; padding: 10px 15px 10px 15px; }
 .sidebar-panel .g3w-panel .g3w-panel-form button.run_button        { margin-top: 5px; font-weight: bold; }
@@ -780,6 +780,8 @@ ul.g3w-tools .tool:hover              { background-color: #374850; }
 .g3w-map-controls-left-bottom .ol-control                              { position: relative; }
 .g3w-map-controls-left-bottom                                          { display: flex; gap: 5px; align-items: end; bottom: 88px; position: absolute; z-index: 1; }
 .ol-zoom-history                                                       { align-items: end; order: 1; }
+
+.is-iframe :is(.g3w-map-controls-left-bottom, .ol-scale-line)          { bottom: 38px; }
 
 .ol-control button:hover                                               { background-color:var(--skin-color); }
 .ol-control button:focus                                               { background-color:#e5e5e5; outline: none; }

--- a/src/static/app.css
+++ b/src/static/app.css
@@ -1051,7 +1051,8 @@ textarea.form-control                     { height: auto; }
  * 10. Contents
  **************************************************************************************/
 .contents                                                           { padding: 0 10px; height: auto; display: flex; flex-direction: column; flex-grow: 1; min-height: 0; }
-.contents > :first-child:not([style*="display"][style*="none"])     { flex-grow: 1; height: auto !important; display: flex !important; flex-direction: column; min-height: 0; }
+.contents > *                                                       { display: none !important; }
+.contents > :last-child                                             { display: flex !important; flex-grow: 1; flex-direction: column; min-height: 0; height: auto !important; }
 .contents > div                                                     { height: 100%; }
 .contents table                                                     { empty-cells: show; width: 100%; background-color: #fff !important; }
 .contents .node-row > div + div,


### PR DESCRIPTION
This pull request makes a targeted improvement to the layout handling in the `.contents` container in the CSS. The main change ensures that the flex styling is only applied to the first child of `.contents` if it is not hidden via inline `display: none` styles.

Layout and styling update:

* Updated the selector for `.contents > :first-child` to only apply flex and sizing styles when the element is not hidden (`display: none`), improving layout consistency when the first child is conditionally hidden.

When:

Click on relation icon

<img width="1194" height="737" alt="Screenshot_20260904_155512" src="https://github.com/user-attachments/assets/41d3ff28-1056-4a0d-b34a-0d42cd6886c4" />


### Before

<img width="1194" height="945" alt="Screenshot_20260904_155711" src="https://github.com/user-attachments/assets/637943eb-ccfb-44ff-aaa5-68a969849fa7" />


### After


<img width="1194" height="945" alt="Screenshot_20260904_155616" src="https://github.com/user-attachments/assets/c12fd525-30c1-455a-86c1-9ed9dcb4d6e0" />
